### PR TITLE
Add ScrollArea primitive that follows the active descendant

### DIFF
--- a/app/renderer/components/display/thumbnail.tsx
+++ b/app/renderer/components/display/thumbnail.tsx
@@ -1,4 +1,4 @@
-import { Children, isValidElement, type HTMLAttributes, type ReactElement, type ReactNode } from 'react';
+import { Children, isValidElement, type HTMLAttributes, type ReactElement, type ReactNode, type Ref } from 'react';
 import { cn } from '@renderer/utils/cn';
 import { cv } from '@renderer/utils/cv';
 
@@ -21,6 +21,7 @@ interface ThumbnailRootProps extends Omit<HTMLAttributes<HTMLDivElement>, 'child
   children: ReactNode;
   onDoubleClick?: () => void;
   selected?: boolean;
+  ref?: Ref<HTMLDivElement>;
 }
 
 interface ThumbnailSlotProps extends HTMLAttributes<HTMLDivElement> {
@@ -54,11 +55,12 @@ function Overlay(_props: ThumbnailOverlayProps) {
   return null;
 }
 
-function Row({ children, className, onClick, onDoubleClick, selected = false, ...rest }: ThumbnailRootProps) {
+function Row({ children, className, onClick, onDoubleClick, selected = false, ref, ...rest }: ThumbnailRootProps) {
   const slots = collectThumbnailSlots(children);
 
   return (
     <div
+      ref={ref}
       {...rest}
       onClick={onClick}
       onDoubleClick={onDoubleClick}
@@ -75,11 +77,12 @@ function Row({ children, className, onClick, onDoubleClick, selected = false, ..
   );
 }
 
-function Tile({ children, className, onClick, onDoubleClick, selected = false, ...rest }: ThumbnailRootProps) {
+function Tile({ children, className, onClick, onDoubleClick, selected = false, ref, ...rest }: ThumbnailRootProps) {
   const slots = collectThumbnailSlots(children);
 
   return (
     <div
+      ref={ref}
       {...rest}
       onClick={onClick}
       onDoubleClick={onDoubleClick}

--- a/app/renderer/components/layout/panel.tsx
+++ b/app/renderer/components/layout/panel.tsx
@@ -1,4 +1,4 @@
-import { Children, isValidElement, type ButtonHTMLAttributes, type HTMLAttributes, type ReactElement, type ReactNode } from 'react';
+import { Children, isValidElement, type ButtonHTMLAttributes, type HTMLAttributes, type ReactElement, type ReactNode, type Ref } from 'react';
 import { cn } from '@renderer/utils/cn';
 import { cv } from '@renderer/utils/cv';
 
@@ -24,6 +24,7 @@ interface PanelSectionPartProps extends HTMLAttributes<HTMLDivElement> {
 interface PanelItemProps extends HTMLAttributes<HTMLDivElement> {
   children?: ReactNode;
   selected?: boolean;
+  ref?: Ref<HTMLDivElement>;
 }
 
 interface PanelItemPartProps extends HTMLAttributes<HTMLDivElement> {
@@ -146,12 +147,12 @@ function SectionBody(_props: PanelSectionPartProps) {
   return null;
 }
 
-function Item({ children, className, selected, ...rest }: PanelItemProps) {
+function Item({ children, className, selected, ref, ...rest }: PanelItemProps) {
   const slots = collectItemSlots(children);
   const content = slots.body?.props.children ?? slots.looseChildren;
 
   return (
-    <div className={itemStyles({ selected, className })} data-layer="panel-item" {...rest}>
+    <div ref={ref} className={itemStyles({ selected, className })} data-layer="panel-item" {...rest}>
       {slots.leading ? (
         <span className={cn('mr-2 shrink-0 text-tertiary', slots.leading.props.className)}>
           {slots.leading.props.children}

--- a/app/renderer/components/layout/scroll-area.tsx
+++ b/app/renderer/components/layout/scroll-area.tsx
@@ -1,0 +1,66 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, type ReactNode } from 'react';
+import { cn } from '@renderer/utils/cn';
+
+interface ScrollAreaContextValue {
+  register: (element: HTMLElement | null) => void;
+}
+
+const ScrollAreaContext = createContext<ScrollAreaContextValue | null>(null);
+
+type ScrollPadding = number | `${number}%`;
+
+interface ScrollAreaProps {
+  className?: string;
+  children: ReactNode;
+  role?: string;
+  'aria-label'?: string;
+  scrollPadding?: ScrollPadding;
+}
+
+export function ScrollArea({ className, children, scrollPadding = 0, ...rest }: ScrollAreaProps) {
+  const containerRef = useRef<HTMLElement | null>(null);
+  const paddingRef = useRef<ScrollPadding>(scrollPadding);
+  paddingRef.current = scrollPadding;
+
+  const register = useCallback((element: HTMLElement | null) => {
+    const container = containerRef.current;
+    if (!element || !container) return;
+    const c = container.getBoundingClientRect();
+    const e = element.getBoundingClientRect();
+    const padding = resolvePadding(paddingRef.current, c.height);
+    const above = e.top < c.top + padding;
+    const below = e.bottom > c.bottom - padding;
+    if (!above && !below) return;
+    const delta = above ? e.top - c.top - padding : e.bottom - c.bottom + padding;
+    container.scrollBy({ top: delta });
+  }, []);
+
+  const value = useMemo<ScrollAreaContextValue>(() => ({ register }), [register]);
+
+  return (
+    <ScrollAreaContext.Provider value={value}>
+      <section ref={containerRef} className={cn('h-full min-h-0 overflow-y-auto', className)} {...rest}>
+        {children}
+      </section>
+    </ScrollAreaContext.Provider>
+  );
+}
+
+function resolvePadding(padding: ScrollPadding, containerHeight: number): number {
+  if (typeof padding === 'number') return padding;
+  const numeric = parseFloat(padding);
+  if (Number.isNaN(numeric)) return 0;
+  return (numeric / 100) * containerHeight;
+}
+
+export function useScrollAreaActiveItem(isActive: boolean) {
+  const ctx = useContext(ScrollAreaContext);
+  if (!ctx) throw new Error('useScrollAreaActiveItem must be used within a ScrollArea');
+  const ref = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (isActive) ctx.register(ref.current);
+  }, [isActive, ctx]);
+
+  return ref;
+}

--- a/app/renderer/features/deck/continuous-slide-grid-tile.tsx
+++ b/app/renderer/features/deck/continuous-slide-grid-tile.tsx
@@ -3,6 +3,7 @@ import { Play } from 'lucide-react';
 import type { Id } from '@core/types';
 import { SceneFrame } from '@renderer/components/display/scene-frame';
 import { Thumbnail } from '@renderer/components/display/thumbnail';
+import { useScrollAreaActiveItem } from '@renderer/components/layout/scroll-area';
 import { SceneStage } from '../canvas/scene-stage';
 import type { RenderScene } from '../canvas/scene-types';
 
@@ -20,6 +21,8 @@ interface ContinuousSlideGridTileProps {
 }
 
 function ContinuousSlideGridTileImpl({ entryId, itemId, index, scene, selected, isLive, isEmpty, textPreview, onActivate, onEdit }: ContinuousSlideGridTileProps) {
+  const ref = useScrollAreaActiveItem(selected);
+
   function handleClick() {
     onActivate(entryId, itemId, index);
   }
@@ -29,7 +32,7 @@ function ContinuousSlideGridTileImpl({ entryId, itemId, index, scene, selected, 
   }
 
   return (
-    <Thumbnail.Tile onClick={handleClick} onDoubleClick={handleDoubleClick} selected={selected}>
+    <Thumbnail.Tile ref={ref} onClick={handleClick} onDoubleClick={handleDoubleClick} selected={selected}>
       <Thumbnail.Body>
         <SceneFrame
           width={scene.width}

--- a/app/renderer/features/deck/continuous-slide-grid.tsx
+++ b/app/renderer/features/deck/continuous-slide-grid.tsx
@@ -5,6 +5,7 @@ import { useRenderScenes } from '../../contexts/canvas/canvas-context';
 import { useDeckBrowser } from './deck-browser-context';
 import { useContinuousSlideSections } from './use-continuous-slide-sections';
 import { ThumbnailGrid } from '../../components/layout/thumbnail-grid';
+import { ScrollArea } from '../../components/layout/scroll-area';
 import { EmptyState } from '../../components/display/empty-state';
 import { ContinuousSlideGridTile } from './continuous-slide-grid-tile';
 import type { RenderScene, SceneSurface } from '../canvas/scene-types';
@@ -74,7 +75,7 @@ export function ContinuousSlideGrid({ items }: ContinuousSlideGridProps) {
   }
 
   return (
-    <section className="h-full min-h-0 overflow-y-auto p-2">
+    <ScrollArea className="p-2">
       <div className="flex flex-col gap-2" role="list" aria-label="Continuous playlist grid">
         {items.map((item) => (
           <GridSection
@@ -92,6 +93,6 @@ export function ContinuousSlideGrid({ items }: ContinuousSlideGridProps) {
           />
         ))}
       </div>
-    </section>
+    </ScrollArea>
   );
 }

--- a/app/renderer/features/deck/continuous-slide-list.tsx
+++ b/app/renderer/features/deck/continuous-slide-list.tsx
@@ -9,6 +9,7 @@ import type { OutlineSlideRow } from './use-slide-list-view';
 import { useContinuousSlideSections } from './use-continuous-slide-sections';
 import { SlideOutlineRow } from './slide-list-row';
 import { EmptyState } from '../../components/display/empty-state';
+import { ScrollArea } from '../../components/layout/scroll-area';
 import type { RenderScene, SceneSurface } from '../canvas/scene-types';
 
 interface ContinuousSlideListProps {
@@ -92,7 +93,7 @@ export function ContinuousSlideList({ items }: ContinuousSlideListProps) {
   }
 
   return (
-    <section className="h-full min-h-0 overflow-y-auto p-2">
+    <ScrollArea className="p-2">
       <div className="flex flex-col gap-5" role="list" aria-label="Continuous playlist outline">
         {items.map((item) => (
           <OutlineSection
@@ -109,6 +110,6 @@ export function ContinuousSlideList({ items }: ContinuousSlideListProps) {
           />
         ))}
       </div>
-    </section>
+    </ScrollArea>
   );
 }

--- a/app/renderer/features/deck/slide-grid-tile.tsx
+++ b/app/renderer/features/deck/slide-grid-tile.tsx
@@ -3,6 +3,7 @@ import { Play } from 'lucide-react';
 import type { Id } from '@core/types';
 import { SceneFrame } from '@renderer/components/display/scene-frame';
 import { Thumbnail } from '@renderer/components/display/thumbnail';
+import { useScrollAreaActiveItem } from '@renderer/components/layout/scroll-area';
 import { SceneStage } from '../canvas/scene-stage';
 import type { RenderScene } from '../canvas/scene-types';
 
@@ -19,6 +20,8 @@ interface SlideGridTileProps {
 }
 
 function SlideGridTileImpl({ index, scene, selected, isLive, isEmpty, textPreview, onActivate, onFocus }: SlideGridTileProps) {
+  const ref = useScrollAreaActiveItem(selected);
+
   function handleClick() {
     onActivate(index);
   }
@@ -28,7 +31,7 @@ function SlideGridTileImpl({ index, scene, selected, isLive, isEmpty, textPrevie
   }
 
   return (
-    <Thumbnail.Tile onClick={handleClick} onDoubleClick={handleDoubleClick} selected={selected}>
+    <Thumbnail.Tile ref={ref} onClick={handleClick} onDoubleClick={handleDoubleClick} selected={selected}>
       <Thumbnail.Body>
         <SceneFrame
           width={scene.width}

--- a/app/renderer/features/deck/slide-grid.tsx
+++ b/app/renderer/features/deck/slide-grid.tsx
@@ -4,6 +4,7 @@ import { getSlideVisualState, slideTextPreview } from '../../utils/slides';
 import { useRenderScenes } from '../../contexts/canvas/canvas-context';
 import { useDeckBrowser } from './deck-browser-context';
 import { ThumbnailGrid } from '../../components/layout/thumbnail-grid';
+import { ScrollArea } from '../../components/layout/scroll-area';
 import { SlideGridTile } from './slide-grid-tile';
 
 export function SlideGrid() {
@@ -14,7 +15,7 @@ export function SlideGrid() {
   const showLiveState = !isDetachedDeckBrowser && currentDeckItemId === currentOutputDeckItemId;
 
   return (
-    <section className="h-full min-h-0 overflow-y-auto p-2">
+    <ScrollArea className="p-2">
       <ThumbnailGrid columns={gridItemSize} className="auto-rows-max content-start" role="grid" aria-label="Slides">
         {slides.map((slide, idx) => {
           const elements = slideElementsById.get(slide.id) ?? [];
@@ -38,6 +39,6 @@ export function SlideGrid() {
           );
         })}
       </ThumbnailGrid>
-    </section>
+    </ScrollArea>
   );
 }

--- a/app/renderer/features/deck/slide-list-row.tsx
+++ b/app/renderer/features/deck/slide-list-row.tsx
@@ -4,6 +4,7 @@ import { cn } from '@renderer/utils/cn';
 import { EditableField } from '../../components/form/editable-field';
 import { SceneFrame } from '../../components/display/scene-frame';
 import { Thumbnail } from '../../components/display/thumbnail';
+import { useScrollAreaActiveItem } from '../../components/layout/scroll-area';
 import { Play } from 'lucide-react';
 import type { OutlineSlideRow } from './use-slide-list-view';
 import { SceneStage } from '../canvas/scene-stage';
@@ -19,6 +20,7 @@ interface SlideOutlineRowProps {
 }
 
 function SlideOutlineRowImpl({ row, scene, isFocused, onSelect, onOpen, onTextCommit }: SlideOutlineRowProps) {
+  const ref = useScrollAreaActiveItem(isFocused);
   const rowStateClass = isFocused
     ? 'border-brand-400/80 bg-brand-400/8'
     : 'border-primary bg-primary/40';
@@ -58,6 +60,7 @@ function SlideOutlineRowImpl({ row, scene, isFocused, onSelect, onOpen, onTextCo
 
   return (
     <Thumbnail.Row
+      ref={ref}
       onClick={handleSelect}
       onDoubleClick={row.textEditable ? undefined : handleOpen}
       className={rowStateClass}

--- a/app/renderer/features/deck/slide-list.tsx
+++ b/app/renderer/features/deck/slide-list.tsx
@@ -2,6 +2,7 @@ import { useOutlineView } from './use-slide-list-view';
 import { useRenderScenes } from '../../contexts/canvas/canvas-context';
 import { SlideOutlineRow } from './slide-list-row';
 import { EmptyState } from '../../components/display/empty-state';
+import { ScrollArea } from '../../components/layout/scroll-area';
 
 export function SlideList() {
   const { rows, currentSlideIndex, selectSlide, openSlide, updateText } = useOutlineView();
@@ -32,10 +33,10 @@ export function SlideList() {
   }
 
   return (
-    <section className="h-full min-h-0 overflow-y-auto p-2">
+    <ScrollArea className="p-2">
       <div className="flex flex-col gap-1" role="list" aria-label="Slide outline">
         {rows.map(renderRow)}
       </div>
-    </section>
+    </ScrollArea>
   );
 }

--- a/app/renderer/features/library/playlist-list.tsx
+++ b/app/renderer/features/library/playlist-list.tsx
@@ -2,6 +2,7 @@ import { Button } from '../../components/controls/button';
 import { EllipsisVertical, List, Plus } from 'lucide-react';
 import { EditableField } from '../../components/form/editable-field';
 import { Panel } from '../../components/layout/panel';
+import { ScrollArea, useScrollAreaActiveItem } from '../../components/layout/scroll-area';
 
 import { useNavigation } from '../../contexts/navigation-context';
 import { useLibraryBrowser } from './library-browser-context';
@@ -23,50 +24,79 @@ export function PlaylistList() {
         </Button.Icon>
       </Panel.Header>
 
-      <Panel.Body className="px-1.5 py-1.5 space-y-1" role="list" aria-label="Playlists">
-        {currentLibraryBundle.playlists.map((tree) => {
-          const isSelected = tree.playlist.id === currentPlaylistId;
-          const isEditing = tree.playlist.id === recentlyCreatedId || actions.isEditing('playlist', tree.playlist.id);
+      <Panel.Body scroll={false}>
+        <ScrollArea className="px-1.5 py-1.5 space-y-1" role="list" aria-label="Playlists">
+          {currentLibraryBundle.playlists.map((tree) => {
+            const isSelected = tree.playlist.id === currentPlaylistId;
+            const isEditing = tree.playlist.id === recentlyCreatedId || actions.isEditing('playlist', tree.playlist.id);
 
-          function handleSelect() { setCurrentPlaylistId(tree.playlist.id); }
-          function handleContextMenu(event: React.MouseEvent<HTMLElement>) { actions.handlePlaylistContextMenu(event, tree.playlist.id); }
-          function handleMenuButtonClick(event: React.MouseEvent<HTMLButtonElement>) {
-            event.stopPropagation();
-            actions.openPlaylistMenuFromButton(tree.playlist.id, event.currentTarget);
-          }
-          function handleRename(name: string) {
-            void renamePlaylist(tree.playlist.id, name);
-            clearRecentlyCreated();
-            actions.clearEditing();
-          }
+            function handleSelect() { setCurrentPlaylistId(tree.playlist.id); }
+            function handleContextMenu(event: React.MouseEvent<HTMLElement>) { actions.handlePlaylistContextMenu(event, tree.playlist.id); }
+            function handleMenuButtonClick(event: React.MouseEvent<HTMLButtonElement>) {
+              event.stopPropagation();
+              actions.openPlaylistMenuFromButton(tree.playlist.id, event.currentTarget);
+            }
+            function handleRename(name: string) {
+              void renamePlaylist(tree.playlist.id, name);
+              clearRecentlyCreated();
+              actions.clearEditing();
+            }
 
-          return (
-            <div key={tree.playlist.id} role="listitem" className="group relative">
-              <Button
-                variant="ghost"
-                active={isSelected}
-                onClick={handleSelect}
+            return (
+              <PlaylistRow
+                key={tree.playlist.id}
+                name={tree.playlist.name}
+                isSelected={isSelected}
+                isEditing={isEditing}
+                onSelect={handleSelect}
                 onContextMenu={handleContextMenu}
-                className="block w-full rounded-sm border-0 px-2 py-1.5 pr-7 text-left text-md hover:bg-quaternary/50 hover:text-primary"
-              >
-                <span className="flex items-center gap-2">
-                  <List className="shrink-0 text-tertiary" size={14} strokeWidth={1.75} />
-                  <EditableField
-                    value={tree.playlist.name}
-                    onCommit={handleRename}
-                    editing={isEditing}
-                    className="text-md"
-                  />
-                </span>
-              </Button>
-
-              <Button.Icon label={`Open ${tree.playlist.name} menu`} onClick={handleMenuButtonClick} variant="ghost" className="absolute right-1 top-1/2 -translate-y-1/2 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100" >
-                <EllipsisVertical />
-              </Button.Icon>
-            </div>
-          );
-        })}
+                onMenuClick={handleMenuButtonClick}
+                onRename={handleRename}
+              />
+            );
+          })}
+        </ScrollArea>
       </Panel.Body>
     </Panel>
+  );
+}
+
+interface PlaylistRowProps {
+  name: string;
+  isSelected: boolean;
+  isEditing: boolean;
+  onSelect: () => void;
+  onContextMenu: (event: React.MouseEvent<HTMLElement>) => void;
+  onMenuClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  onRename: (name: string) => void;
+}
+
+function PlaylistRow({ name, isSelected, isEditing, onSelect, onContextMenu, onMenuClick, onRename }: PlaylistRowProps) {
+  const ref = useScrollAreaActiveItem(isSelected);
+
+  return (
+    <div ref={ref} role="listitem" className="group relative">
+      <Button
+        variant="ghost"
+        active={isSelected}
+        onClick={onSelect}
+        onContextMenu={onContextMenu}
+        className="block w-full rounded-sm border-0 px-2 py-1.5 pr-7 text-left text-md hover:bg-quaternary/50 hover:text-primary"
+      >
+        <span className="flex items-center gap-2">
+          <List className="shrink-0 text-tertiary" size={14} strokeWidth={1.75} />
+          <EditableField
+            value={name}
+            onCommit={onRename}
+            editing={isEditing}
+            className="text-md"
+          />
+        </span>
+      </Button>
+
+      <Button.Icon label={`Open ${name} menu`} onClick={onMenuClick} variant="ghost" className="absolute right-1 top-1/2 -translate-y-1/2 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100" >
+        <EllipsisVertical />
+      </Button.Icon>
+    </div>
   );
 }

--- a/app/renderer/features/library/playlist-segment-group.tsx
+++ b/app/renderer/features/library/playlist-segment-group.tsx
@@ -9,6 +9,7 @@ import { useSlides } from '../../contexts/slide-context';
 import { useLibraryBrowser } from './library-browser-context';
 import { getSegmentHeaderColors } from './segment-header-color';
 import { Panel } from '@renderer/components/layout/panel';
+import { useScrollAreaActiveItem } from '@renderer/components/layout/scroll-area';
 import { Paragraph } from '@renderer/components/display/text';
 
 interface PlaylistSegmentGroupProps {
@@ -59,7 +60,6 @@ export function PlaylistSegmentGroup({ segment }: PlaylistSegmentGroupProps) {
       <Accordion.Content>
         {segment.entries.map((entry) => {
           const isSelected = entry.entry.id === currentPlaylistEntryId;
-          const isPresentationEditing = actions.isEditing('presentation', entry.item.id);
 
           function handleSelect() { selectPlaylistEntry(entry.entry.id); }
           function handleContextMenu(event: React.MouseEvent<HTMLElement>) { actions.handleSegmentPresentationContextMenu(event, entry.entry.id, entry.item.id); }
@@ -68,52 +68,44 @@ export function PlaylistSegmentGroup({ segment }: PlaylistSegmentGroupProps) {
             actions.openSegmentPresentationMenuFromButton(entry.entry.id, entry.item.id, event.currentTarget);
           }
 
-          function handleRename(title: string) {
-            actions.renameDeckItem(entry.item.id, title);
-            actions.clearEditing();
-          }
-
           return (
-            <Panel.Item key={entry.entry.id} className='!rounded-none' selected={isSelected} onContextMenu={handleContextMenu}>
-              <Panel.ItemButton onClick={handleSelect}>
-                <DeckItemIcon entity={entry.item} className="shrink-0 text-tertiary" />
-                <Paragraph.xs>{entry.item.title}</Paragraph.xs>
-              </Panel.ItemButton>
-              <Panel.ItemActions>
-                <Button.Icon label={`Open ${entry.item.title} menu`} onClick={handleMenuButtonClick}>
-                  <EllipsisVertical size={14} strokeWidth={2} />
-                </Button.Icon>
-              </Panel.ItemActions>
-            </Panel.Item>
-          )
-
-          // return (
-          //   <div key={entry.entry.id} className="group relative">
-          //     <Button
-          //       variant="ghost"
-          //       active={isSelected}
-          //       onClick={handleSelect}
-          //       onContextMenu={handleContextMenu}
-          //       className="flex w-full items-center gap-2 rounded-sm border-0 px-2 py-1 pl-7 pr-8 text-left text-md cursor-pointer hover:bg-quaternary/50 hover:text-primary"
-          //     >
-          //       <DeckItemIcon entity={entry.item} className="shrink-0 text-tertiary" />
-          //       <EditableField value={entry.item.title} onCommit={handleRename} editing={isPresentationEditing} className="flex-1 text-md" />
-          //     </Button>
-
-
-
-          //     <Button.Icon
-          //       label={`Open ${entry.item.title} menu`}
-          //       onClick={handleMenuButtonClick}
-          //       variant="ghost"
-          //       className="absolute right-1 top-1/2 -translate-y-1/2 rounded border border-transparent text-tertiary opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 hover:border-primary hover:text-primary"
-          //     >
-          //       <EllipsisVertical size={14} strokeWidth={2} />
-          //     </Button.Icon>
-          //   </div>
-          // );
+            <SegmentEntryRow
+              key={entry.entry.id}
+              item={entry.item}
+              isSelected={isSelected}
+              onSelect={handleSelect}
+              onContextMenu={handleContextMenu}
+              onMenuClick={handleMenuButtonClick}
+            />
+          );
         })}
       </Accordion.Content>
     </Accordion.Item>
+  );
+}
+
+interface SegmentEntryRowProps {
+  item: PlaylistTree['segments'][number]['entries'][number]['item'];
+  isSelected: boolean;
+  onSelect: () => void;
+  onContextMenu: (event: React.MouseEvent<HTMLElement>) => void;
+  onMenuClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
+}
+
+function SegmentEntryRow({ item, isSelected, onSelect, onContextMenu, onMenuClick }: SegmentEntryRowProps) {
+  const ref = useScrollAreaActiveItem(isSelected);
+
+  return (
+    <Panel.Item ref={ref} className='!rounded-none' selected={isSelected} onContextMenu={onContextMenu}>
+      <Panel.ItemButton onClick={onSelect}>
+        <DeckItemIcon entity={item} className="shrink-0 text-tertiary" />
+        <Paragraph.xs>{item.title}</Paragraph.xs>
+      </Panel.ItemButton>
+      <Panel.ItemActions>
+        <Button.Icon label={`Open ${item.title} menu`} onClick={onMenuClick}>
+          <EllipsisVertical size={14} strokeWidth={2} />
+        </Button.Icon>
+      </Panel.ItemActions>
+    </Panel.Item>
   );
 }

--- a/app/renderer/features/library/segments-browser.tsx
+++ b/app/renderer/features/library/segments-browser.tsx
@@ -1,6 +1,7 @@
 import { FolderPlus } from 'lucide-react';
 import { Button } from '../../components/controls/button';
 import { Panel } from '../../components/layout/panel';
+import { ScrollArea } from '../../components/layout/scroll-area';
 import { useNavigation } from '../../contexts/navigation-context';
 import { useLibraryBrowser } from './library-browser-context';
 import { useLibraryPanelState } from './library-panel-context';
@@ -30,10 +31,12 @@ export function SegmentsBrowser() {
         </Button.Icon>
       </Panel.Header>
 
-      <Panel.Body>
-        <Accordion type='multiple' value={expandedSegmentIds} onValueChange={handleSegmentValueChange}>
-          {state.selectedTree.segments.map((segment) => <PlaylistSegmentGroup key={segment.segment.id} segment={segment} />)}
-        </Accordion>
+      <Panel.Body scroll={false}>
+        <ScrollArea>
+          <Accordion type='multiple' value={expandedSegmentIds} onValueChange={handleSegmentValueChange}>
+            {state.selectedTree.segments.map((segment) => <PlaylistSegmentGroup key={segment.segment.id} segment={segment} />)}
+          </Accordion>
+        </ScrollArea>
       </Panel.Body>
     </Panel>
   );


### PR DESCRIPTION
## Summary
- Adds a reusable `ScrollArea` + `useScrollAreaActiveItem(isActive)` primitive that auto-scrolls the active descendant into view when it's off-screen, and no-ops when it's already visible.
- Adopts it in all four slide views (grid / list / continuous grid / continuous list), the playlist list, and the segments browser — so the active row tracks keyboard navigation instead of disappearing past the viewport edge.
- `scrollPadding` prop (`number` px or `` `${number}%` `` of container height) keeps the active element off the edge when scrolling; defaults to `0`.

## Implementation notes
- `Thumbnail.Tile`/`Thumbnail.Row` and `Panel.Item` now accept a `ref` prop (React 19 — no `forwardRef` needed). The hook attaches directly to the real rendered element. An earlier attempt wrapped each tile in a `<div className="contents">` to avoid touching the shared primitives, but `display: contents` elements return a zero-sized `DOMRect` from `getBoundingClientRect()`, which defeated the in-view check and made `scrollIntoView` a no-op.
- Scroll math is a simple bounding-rect compare + `container.scrollBy({ top: delta })`; no `IntersectionObserver`.
- Context value is memoized and `register` is stable, so only the transitioning tile re-runs its effect.

## Test plan
- [ ] Open the show page with a deck that overflows the grid/list viewport.
- [ ] Arrow-key through slides past the bottom and top edges — active tile scrolls into view with the configured padding; navigating between visible tiles doesn't scroll.
- [ ] Switch between grid ↔ list views mid-deck — active slide is visible on mount.
- [ ] In continuous views, click a slide in an off-screen section — it scrolls into view.
- [ ] Playlist list / segments browser — selecting an off-screen entry scrolls it in; collapsing/re-expanding a segment with the active entry re-reveals it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)