### PR TITLE
Fix release publish notes generation

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,4 +1,4 @@
-# Release notes template used by `gh release edit --generate-notes`.
+# Release notes template used by the GitHub release notes API in CI.
 # Groups commits/PRs into categories based on labels and paths.
 # See: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -185,12 +185,29 @@ jobs:
       - name: Promote draft release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
           VERSION: ${{ needs.detect-release.outputs.version }}
         run: |
           set -euo pipefail
           echo "Publishing v$VERSION"
+          release_notes_file="$(mktemp)"
+          release_title="$(
+            gh api \
+              --method POST \
+              -H "Accept: application/vnd.github+json" \
+              "/repos/$REPOSITORY/releases/generate-notes" \
+              -f tag_name="v$VERSION" \
+              --jq '.name'
+          )"
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/$REPOSITORY/releases/generate-notes" \
+            -f tag_name="v$VERSION" \
+            --jq '.body' > "$release_notes_file"
           gh release edit "v$VERSION" \
             --draft=false \
             --latest \
-            --generate-notes
+            --title "$release_title" \
+            --notes-file "$release_notes_file"
           echo "::notice::Release v$VERSION published at $(gh release view v$VERSION --json url -q .url)"


### PR DESCRIPTION
## Summary
- replace unsupported `gh release edit --generate-notes` usage in CI
- generate release notes through the GitHub releases API before publishing the draft release
- update the release template comment to match the workflow

## Testing
- git diff --check -- .github/workflows/build.yml .github/release.yml