### PR TITLE
Slide browser polish, sort, kbd nav, segment move, editor auto-scroll

### DIFF
--- a/app/core/ipc.ts
+++ b/app/core/ipc.ts
@@ -41,6 +41,7 @@ export interface MainApi {
   addDeckItemToSegment: (segmentId: Id, itemId: Id) => Promise<AppSnapshot>;
   moveDeckItemToSegment: (playlistId: Id, itemId: Id, segmentId: Id | null) => Promise<AppSnapshot>;
   movePlaylistEntryToSegment: (entryId: Id, segmentId: Id | null) => Promise<AppSnapshot>;
+  movePlaylistEntry: (entryId: Id, direction: 'up' | 'down') => Promise<AppSnapshot>;
   moveDeckItem: (id: Id, direction: 'up' | 'down') => Promise<AppSnapshot>;
   createPresentation: (title: string) => Promise<AppSnapshot>;
   createLyric: (title: string) => Promise<AppSnapshot>;
@@ -112,6 +113,7 @@ export const IPC = {
   addDeckItemToSegment: 'cast:addDeckItemToSegment',
   moveDeckItemToSegment: 'cast:moveDeckItemToSegment',
   movePlaylistEntryToSegment: 'cast:movePlaylistEntryToSegment',
+  movePlaylistEntry: 'cast:movePlaylistEntry',
   moveDeckItem: 'cast:moveDeckItem',
   createPresentation: 'cast:createPresentation',
   createLyric: 'cast:createLyric',

--- a/app/database/store.ts
+++ b/app/database/store.ts
@@ -1397,6 +1397,41 @@ export class CastRepository {
     return this.getSnapshot();
   }
 
+  movePlaylistEntry(entryId: Id, direction: 'up' | 'down'): AppSnapshot {
+    const current = this.db
+      .prepare('SELECT id, segment_id, order_index FROM playlist_entries WHERE id = ?')
+      .get(entryId) as { id: string; segment_id: string; order_index: number } | undefined;
+
+    if (!current) return this.getSnapshot();
+
+    const neighbor = direction === 'up'
+      ? this.db
+        .prepare(
+          'SELECT id, order_index FROM playlist_entries WHERE segment_id = ? AND order_index < ? ORDER BY order_index DESC LIMIT 1'
+        )
+        .get(current.segment_id, current.order_index)
+      : this.db
+        .prepare(
+          'SELECT id, order_index FROM playlist_entries WHERE segment_id = ? AND order_index > ? ORDER BY order_index ASC LIMIT 1'
+        )
+        .get(current.segment_id, current.order_index);
+
+    if (!neighbor) return this.getSnapshot();
+
+    const now = nowIso();
+    const tx = this.db.transaction(() => {
+      this.db
+        .prepare('UPDATE playlist_entries SET order_index = ?, updated_at = ? WHERE id = ?')
+        .run((neighbor as { order_index: number }).order_index, now, current.id);
+      this.db
+        .prepare('UPDATE playlist_entries SET order_index = ?, updated_at = ? WHERE id = ?')
+        .run(current.order_index, now, (neighbor as { id: string }).id);
+    });
+
+    tx();
+    return this.getSnapshot();
+  }
+
   movePlaylistEntryToSegment(entryId: Id, segmentId: Id | null): AppSnapshot {
     const entry = this.db
       .prepare(

--- a/app/main/ipc.ts
+++ b/app/main/ipc.ts
@@ -142,6 +142,9 @@ export const registerIpcHandlers = (
   safeHandle(IPC.movePlaylistEntryToSegment, (_event, entryId: Id, segmentId: Id | null) =>
     repo.movePlaylistEntryToSegment(entryId, segmentId)
   );
+  safeHandle(IPC.movePlaylistEntry, (_event, entryId: Id, direction: 'up' | 'down') =>
+    repo.movePlaylistEntry(entryId, direction)
+  );
   safeHandle(IPC.moveDeckItem, (_event, id: Id, direction: 'up' | 'down') =>
     repo.moveDeckItem(id, direction)
   );

--- a/app/main/preload.ts
+++ b/app/main/preload.ts
@@ -47,6 +47,8 @@ const api = {
     ipcRenderer.invoke(IPC.moveDeckItemToSegment, playlistId, itemId, segmentId),
   movePlaylistEntryToSegment: (entryId: Id, segmentId: Id | null) =>
     ipcRenderer.invoke(IPC.movePlaylistEntryToSegment, entryId, segmentId),
+  movePlaylistEntry: (entryId: Id, direction: 'up' | 'down') =>
+    ipcRenderer.invoke(IPC.movePlaylistEntry, entryId, direction),
   moveDeckItem: (id: Id, direction: 'up' | 'down') => ipcRenderer.invoke(IPC.moveDeckItem, id, direction),
   createPresentation: (title: string) => ipcRenderer.invoke(IPC.createPresentation, title),
   createLyric: (title: string) => ipcRenderer.invoke(IPC.createLyric, title),

--- a/app/renderer/components/display/thumbnail.tsx
+++ b/app/renderer/components/display/thumbnail.tsx
@@ -6,7 +6,7 @@ const thumbnailStyles = cv({
   base: 'group relative w-full min-w-0 overflow-hidden rounded-xs border bg-primary text-left transition-colors',
   variants: {
     selected: {
-      true: ['border-brand-400/70 ring-1 ring-brand-400/35'],
+      true: ['border-brand-400/70 bg-brand-400/15'],
       false: ['border-primary hover:border-secondary'],
     },
   },

--- a/app/renderer/features/deck/build-deck-menu-items.ts
+++ b/app/renderer/features/deck/build-deck-menu-items.ts
@@ -9,6 +9,7 @@ interface BuildPresentationMenuItemsOptions {
   itemIds: Id[];
   selectPlaylistEntry?: (entryId: Id) => void;
   moveDeckItem: (id: Id, direction: 'up' | 'down') => Promise<void>;
+  movePlaylistEntry?: (entryId: Id, direction: 'up' | 'down') => Promise<void>;
   movePlaylistEntryToSegment: (entryId: Id, segmentId: Id | null) => Promise<void>;
   beginRenameDeckItem: (id: Id) => void;
   deleteDeckItem: (id: Id) => Promise<void>;
@@ -22,23 +23,11 @@ export function buildDeckItemMenuItems({
   itemIds,
   selectPlaylistEntry,
   moveDeckItem,
+  movePlaylistEntry,
   movePlaylistEntryToSegment,
   beginRenameDeckItem,
   deleteDeckItem
 }: BuildPresentationMenuItemsOptions): ContextMenuItem[] {
-  const itemIndex = itemIds.indexOf(itemId);
-  const moveUpItem: ContextMenuItem = {
-    id: 'deck-item-up',
-    label: 'Move Up',
-    disabled: itemIndex <= 0,
-    onSelect: () => { void moveDeckItem(itemId, 'up'); }
-  };
-  const moveDownItem: ContextMenuItem = {
-    id: 'deck-item-down',
-    label: 'Move Down',
-    disabled: itemIndex < 0 || itemIndex >= itemIds.length - 1,
-    onSelect: () => { void moveDeckItem(itemId, 'down'); }
-  };
   const deleteItem: ContextMenuItem = {
     id: 'delete-deck-item',
     label: 'Delete',
@@ -50,17 +39,30 @@ export function buildDeckItemMenuItems({
   };
 
   if (scope === 'library') {
+    const itemIndex = itemIds.indexOf(itemId);
     return [
       { id: 'rename-deck-item', label: 'Rename', onSelect: () => beginRenameDeckItem(itemId) },
-      moveUpItem,
-      moveDownItem,
+      {
+        id: 'deck-item-up',
+        label: 'Move Up',
+        disabled: itemIndex <= 0,
+        onSelect: () => { void moveDeckItem(itemId, 'up'); }
+      },
+      {
+        id: 'deck-item-down',
+        label: 'Move Down',
+        disabled: itemIndex < 0 || itemIndex >= itemIds.length - 1,
+        onSelect: () => { void moveDeckItem(itemId, 'down'); }
+      },
       deleteItem
     ];
   }
 
-  const assignedSegmentId = selectedTree?.segments.find((segment) =>
+  const assignedSegment = selectedTree?.segments.find((segment) =>
     segment.entries.some((entry) => entry.entry.id === entryId)
-  )?.segment.id ?? null;
+  ) ?? null;
+  const entryIndex = assignedSegment?.entries.findIndex((entry) => entry.entry.id === entryId) ?? -1;
+  const totalEntries = assignedSegment?.entries.length ?? 0;
   const moveOptions = (selectedTree?.segments ?? []).map((segment) => ({
     id: `move-${segment.segment.id}`,
     label: segment.segment.name,
@@ -73,11 +75,27 @@ export function buildDeckItemMenuItems({
 
   return [
     { id: 'rename-deck-item', label: 'Rename', onSelect: () => beginRenameDeckItem(itemId) },
-    moveUpItem,
-    moveDownItem,
+    {
+      id: 'deck-item-up',
+      label: 'Move Up',
+      disabled: !entryId || !movePlaylistEntry || entryIndex <= 0,
+      onSelect: () => {
+        if (!entryId || !movePlaylistEntry) return;
+        void movePlaylistEntry(entryId, 'up');
+      }
+    },
+    {
+      id: 'deck-item-down',
+      label: 'Move Down',
+      disabled: !entryId || !movePlaylistEntry || entryIndex < 0 || entryIndex >= totalEntries - 1,
+      onSelect: () => {
+        if (!entryId || !movePlaylistEntry) return;
+        void movePlaylistEntry(entryId, 'down');
+      }
+    },
     {
       id: 'move-deck-item',
-      label: 'Move',
+      label: 'Move to segment',
       disabled: !entryId,
       children: [
         ...moveOptions,
@@ -94,7 +112,7 @@ export function buildDeckItemMenuItems({
     {
       id: 'remove-from-segment',
       label: 'Remove',
-      disabled: !entryId || !assignedSegmentId,
+      disabled: !entryId || !assignedSegment,
       onSelect: () => {
         if (!entryId) return;
         void movePlaylistEntryToSegment(entryId, null);

--- a/app/renderer/features/deck/continuous-slide-list.tsx
+++ b/app/renderer/features/deck/continuous-slide-list.tsx
@@ -73,7 +73,7 @@ function OutlineSection({ item, currentPlaylistEntryId, currentOutputPlaylistEnt
       <header className="px-1">
         <h3 className="m-0 text-sm font-semibold text-primary">{item.item.title}</h3>
       </header>
-      <div className="flex flex-col gap-1" role="list" aria-label={`${item.item.title} outline`}>
+      <div className="flex flex-col gap-3" role="list" aria-label={`${item.item.title} outline`}>
         {item.slides.map(renderRow)}
       </div>
     </section>

--- a/app/renderer/features/deck/deck-bin-panel.tsx
+++ b/app/renderer/features/deck/deck-bin-panel.tsx
@@ -139,11 +139,7 @@ function DeckItemTile({ item, slides, isSelected, isEditing, onOpen, onOpenMenu,
 
   return (
     <div className="group cursor-pointer" onContextMenu={handleContextMenu}>
-      <Thumbnail.Tile
-        onClick={handleOpen}
-        selected={isSelected}
-        className={isSelected ? 'ring-1 ring-brand-400 ring-offset-1 ring-offset-background-primary' : ''}
-      >
+      <Thumbnail.Tile onClick={handleOpen} selected={isSelected}>
         <Thumbnail.Body>
           <>
             <ScenePreview scene={scene} />

--- a/app/renderer/features/deck/slide-list.tsx
+++ b/app/renderer/features/deck/slide-list.tsx
@@ -34,7 +34,7 @@ export function SlideList() {
 
   return (
     <ScrollArea className="p-2">
-      <div className="flex flex-col gap-1" role="list" aria-label="Slide outline">
+      <div className="flex flex-col gap-3" role="list" aria-label="Slide outline">
         {rows.map(renderRow)}
       </div>
     </ScrollArea>

--- a/app/renderer/features/deck/use-deck-bin-sort.ts
+++ b/app/renderer/features/deck/use-deck-bin-sort.ts
@@ -1,0 +1,59 @@
+import { useCallback, useSyncExternalStore } from 'react';
+
+export type DeckBinSortKey = 'name' | 'created' | 'modified' | 'slides';
+export type SortDirection = 'asc' | 'desc';
+export interface DeckBinSort {
+  key: DeckBinSortKey;
+  direction: SortDirection;
+}
+
+const STORAGE_KEY = 'recast.deck-bin-sort';
+const DEFAULT_SORT: DeckBinSort = { key: 'modified', direction: 'desc' };
+const VALID_KEYS: DeckBinSortKey[] = ['name', 'created', 'modified', 'slides'];
+const VALID_DIRECTIONS: SortDirection[] = ['asc', 'desc'];
+
+function isValid(value: unknown): value is DeckBinSort {
+  if (!value || typeof value !== 'object') return false;
+  const record = value as Record<string, unknown>;
+  return VALID_KEYS.includes(record.key as DeckBinSortKey)
+    && VALID_DIRECTIONS.includes(record.direction as SortDirection);
+}
+
+function readFromStorage(): DeckBinSort {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return DEFAULT_SORT;
+    const parsed = JSON.parse(raw);
+    return isValid(parsed) ? parsed : DEFAULT_SORT;
+  } catch {
+    return DEFAULT_SORT;
+  }
+}
+
+let sortState: DeckBinSort = readFromStorage();
+const listeners = new Set<() => void>();
+
+function emit() {
+  for (const listener of listeners) listener();
+}
+
+function subscribe(callback: () => void) {
+  listeners.add(callback);
+  return () => { listeners.delete(callback); };
+}
+
+export function useDeckBinSort() {
+  const sort = useSyncExternalStore(subscribe, () => sortState, () => sortState);
+
+  const setSort = useCallback((next: DeckBinSort) => {
+    sortState = next;
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+    } catch {
+      // ignore storage errors; in-memory state still updates
+    }
+    emit();
+  }, []);
+
+  return { sort, setSort };
+}

--- a/app/renderer/features/deck/use-deck-bin.ts
+++ b/app/renderer/features/deck/use-deck-bin.ts
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import type { Id } from '@core/types';
+import type { DeckItem, Id } from '@core/types';
 import type { ContextMenuItem } from '../../components/overlays/context-menu';
 import { useNavigation } from '../../contexts/navigation-context';
 import { useProjectContent } from '../../contexts/use-project-content';
@@ -7,6 +7,7 @@ import { useContextMenuState } from '../../hooks/use-context-menu-state';
 import { filterByText } from '../../utils/filter-by-text';
 import { buildDeckItemMenuItems } from './build-deck-menu-items';
 import { useLibraryPanelManagement } from '../library/use-library-panel-management';
+import { useDeckBinSort, type DeckBinSort } from './use-deck-bin-sort';
 
 export function useDeckBin(filterText: string) {
   const {
@@ -25,14 +26,16 @@ export function useDeckBin(filterText: string) {
   } = useLibraryPanelManagement();
   const menu = useContextMenuState<Id>();
   const [editingDeckItemId, setEditingPresentationId] = useState<Id | null>(null);
+  const { sort } = useDeckBinSort();
 
   const filteredDeckItems = useMemo(() => {
-    return filterByText(deckItems, filterText, (item) => {
+    const filtered = filterByText(deckItems, filterText, (item) => {
       const slides = slidesByDeckItemId.get(item.id) ?? [];
       const slideLabels = slides.map((slide) => `slide ${slide.order + 1}`);
       return [item.title, item.type, ...slideLabels];
     });
-  }, [deckItems, filterText, slidesByDeckItemId]);
+    return sortDeckItems(filtered, sort, slidesByDeckItemId);
+  }, [deckItems, filterText, slidesByDeckItemId, sort]);
 
   const menuItems = useMemo<ContextMenuItem[]>(() => {
     if (!menu.menuState) return [];
@@ -64,4 +67,25 @@ export function useDeckBin(filterText: string) {
     handleRename,
     slidesByDeckItemId,
   };
+}
+
+function sortDeckItems(items: DeckItem[], sort: DeckBinSort, slidesByDeckItemId: ReadonlyMap<Id, unknown[]>): DeckItem[] {
+  const direction = sort.direction === 'asc' ? 1 : -1;
+  const sorted = [...items];
+  sorted.sort((a, b) => {
+    switch (sort.key) {
+      case 'name':
+        return direction * a.title.localeCompare(b.title);
+      case 'created':
+        return direction * a.createdAt.localeCompare(b.createdAt);
+      case 'modified':
+        return direction * a.updatedAt.localeCompare(b.updatedAt);
+      case 'slides': {
+        const aCount = slidesByDeckItemId.get(a.id)?.length ?? 0;
+        const bCount = slidesByDeckItemId.get(b.id)?.length ?? 0;
+        return direction * (aCount - bCount);
+      }
+    }
+  });
+  return sorted;
 }

--- a/app/renderer/features/library/library-panel-menu-items.ts
+++ b/app/renderer/features/library/library-panel-menu-items.ts
@@ -29,6 +29,7 @@ interface BuildMenuItemsOptions {
   deleteDeckItem: (id: Id) => Promise<void>;
   movePlaylist: (id: Id, direction: 'up' | 'down') => Promise<void>;
   moveDeckItem: (id: Id, direction: 'up' | 'down') => Promise<void>;
+  movePlaylistEntry: (entryId: Id, direction: 'up' | 'down') => Promise<void>;
   setSegmentColor: (id: Id, colorKey: string | null) => Promise<void>;
   addDeckItemToSegment: (segmentId: Id, itemId: Id) => Promise<Id | null>;
   movePlaylistEntryToSegment: (entryId: Id, segmentId: Id | null) => Promise<void>;
@@ -41,7 +42,7 @@ interface BuildMenuItemsOptions {
 }
 
 export function buildLibraryPanelMenuItems(options: BuildMenuItemsOptions): ContextMenuItem[] {
-  const { target, currentLibraryId, selectedTree, libraryDeckItems, playlistIds, deckItemIds, setLibraryPanelView, selectPlaylistDeckItem, selectPlaylistEntry, deleteLibrary, deletePlaylist, deleteSegment, deleteDeckItem, movePlaylist, moveDeckItem, setSegmentColor, addDeckItemToSegment, movePlaylistEntryToSegment, createPresentationInSegment, createLyricInSegment, beginRenameLibrary, beginRenamePlaylist, beginRenameSegment, beginRenamePresentation } = options;
+  const { target, currentLibraryId, selectedTree, libraryDeckItems, playlistIds, deckItemIds, setLibraryPanelView, selectPlaylistDeckItem, selectPlaylistEntry, deleteLibrary, deletePlaylist, deleteSegment, deleteDeckItem, movePlaylist, moveDeckItem, movePlaylistEntry, setSegmentColor, addDeckItemToSegment, movePlaylistEntryToSegment, createPresentationInSegment, createLyricInSegment, beginRenameLibrary, beginRenamePlaylist, beginRenameSegment, beginRenamePresentation } = options;
 
   if (target.type === 'library') {
     return [
@@ -158,6 +159,7 @@ export function buildLibraryPanelMenuItems(options: BuildMenuItemsOptions): Cont
     itemIds: deckItemIds,
     selectPlaylistEntry,
     moveDeckItem,
+    movePlaylistEntry,
     movePlaylistEntryToSegment,
     beginRenameDeckItem: beginRenamePresentation,
     deleteDeckItem,

--- a/app/renderer/features/library/use-library-panel-context-menu.ts
+++ b/app/renderer/features/library/use-library-panel-context-menu.ts
@@ -21,7 +21,7 @@ export function useLibraryPanelContextMenu() {
   const { deckItems } = useProjectContent();
   const { selectPlaylistDeckItem, selectPlaylistEntry } = useSlides();
   const { setLibraryPanelView } = useLibraryPanelState();
-  const { deleteLibrary, deletePlaylist, deleteSegment, deleteDeckItem, movePlaylist, moveDeckItem, setSegmentColor, addDeckItemToSegment, movePlaylistEntryToSegment, createPresentationInSegment, createLyricInSegment } = useLibraryPanelManagement();
+  const { deleteLibrary, deletePlaylist, deleteSegment, deleteDeckItem, movePlaylist, moveDeckItem, movePlaylistEntry, setSegmentColor, addDeckItemToSegment, movePlaylistEntryToSegment, createPresentationInSegment, createLyricInSegment } = useLibraryPanelManagement();
   const menu = useContextMenuState<LibraryPanelMenuTarget>();
   const [editingTarget, setEditingTarget] = useState<EditingTarget>(null);
   const selectedTree = currentLibraryBundle?.playlists.find((playlist) => playlist.playlist.id === currentPlaylistId) ?? null;
@@ -56,6 +56,7 @@ export function useLibraryPanelContextMenu() {
       deleteDeckItem,
       movePlaylist,
       moveDeckItem,
+      movePlaylistEntry,
       setSegmentColor,
       addDeckItemToSegment,
       movePlaylistEntryToSegment,
@@ -66,7 +67,7 @@ export function useLibraryPanelContextMenu() {
       beginRenameSegment: (id: Id) => beginEditing('segment', id),
       beginRenamePresentation: (id: Id) => beginEditing('presentation', id),
     });
-  }, [menu.menuState, currentLibraryId, currentPlaylistId, selectedTree, deckItems, playlistIds, deckItemIds, setLibraryPanelView, selectPlaylistDeckItem, selectPlaylistEntry, deleteLibrary, deletePlaylist, deleteSegment, deleteDeckItem, movePlaylist, moveDeckItem, setSegmentColor, addDeckItemToSegment, movePlaylistEntryToSegment, createPresentationInSegment, createLyricInSegment, beginEditing]);
+  }, [menu.menuState, currentLibraryId, currentPlaylistId, selectedTree, deckItems, playlistIds, deckItemIds, setLibraryPanelView, selectPlaylistDeckItem, selectPlaylistEntry, deleteLibrary, deletePlaylist, deleteSegment, deleteDeckItem, movePlaylist, moveDeckItem, movePlaylistEntry, setSegmentColor, addDeckItemToSegment, movePlaylistEntryToSegment, createPresentationInSegment, createLyricInSegment, beginEditing]);
 
   return {
     menuState: menu.menuState,

--- a/app/renderer/features/library/use-library-panel-management.ts
+++ b/app/renderer/features/library/use-library-panel-management.ts
@@ -116,6 +116,11 @@ export function useLibraryPanelManagement() {
     setStatusText(direction === 'up' ? 'Moved item up' : 'Moved item down');
   }, [mutate, setStatusText]);
 
+  const movePlaylistEntry = useCallback(async (entryId: Id, direction: 'up' | 'down') => {
+    await mutate(() => window.castApi.movePlaylistEntry(entryId, direction));
+    setStatusText(direction === 'up' ? 'Moved entry up' : 'Moved entry down');
+  }, [mutate, setStatusText]);
+
   const addDeckItemToSegment = useCallback(async (segmentId: Id, itemId: Id) => {
     const previousEntryIds = new Set(getSegmentEntryIds(snapshot, segmentId));
     const nextSnapshot = await mutate(() => window.castApi.addDeckItemToSegment(segmentId, itemId));
@@ -175,6 +180,7 @@ export function useLibraryPanelManagement() {
     movePlaylistEntryToSegment,
     movePlaylist,
     moveDeckItem,
+    movePlaylistEntry,
     addDeckItemToSegment,
     createPresentationInSegment,
     createLyricInSegment

--- a/app/renderer/features/workbench/resource-drawer.tsx
+++ b/app/renderer/features/workbench/resource-drawer.tsx
@@ -1,6 +1,6 @@
-import { createContext, useContext, useState, type ChangeEvent, type ReactNode } from 'react';
-import { ContextMenu } from '../../components/overlays/context-menu';
-import { Grid2x2, List, Plus } from 'lucide-react';
+import { createContext, useContext, useMemo, useState, type ChangeEvent, type ReactNode } from 'react';
+import { ContextMenu, type ContextMenuItem } from '../../components/overlays/context-menu';
+import { ArrowDownUp, Grid2x2, List, Plus } from 'lucide-react';
 import { Button } from '../../components/controls/button';
 import { SegmentedControl } from '../../components/controls/segmented-control';
 import { Tabs } from '../../components/display/tabs';
@@ -9,6 +9,7 @@ import { SelectableRow } from '../../components/display/selectable-row';
 import { FileTrigger } from '../../components/form/file-trigger';
 import { GridSizeSlider } from '../../components/form/grid-size-slider';
 import { useCreateMenu } from '../../hooks/use-create-menu';
+import { useContextMenuState } from '../../hooks/use-context-menu-state';
 import { useElements } from '../../contexts/canvas/canvas-context';
 import { useNavigation } from '../../contexts/navigation-context';
 import { useResourceDrawer } from './resource-drawer-context';
@@ -23,6 +24,7 @@ import { useAudio } from '../../contexts/playback/playback-context';
 import { useAudioCoverArt } from '../../hooks/use-audio-cover-art';
 import { MediaBinPanel } from '../assets/media/media-bin-panel';
 import { DeckBinPanel } from '../deck/deck-bin-panel';
+import { useDeckBinSort, type DeckBinSortKey, type SortDirection } from '../deck/use-deck-bin-sort';
 import { TemplateBinPanel } from '../assets/templates/template-bin-panel';
 import { cn } from '@renderer/utils/cn';
 import { EmptyState } from '../../components/display/empty-state';
@@ -301,6 +303,31 @@ function ResourceDrawerContent() {
   const { actions, meta, state } = useDrawer();
   const { drawerViewMode, setDrawerViewMode } = useResourceDrawer();
   const audio = useAudio();
+  const { sort, setSort } = useDeckBinSort();
+  const sortMenu = useContextMenuState<null>();
+
+  const sortMenuItems = useMemo<ContextMenuItem[]>(() => {
+    const keyOption = (id: DeckBinSortKey, label: string): ContextMenuItem => ({
+      id: `sort-${id}`,
+      label,
+      selected: sort.key === id,
+      onSelect: () => setSort({ ...sort, key: id }),
+    });
+    const directionOption = (direction: SortDirection, label: string): ContextMenuItem => ({
+      id: `sort-direction-${direction}`,
+      label,
+      selected: sort.direction === direction,
+      onSelect: () => setSort({ ...sort, direction }),
+    });
+    return [
+      keyOption('name', 'Name'),
+      keyOption('created', 'Date created'),
+      keyOption('modified', 'Date modified'),
+      keyOption('slides', 'Slide count'),
+      directionOption('asc', 'Ascending'),
+      directionOption('desc', 'Descending'),
+    ];
+  }, [sort, setSort]);
 
   function handleImportSelect(_files: FileList, event: ChangeEvent<HTMLInputElement>) {
     actions.handleImport(event);
@@ -316,6 +343,12 @@ function ResourceDrawerContent() {
     setDrawerViewMode(nextValue);
   }
 
+  function handleOpenSortMenu(event: React.MouseEvent<HTMLButtonElement>) {
+    sortMenu.openFromButton(event.currentTarget, null);
+  }
+
+  const showSortControl = state.drawerTab === 'deck';
+
   return (
     <Tabs.Root value={state.drawerTab} onValueChange={handleTabChange}>
       <div className="h-8 flex border-b border-primary px-1 items-end">
@@ -326,6 +359,11 @@ function ResourceDrawerContent() {
           <Tabs.Trigger value="templates">Templates</Tabs.Trigger>
         </Tabs.List>
         <div className={cn('flex shrink-0 items-center gap-0.5 py-0.5')}>
+          {showSortControl ? (
+            <Button.Icon label="Sort" variant="ghost" onClick={handleOpenSortMenu}>
+              <ArrowDownUp />
+            </Button.Icon>
+          ) : null}
           {meta.showGridSizeControl ? <GridSizeSlider value={meta.gridSize} min={meta.gridSizeMin} max={meta.gridSizeMax} step={meta.gridSizeStep} onChange={actions.setGridSize} /> : null}
           {meta.showImportAction &&
             <FileTrigger.Root accept={state.drawerTab === 'audio' ? IMPORT_ACCEPT_BY_TAB.audio : IMPORT_ACCEPT_BY_TAB.media} multiple onSelect={handleImportSelect} className="relative inline-flex">
@@ -379,6 +417,9 @@ function ResourceDrawerContent() {
           <TemplateBinPanel filterText="" gridItemSize={meta.gridSize} />
         </Tabs.Panel>
       </Tabs.Panels>
+      {sortMenu.menuState ? (
+        <ContextMenu x={sortMenu.menuState.x} y={sortMenu.menuState.y} items={sortMenuItems} onClose={sortMenu.close} />
+      ) : null}
     </Tabs.Root>
   );
 }

--- a/app/renderer/features/workbench/use-editor-left-panel-nav.ts
+++ b/app/renderer/features/workbench/use-editor-left-panel-nav.ts
@@ -1,0 +1,42 @@
+import { useEffect } from 'react';
+import type { Id } from '@core/types';
+import { useElements } from '../../contexts/canvas/canvas-context';
+
+interface NavItem {
+  id: Id;
+}
+
+interface UseEditorLeftPanelNavOptions<T extends NavItem> {
+  items: readonly T[];
+  currentId: Id | null;
+  activate: (id: Id, index: number) => void;
+}
+
+export function useEditorLeftPanelNav<T extends NavItem>({ items, currentId, activate }: UseEditorLeftPanelNavOptions<T>) {
+  const { selectedElementId } = useElements();
+
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key !== 'ArrowUp' && event.key !== 'ArrowDown') return;
+      if (event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) return;
+      if (selectedElementId) return;
+      const target = event.target as HTMLElement | null;
+      const isEditable = target?.tagName === 'INPUT'
+        || target?.tagName === 'TEXTAREA'
+        || target?.getAttribute('contenteditable') === 'true';
+      if (isEditable) return;
+      if (items.length === 0) return;
+
+      const currentIndex = currentId ? items.findIndex((item) => item.id === currentId) : -1;
+      const delta = event.key === 'ArrowDown' ? 1 : -1;
+      const resolvedIndex = currentIndex === -1 ? 0 : currentIndex + delta;
+      const nextIndex = Math.max(0, Math.min(items.length - 1, resolvedIndex));
+      if (nextIndex === currentIndex) return;
+      event.preventDefault();
+      activate(items[nextIndex].id, nextIndex);
+    }
+
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [items, currentId, activate, selectedElementId]);
+}

--- a/app/renderer/screens/deck-editor/page.tsx
+++ b/app/renderer/screens/deck-editor/page.tsx
@@ -17,11 +17,13 @@ import { InspectorTabsPanel } from '../../features/canvas/inspector-tabs-panel';
 import { useInspectorPanelPushAction } from '../../features/canvas/use-inspector-panel-push-action';
 import { StagePanel } from '../../features/canvas/stage-panel';
 import { SplitPanel } from '../../features/workbench/split-panel';
+import { useEditorLeftPanelNav } from '../../features/workbench/use-editor-left-panel-nav';
 import { useSlideNotesPanel } from '../../features/deck/use-slide-notes-panel';
 import { ObjectListPanel } from '@renderer/features/canvas/object-list-panel';
 import { Thumbnail } from '@renderer/components/display/thumbnail';
 import { SceneFrame } from '@renderer/components/display/scene-frame';
 import { SceneStage } from '@renderer/features/canvas/scene-stage';
+import { EmptyState } from '@renderer/components/display/empty-state';
 
 export function DeckEditorScreen() {
   const { browseDeckItem, currentDeckItem } = useNavigation();
@@ -43,6 +45,12 @@ export function DeckEditorScreen() {
   } = useSlideNotesPanel();
   const [presentationMenuPosition, setPresentationMenuPosition] = useState<{ x: number; y: number } | null>(null);
   const slideMenu = useContextMenuState<Id>();
+
+  useEditorLeftPanelNav({
+    items: slides,
+    currentId: currentSlide?.id ?? null,
+    activate: (_id, index) => setCurrentSlideIndex(index),
+  });
 
   const presentationMenuItems = useMemo<ContextMenuItem[]>(() => {
     return deckItems.map((item) => ({
@@ -118,7 +126,18 @@ export function DeckEditorScreen() {
                     </Panel.SectionAction>
                   </Panel.SectionHeader>
                   <Panel.SectionBody className="overflow-y-auto p-2">
-                  <div className="grid min-w-0 grid-cols-1 content-start gap-1" role="grid" aria-label={`Current ${currentDeckItem?.type === 'lyric' ? 'lyrics' : 'slides'}`}>
+                  {!currentDeckItem ? (
+                    <EmptyState.Root>
+                      <EmptyState.Title>No item selected</EmptyState.Title>
+                      <EmptyState.Description>Pick a presentation or lyric from the menu above to start editing.</EmptyState.Description>
+                    </EmptyState.Root>
+                  ) : slides.length === 0 ? (
+                    <EmptyState.Root>
+                      <EmptyState.Title>No slides yet</EmptyState.Title>
+                      <EmptyState.Description>Click the + button to add your first slide.</EmptyState.Description>
+                    </EmptyState.Root>
+                  ) : (
+                  <div className="grid min-w-0 grid-cols-1 content-start gap-3" role="grid" aria-label={`Current ${currentDeckItem?.type === 'lyric' ? 'lyrics' : 'slides'}`}>
                     {slides.map((slide, index) => {
                       const elements = currentSlide?.id === slide.id ? effectiveElements : getSlideElements(slide.id);
                       const scene = getThumbnailScene(slide.id, 'deck-editor');
@@ -175,6 +194,7 @@ export function DeckEditorScreen() {
                       );
                     })}
                   </div>
+                  )}
                   </Panel.SectionBody>
                 </Panel.Section>
               </SplitPanel.Segment>

--- a/app/renderer/screens/deck-editor/page.tsx
+++ b/app/renderer/screens/deck-editor/page.tsx
@@ -24,6 +24,7 @@ import { Thumbnail } from '@renderer/components/display/thumbnail';
 import { SceneFrame } from '@renderer/components/display/scene-frame';
 import { SceneStage } from '@renderer/features/canvas/scene-stage';
 import { EmptyState } from '@renderer/components/display/empty-state';
+import { ScrollArea, useScrollAreaActiveItem } from '@renderer/components/layout/scroll-area';
 
 export function DeckEditorScreen() {
   const { browseDeckItem, currentDeckItem } = useNavigation();
@@ -125,7 +126,7 @@ export function DeckEditorScreen() {
                       </Button.Icon>
                     </Panel.SectionAction>
                   </Panel.SectionHeader>
-                  <Panel.SectionBody className="overflow-y-auto p-2">
+                  <Panel.SectionBody>
                   {!currentDeckItem ? (
                     <EmptyState.Root>
                       <EmptyState.Title>No item selected</EmptyState.Title>
@@ -137,6 +138,7 @@ export function DeckEditorScreen() {
                       <EmptyState.Description>Click the + button to add your first slide.</EmptyState.Description>
                     </EmptyState.Root>
                   ) : (
+                  <ScrollArea className="p-2">
                   <div className="grid min-w-0 grid-cols-1 content-start gap-3" role="grid" aria-label={`Current ${currentDeckItem?.type === 'lyric' ? 'lyrics' : 'slides'}`}>
                     {slides.map((slide, index) => {
                       const elements = currentSlide?.id === slide.id ? effectiveElements : getSlideElements(slide.id);
@@ -157,7 +159,9 @@ export function DeckEditorScreen() {
                       const isEmpty = state === 'warning';
 
                       return (
-                        <Thumbnail.Tile
+                        <ActiveSlideTile
+                          key={slide.id}
+                          isActive={index === currentSlideIndex}
                           onClick={handleSelect}
                           onDoubleClick={handleSelect}
                           selected={index === currentSlideIndex}
@@ -190,10 +194,11 @@ export function DeckEditorScreen() {
                               <span className="min-w-0 truncate text-sm text-tertiary">{slideTextPreview(elements)}</span>
                             </div>
                           </Thumbnail.Caption>
-                        </Thumbnail.Tile>
+                        </ActiveSlideTile>
                       );
                     })}
                   </div>
+                  </ScrollArea>
                   )}
                   </Panel.SectionBody>
                 </Panel.Section>
@@ -263,4 +268,9 @@ export function DeckEditorScreen() {
       </SplitPanel.Panel>
     </section>
   );
+}
+
+function ActiveSlideTile({ isActive, ...props }: React.ComponentProps<typeof Thumbnail.Tile> & { isActive: boolean }) {
+  const ref = useScrollAreaActiveItem(isActive);
+  return <Thumbnail.Tile ref={ref} {...props} />;
 }

--- a/app/renderer/screens/overlay-editor/page.tsx
+++ b/app/renderer/screens/overlay-editor/page.tsx
@@ -15,12 +15,20 @@ import { buildRenderScene } from '../../features/canvas/build-render-scene';
 import { SceneStage } from '../../features/canvas/scene-stage';
 import { StagePanel } from '../../features/canvas/stage-panel';
 import { SplitPanel } from '../../features/workbench/split-panel';
+import { useEditorLeftPanelNav } from '../../features/workbench/use-editor-left-panel-nav';
 import { Label } from '@renderer/components/display/text';
+import { EmptyState } from '@renderer/components/display/empty-state';
 
 export function OverlayEditorScreen() {
   const { overlays, currentOverlayId, setCurrentOverlayId, createOverlay, deleteCurrentOverlay, duplicateOverlay, requestNameFocus } = useOverlayEditor();
   const { state: inspectorState, handlePushChanges } = useInspectorPanelPushAction();
   const menu = useContextMenuState<Id>();
+
+  useEditorLeftPanelNav({
+    items: overlays,
+    currentId: currentOverlayId,
+    activate: (id) => setCurrentOverlayId(id),
+  });
 
   function handleAddOverlay() {
     void createOverlay();
@@ -59,6 +67,12 @@ export function OverlayEditorScreen() {
                     </Panel.SectionAction>
                   </Panel.SectionHeader>
                   <Panel.SectionBody className="overflow-y-auto p-2">
+                    {overlays.length === 0 ? (
+                      <EmptyState.Root>
+                        <EmptyState.Title>No overlays yet</EmptyState.Title>
+                        <EmptyState.Description>Click the + button to create your first overlay.</EmptyState.Description>
+                      </EmptyState.Root>
+                    ) : (
                     <div className="grid min-w-0 grid-cols-1 content-start gap-1" role="grid" aria-label="Library overlays">
                       {overlays.map((overlay, index) => {
                         const scene = buildRenderScene(null, overlayToLayerElements(overlay));
@@ -98,6 +112,7 @@ export function OverlayEditorScreen() {
                         );
                       })}
                     </div>
+                    )}
                   </Panel.SectionBody>
                 </Panel.Section>
               </SplitPanel.Segment>

--- a/app/renderer/screens/overlay-editor/page.tsx
+++ b/app/renderer/screens/overlay-editor/page.tsx
@@ -18,6 +18,7 @@ import { SplitPanel } from '../../features/workbench/split-panel';
 import { useEditorLeftPanelNav } from '../../features/workbench/use-editor-left-panel-nav';
 import { Label } from '@renderer/components/display/text';
 import { EmptyState } from '@renderer/components/display/empty-state';
+import { ScrollArea, useScrollAreaActiveItem } from '@renderer/components/layout/scroll-area';
 
 export function OverlayEditorScreen() {
   const { overlays, currentOverlayId, setCurrentOverlayId, createOverlay, deleteCurrentOverlay, duplicateOverlay, requestNameFocus } = useOverlayEditor();
@@ -66,13 +67,14 @@ export function OverlayEditorScreen() {
                       </Button.Icon>
                     </Panel.SectionAction>
                   </Panel.SectionHeader>
-                  <Panel.SectionBody className="overflow-y-auto p-2">
+                  <Panel.SectionBody>
                     {overlays.length === 0 ? (
                       <EmptyState.Root>
                         <EmptyState.Title>No overlays yet</EmptyState.Title>
                         <EmptyState.Description>Click the + button to create your first overlay.</EmptyState.Description>
                       </EmptyState.Root>
                     ) : (
+                    <ScrollArea className="p-2">
                     <div className="grid min-w-0 grid-cols-1 content-start gap-1" role="grid" aria-label="Library overlays">
                       {overlays.map((overlay, index) => {
                         const scene = buildRenderScene(null, overlayToLayerElements(overlay));
@@ -91,7 +93,7 @@ export function OverlayEditorScreen() {
                         }
 
                         return (
-                          <Thumbnail.Tile key={overlay.id} onClick={handleSelect} onContextMenu={handleContextMenu} selected={currentOverlayId === overlay.id}>
+                          <ActiveOverlayTile key={overlay.id} isActive={currentOverlayId === overlay.id} onClick={handleSelect} onContextMenu={handleContextMenu} selected={currentOverlayId === overlay.id}>
                             <Thumbnail.Body>
                               <SceneFrame width={scene.width} height={scene.height} className="bg-tertiary" stageClassName="absolute inset-0" checkerboard>
                                 <SceneStage scene={scene} surface="list" className="absolute inset-0 pointer-events-none" />
@@ -108,10 +110,11 @@ export function OverlayEditorScreen() {
                                 <span className="min-w-0 truncate text-sm text-tertiary">{overlay.name}</span>
                               </div>
                             </Thumbnail.Caption>
-                          </Thumbnail.Tile>
+                          </ActiveOverlayTile>
                         );
                       })}
                     </div>
+                    </ScrollArea>
                     )}
                   </Panel.SectionBody>
                 </Panel.Section>
@@ -150,4 +153,9 @@ export function OverlayEditorScreen() {
       </SplitPanel.Panel>
     </section>
   );
+}
+
+function ActiveOverlayTile({ isActive, ...props }: React.ComponentProps<typeof Thumbnail.Tile> & { isActive: boolean }) {
+  const ref = useScrollAreaActiveItem(isActive);
+  return <Thumbnail.Tile ref={ref} {...props} />;
 }

--- a/app/renderer/screens/template-editor/page.tsx
+++ b/app/renderer/screens/template-editor/page.tsx
@@ -17,6 +17,7 @@ import { StagePanel } from '../../features/canvas/stage-panel';
 import { SplitPanel } from '../../features/workbench/split-panel';
 import { useEditorLeftPanelNav } from '../../features/workbench/use-editor-left-panel-nav';
 import { EmptyState } from '@renderer/components/display/empty-state';
+import { ScrollArea, useScrollAreaActiveItem } from '@renderer/components/layout/scroll-area';
 
 export function TemplateEditorScreen() {
   const { templates, currentTemplateId, openTemplateEditor, createTemplate, deleteTemplate, duplicateTemplate, requestNameFocus } = useTemplateEditor();
@@ -65,13 +66,14 @@ export function TemplateEditorScreen() {
                       </Button.Icon>
                     </Panel.SectionAction>
                   </Panel.SectionHeader>
-                  <Panel.SectionBody className="overflow-y-auto p-2">
+                  <Panel.SectionBody>
                     {templates.length === 0 ? (
                       <EmptyState.Root>
                         <EmptyState.Title>No templates yet</EmptyState.Title>
                         <EmptyState.Description>Click the + button to create your first template.</EmptyState.Description>
                       </EmptyState.Root>
                     ) : (
+                    <ScrollArea className="p-2">
                     <div className="grid min-w-0 grid-cols-1 content-start gap-1" role="grid" aria-label="Templates">
                       {templates.map((template, index) => {
                         const scene = buildRenderScene(null, template.elements);
@@ -95,7 +97,7 @@ export function TemplateEditorScreen() {
                         }
 
                         return (
-                          <Thumbnail.Tile key={template.id} onClick={handleSelect} onContextMenu={handleContextMenu} selected={template.id === currentTemplateId}>
+                          <ActiveTemplateTile key={template.id} isActive={template.id === currentTemplateId} onClick={handleSelect} onContextMenu={handleContextMenu} selected={template.id === currentTemplateId}>
                             <Thumbnail.Body>
                               <SceneFrame width={scene.width} height={scene.height} className="bg-tertiary" stageClassName="absolute inset-0" checkerboard>
                                 <SceneStage scene={scene} surface="list" className="absolute inset-0 pointer-events-none" />
@@ -113,10 +115,11 @@ export function TemplateEditorScreen() {
                                 <span className="min-w-0 truncate text-sm text-tertiary">{template.name}</span>
                               </div>
                             </Thumbnail.Caption>
-                          </Thumbnail.Tile>
+                          </ActiveTemplateTile>
                         );
                       })}
                     </div>
+                    </ScrollArea>
                     )}
                   </Panel.SectionBody>
                 </Panel.Section>
@@ -156,6 +159,11 @@ export function TemplateEditorScreen() {
       </SplitPanel.Panel>
     </section>
   );
+}
+
+function ActiveTemplateTile({ isActive, ...props }: React.ComponentProps<typeof Thumbnail.Tile> & { isActive: boolean }) {
+  const ref = useScrollAreaActiveItem(isActive);
+  return <Thumbnail.Tile ref={ref} {...props} />;
 }
 
 function TemplateKindIcon({ kind }: { kind: Template['kind'] }) {

--- a/app/renderer/screens/template-editor/page.tsx
+++ b/app/renderer/screens/template-editor/page.tsx
@@ -15,12 +15,20 @@ import { buildRenderScene } from '../../features/canvas/build-render-scene';
 import { SceneStage } from '../../features/canvas/scene-stage';
 import { StagePanel } from '../../features/canvas/stage-panel';
 import { SplitPanel } from '../../features/workbench/split-panel';
+import { useEditorLeftPanelNav } from '../../features/workbench/use-editor-left-panel-nav';
+import { EmptyState } from '@renderer/components/display/empty-state';
 
 export function TemplateEditorScreen() {
   const { templates, currentTemplateId, openTemplateEditor, createTemplate, deleteTemplate, duplicateTemplate, requestNameFocus } = useTemplateEditor();
   const { state: inspectorState, handlePushChanges } = useInspectorPanelPushAction();
   const { menuItems, menuState, openMenuFromButton, closeMenu } = useCreateTemplateMenu({ createTemplate });
   const templateMenu = useContextMenuState<Id>();
+
+  useEditorLeftPanelNav({
+    items: templates,
+    currentId: currentTemplateId,
+    activate: (id) => openTemplateEditor(id),
+  });
 
   function handleOpenCreateMenu(event: React.MouseEvent<HTMLButtonElement>) {
     openMenuFromButton(event.currentTarget);
@@ -58,6 +66,12 @@ export function TemplateEditorScreen() {
                     </Panel.SectionAction>
                   </Panel.SectionHeader>
                   <Panel.SectionBody className="overflow-y-auto p-2">
+                    {templates.length === 0 ? (
+                      <EmptyState.Root>
+                        <EmptyState.Title>No templates yet</EmptyState.Title>
+                        <EmptyState.Description>Click the + button to create your first template.</EmptyState.Description>
+                      </EmptyState.Root>
+                    ) : (
                     <div className="grid min-w-0 grid-cols-1 content-start gap-1" role="grid" aria-label="Templates">
                       {templates.map((template, index) => {
                         const scene = buildRenderScene(null, template.elements);
@@ -103,6 +117,7 @@ export function TemplateEditorScreen() {
                         );
                       })}
                     </div>
+                    )}
                   </Panel.SectionBody>
                 </Panel.Section>
               </SplitPanel.Segment>


### PR DESCRIPTION
## Summary
Rolls up the follow-up work after the scroll-area primitive was merged.

- **Thumbnail selection** — drop the white ring and swap to a stronger tinted background so the active tile reads clearly against the dark canvas.
- **Slide spacing** — bump `gap-1` → `gap-3` in the Show list views and the deck editor's slide list so adjacent lyric blocks don't visually bleed together.
- **Empty states** — Edit / Overlay / Templates left panels now show an explicit empty state (no item selected / no overlays / no templates) instead of rendering blank.
- **Media-bin sort** — new drawer-header sort control with Name, Date created, Date modified, Slide count + direction toggle. Persists per user via localStorage. Default: Date modified, newest first.
- **Keyboard nav** — Up/Down arrows navigate (and activate) the left-panel list on all three editor screens. Ignored when an element is selected so the existing element-nudge shortcuts still take precedence.
- **Segment Move Up/Down** — new `movePlaylistEntry` IPC + store action. A segment entry's Move Up/Down now reorders within its segment instead of bleeding into the global deck bin order.
- **Editor auto-scroll** — Deck / Overlay / Template left panels wrap their thumbnail grids in `ScrollArea` and attach `useScrollAreaActiveItem` per tile, so arrow-key navigation pulls the active tile back into view when it leaves the viewport (same UX as the Show page).

## Test plan
- [ ] Deck editor: selecting a slide shows tinted bg, no ring. Adjacent slides visually distinct.
- [ ] Open Edit / Overlay / Templates with nothing selected or an empty project — friendly empty state instead of blank.
- [ ] Drawer Deck tab: click the new ArrowDownUp icon, pick a sort + direction, reload, verify persisted.
- [ ] On Edit / Overlay / Templates, arrow Up/Down with no element selected navigates the left list; the active tile auto-scrolls in.
- [ ] In a playlist segment, right-click an entry → Move Up/Down reorders within the segment only (Deck tab order unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)