### PR TITLE
Make npm test pass when no tests match

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build": "electron-vite build",
     "preview": "electron-vite preview",
     "typecheck": "tsc --noEmit",
-    "test": "vitest run",
+    "test": "vitest run --passWithNoTests",
     "test:watch": "vitest --watch",
     "test:e2e": "playwright test",
     "capture:ui-screenshots": "npm run build && node app/e2e/capture-ui-screenshots.mjs",


### PR DESCRIPTION
## Summary

- Vitest exits with code 1 when no test files match its include pattern, which fails the CI test step after `app/core/ndi.test.ts` was removed earlier.
- Pass `--passWithNoTests` so the `test` script is a no-op success until tests get added back.

## Test plan
- [x] `npm test` locally exits 0 with the "No test files found, exiting with code 0" message.
- [ ] CI on this PR's `build` jobs gets past the "Run tests" step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)