### PR TITLE
Fix CI packaging and publish tagged releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,11 @@ name: Build & Package
 on:
   push:
     branches: [main]
+    tags:
+      - 'v*'
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 concurrency:
   group: build-${{ github.sha }}
@@ -10,6 +15,8 @@ concurrency:
 
 jobs:
   build:
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix:
@@ -22,20 +29,22 @@ jobs:
             platform: linux
 
     runs-on: ${{ matrix.os }}
+    env:
+      ELECTRON_BUILDER_PUBLISH_MODE: ${{ startsWith(github.ref, 'refs/tags/v') && 'always' || 'never' }}
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
 
       - name: Setup Python (Windows)
         if: matrix.platform == 'win'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -56,24 +65,24 @@ jobs:
 
       - name: Package (macOS)
         if: matrix.platform == 'mac'
-        run: npx electron-builder --mac
+        run: npx electron-builder --mac --publish ${{ env.ELECTRON_BUILDER_PUBLISH_MODE }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Package (Windows)
         if: matrix.platform == 'win'
-        run: npx electron-builder --win
+        run: npx electron-builder --win --publish ${{ env.ELECTRON_BUILDER_PUBLISH_MODE }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Package (Linux)
         if: matrix.platform == 'linux'
-        run: npx electron-builder --linux
+        run: npx electron-builder --linux --publish ${{ env.ELECTRON_BUILDER_PUBLISH_MODE }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: recast-${{ matrix.platform }}
           path: |

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -6,6 +6,10 @@ directories:
   buildResources: resources
   output: dist
 
+publish:
+  provider: github
+  releaseType: release
+
 files:
   - out/**/*
   - resources/**/*
@@ -44,6 +48,7 @@ nsis:
 linux:
   icon: resources/icon.png
   category: Utility
+  maintainer: Craig Chihururu <craigchihururu@gmail.com>
   target:
     - AppImage
     - deb

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "description": "Cross-platform presentation tool with reusable content hierarchy, slide rendering, and NDI output",
   "author": "IT-PSAPE",
+  "packageManager": "npm@11.6.2",
   "homepage": "https://github.com/IT-PSAPE/cast-interface#readme",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- update GitHub Actions to current runtime-compatible versions and opt into Node 24 for JavaScript actions
- fix Linux packaging metadata and declare the npm package manager explicitly for cleaner electron-builder runs
- publish tagged builds to GitHub Releases while keeping regular main-branch pushes as non-publishing CI builds

## Verification
- npm run typecheck
- release packaging remains CI-verified only