### PR TITLE
Refactor editor screens and stage playback workflow

### DIFF
--- a/app/core/ipc.ts
+++ b/app/core/ipc.ts
@@ -13,6 +13,8 @@ import type {
   NdiOutputState,
   OverlayCreateInput,
   OverlayUpdateInput,
+  StageCreateInput,
+  StageUpdateInput,
   TemplateCreateInput,
   TemplateUpdateInput,
   SlideCreateInput,
@@ -76,6 +78,10 @@ export interface MainApi {
   detachTemplateFromDeckItem: (itemId: Id) => Promise<SnapshotPatch>;
   syncTemplateToLinkedDeckItems: (templateId: Id) => Promise<SnapshotPatch>;
   applyTemplateToOverlay: (templateId: Id, overlayId: Id) => Promise<SnapshotPatch>;
+  createStage: (input: StageCreateInput) => Promise<SnapshotPatch>;
+  updateStage: (input: StageUpdateInput) => Promise<SnapshotPatch>;
+  deleteStage: (stageId: Id) => Promise<SnapshotPatch>;
+  duplicateStage: (stageId: Id) => Promise<SnapshotPatch>;
   renameLibrary: (id: Id, name: string) => Promise<SnapshotPatch>;
   renamePlaylist: (id: Id, name: string) => Promise<SnapshotPatch>;
   renamePresentation: (id: Id, title: string) => Promise<SnapshotPatch>;
@@ -90,7 +96,7 @@ export interface MainApi {
   getNdiOutputConfigs: () => Promise<NdiOutputConfigMap>;
   updateNdiOutputConfig: (name: NdiOutputName, config: Partial<NdiOutputConfig>) => Promise<NdiOutputConfigMap>;
   getNdiDiagnostics: () => Promise<NdiDiagnostics>;
-  sendNdiFrame: (buffer: ArrayBuffer, width: number, height: number) => void;
+  sendNdiFrame: (name: NdiOutputName, buffer: ArrayBuffer, width: number, height: number) => void;
   onNdiOutputStateChanged: (callback: (state: NdiOutputState) => void) => () => void;
   getAudioCoverArt: (src: string) => Promise<string | null>;
   onNdiDiagnosticsChanged: (callback: (diagnostics: NdiDiagnostics) => void) => () => void;
@@ -154,6 +160,10 @@ export const IPC = {
   detachTemplateFromDeckItem: 'cast:detachTemplateFromDeckItem',
   syncTemplateToLinkedDeckItems: 'cast:syncTemplateToLinkedDeckItems',
   applyTemplateToOverlay: 'cast:applyTemplateToOverlay',
+  createStage: 'cast:createStage',
+  updateStage: 'cast:updateStage',
+  deleteStage: 'cast:deleteStage',
+  duplicateStage: 'cast:duplicateStage',
   renameLibrary: 'cast:renameLibrary',
   renamePlaylist: 'cast:renamePlaylist',
   renamePresentation: 'cast:renamePresentation',

--- a/app/core/ndi.ts
+++ b/app/core/ndi.ts
@@ -18,9 +18,16 @@ export const NDI_OUTPUT_DEFINITIONS: Record<NdiOutputName, NdiOutputDefinition> 
     height: NDI_OUTPUT_HEIGHT,
     withAlpha: false,
   },
+  stage: {
+    output: 'stage',
+    senderName: 'Recast - Stage',
+    width: NDI_OUTPUT_WIDTH,
+    height: NDI_OUTPUT_HEIGHT,
+    withAlpha: false,
+  },
 };
 
-export const NDI_OUTPUT_ORDER: NdiOutputName[] = ['audience'];
+export const NDI_OUTPUT_ORDER: NdiOutputName[] = ['audience', 'stage'];
 
 export function createDefaultNdiOutputConfigs(): NdiOutputConfigMap {
   return {
@@ -28,24 +35,31 @@ export function createDefaultNdiOutputConfigs(): NdiOutputConfigMap {
       senderName: NDI_OUTPUT_DEFINITIONS.audience.senderName,
       withAlpha: NDI_OUTPUT_DEFINITIONS.audience.withAlpha,
     },
+    stage: {
+      senderName: NDI_OUTPUT_DEFINITIONS.stage.senderName,
+      withAlpha: NDI_OUTPUT_DEFINITIONS.stage.withAlpha,
+    },
   };
+}
+
+function normalizeOutputConfigEntry(
+  entry: Partial<NdiOutputConfig> | undefined,
+  fallback: NdiOutputConfig,
+): NdiOutputConfig {
+  const senderName = typeof entry?.senderName === 'string' && entry.senderName.trim()
+    ? entry.senderName.trim()
+    : fallback.senderName;
+  const withAlpha = typeof entry?.withAlpha === 'boolean'
+    ? entry.withAlpha
+    : fallback.withAlpha;
+  return { senderName, withAlpha };
 }
 
 export function normalizeNdiOutputConfigs(configs?: PartialNdiOutputConfigMap | null): NdiOutputConfigMap {
   const defaults = createDefaultNdiOutputConfigs();
-  const audience = configs?.audience;
-  const senderName = typeof audience?.senderName === 'string' && audience.senderName.trim()
-    ? audience.senderName.trim()
-    : defaults.audience.senderName;
-  const withAlpha = typeof audience?.withAlpha === 'boolean'
-    ? audience.withAlpha
-    : defaults.audience.withAlpha;
-
   return {
-    audience: {
-      senderName,
-      withAlpha,
-    },
+    audience: normalizeOutputConfigEntry(configs?.audience, defaults.audience),
+    stage: normalizeOutputConfigEntry(configs?.stage, defaults.stage),
   };
 }
 
@@ -55,6 +69,10 @@ export function migrateLegacyNdiOutputConfigs(configs?: PartialNdiOutputConfigMa
     audience: {
       senderName: normalized.audience.senderName,
       withAlpha: NDI_OUTPUT_DEFINITIONS.audience.withAlpha,
+    },
+    stage: {
+      senderName: normalized.stage.senderName,
+      withAlpha: NDI_OUTPUT_DEFINITIONS.stage.withAlpha,
     },
   };
 }

--- a/app/core/snapshot-patch.ts
+++ b/app/core/snapshot-patch.ts
@@ -1,4 +1,4 @@
-import type { AppSnapshot, Id, LibraryPlaylistBundle, Library, Lyric, MediaAsset, Overlay, Presentation, Slide, SlideElement, Template } from './types';
+import type { AppSnapshot, Id, LibraryPlaylistBundle, Library, Lyric, MediaAsset, Overlay, Presentation, Slide, SlideElement, Stage, Template } from './types';
 
 // ─── Types ──────────────────────────────────────────────────────────
 
@@ -30,6 +30,7 @@ export interface SnapshotPatch {
     mediaAssets?: MediaAsset[];
     overlays?: Overlay[];
     templates?: Template[];
+    stages?: Stage[];
     libraryBundles?: LibraryPlaylistBundle[];
   };
   deletes: {
@@ -41,6 +42,7 @@ export interface SnapshotPatch {
     mediaAssets?: Id[];
     overlays?: Id[];
     templates?: Id[];
+    stages?: Id[];
   };
 }
 
@@ -67,6 +69,7 @@ export function applyPatch(snapshot: AppSnapshot, patch: SnapshotPatch): AppSnap
     mediaAssets: mergeTable(snapshot.mediaAssets, patch.upserts.mediaAssets, patch.deletes.mediaAssets),
     overlays: mergeTable(snapshot.overlays, patch.upserts.overlays, patch.deletes.overlays),
     templates: mergeTable(snapshot.templates, patch.upserts.templates, patch.deletes.templates),
+    stages: mergeTable(snapshot.stages, patch.upserts.stages, patch.deletes.stages),
     libraryBundles: patch.upserts.libraryBundles ?? snapshot.libraryBundles,
   };
   return next;

--- a/app/core/types.ts
+++ b/app/core/types.ts
@@ -218,6 +218,17 @@ export interface Template {
   updatedAt: string;
 }
 
+export interface Stage {
+  id: Id;
+  name: string;
+  width: number;
+  height: number;
+  elements: SlideElement[];
+  order: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface DeckBundleTemplate {
   id: Id;
   name: string;
@@ -328,6 +339,7 @@ export interface AppSnapshot {
   mediaAssets: MediaAsset[];
   overlays: Overlay[];
   templates: Template[];
+  stages: Stage[];
 }
 
 export interface PlaybackState {
@@ -383,10 +395,11 @@ export interface ElementUpdateInput {
   payload?: SlideElementPayload;
 }
 
-export type NdiOutputName = 'audience';
+export type NdiOutputName = 'audience' | 'stage';
 
 export interface NdiOutputState {
   audience: boolean;
+  stage: boolean;
 }
 
 export type NdiSourceStatus = 'idle' | 'live';
@@ -440,6 +453,21 @@ export interface TemplateUpdateInput {
   id: Id;
   name?: string;
   kind?: TemplateKind;
+  width?: number;
+  height?: number;
+  elements?: SlideElement[];
+}
+
+export interface StageCreateInput {
+  name: string;
+  width?: number;
+  height?: number;
+  elements?: SlideElement[];
+}
+
+export interface StageUpdateInput {
+  id: Id;
+  name?: string;
   width?: number;
   height?: number;
   elements?: SlideElement[];

--- a/app/database/store.ts
+++ b/app/database/store.ts
@@ -43,6 +43,9 @@ import type {
   SlideCreateInput,
   SlideNotesUpdateInput,
   SlideOrderUpdateInput,
+  Stage,
+  StageCreateInput,
+  StageUpdateInput,
   Template,
   TemplateCreateInput,
   TemplateKind,
@@ -56,7 +59,8 @@ const DEFAULT_H = 1080;
 const TEMPLATES_SCHEMA_VERSION = 4;
 const DECK_ITEMS_SCHEMA_VERSION = 6;
 const REORDER_SCHEMA_VERSION = 7;
-const LATEST_SCHEMA_VERSION = REORDER_SCHEMA_VERSION;
+const STAGES_SCHEMA_VERSION = 8;
+const LATEST_SCHEMA_VERSION = STAGES_SCHEMA_VERSION;
 const GLOBAL_SCHEMA_VERSION = 3;
 const LEGACY_SCHEMA_VERSION = 2;
 
@@ -226,6 +230,11 @@ export class CastRepository {
     if (this.getUserVersion() < REORDER_SCHEMA_VERSION) {
       this.ensureReorderColumns();
       this.setUserVersion(REORDER_SCHEMA_VERSION);
+    }
+
+    if (this.getUserVersion() < STAGES_SCHEMA_VERSION) {
+      this.ensureStagesSchema();
+      this.setUserVersion(STAGES_SCHEMA_VERSION);
     }
   }
 
@@ -420,6 +429,17 @@ export class CastRepository {
         updated_at TEXT NOT NULL
       );
 
+      CREATE TABLE IF NOT EXISTS stages (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        width INTEGER NOT NULL,
+        height INTEGER NOT NULL,
+        order_index INTEGER NOT NULL DEFAULT 0,
+        elements_json TEXT NOT NULL DEFAULT '[]',
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+
       CREATE INDEX IF NOT EXISTS idx_presentations_library_id ON presentations(library_id);
       CREATE INDEX IF NOT EXISTS idx_slides_presentation_id ON slides(presentation_id);
       CREATE INDEX IF NOT EXISTS idx_slide_elements_slide_id ON slide_elements(slide_id);
@@ -429,6 +449,7 @@ export class CastRepository {
       CREATE INDEX IF NOT EXISTS idx_media_assets_library_id ON media_assets(library_id);
       CREATE INDEX IF NOT EXISTS idx_overlays_library_id ON overlays(library_id);
       CREATE INDEX IF NOT EXISTS idx_templates_order_index ON templates(order_index);
+      CREATE INDEX IF NOT EXISTS idx_stages_order_index ON stages(order_index);
     `);
   }
 
@@ -611,6 +632,22 @@ export class CastRepository {
       );
     `);
     this.db.exec('CREATE INDEX IF NOT EXISTS idx_templates_order_index ON templates(order_index)');
+  }
+
+  private ensureStagesSchema(): void {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS stages (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        width INTEGER NOT NULL,
+        height INTEGER NOT NULL,
+        order_index INTEGER NOT NULL DEFAULT 0,
+        elements_json TEXT NOT NULL DEFAULT '[]',
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+    `);
+    this.db.exec('CREATE INDEX IF NOT EXISTS idx_stages_order_index ON stages(order_index)');
   }
 
   private ensurePresentationTemplateSchema(): void {
@@ -1123,6 +1160,7 @@ export class CastRepository {
       mediaAssets: this.getMediaAssets(),
       overlays: this.getOverlays(),
       templates: this.getTemplates(),
+      stages: this.getStages(),
     };
   }
 
@@ -1145,6 +1183,7 @@ export class CastRepository {
         DELETE FROM media_assets;
         DELETE FROM overlays;
         DELETE FROM templates;
+        DELETE FROM stages;
         DELETE FROM libraries;
       `);
 
@@ -1324,6 +1363,23 @@ export class CastRepository {
           JSON.stringify(overlay.animation),
           overlay.createdAt,
           overlay.updatedAt,
+        );
+      }
+
+      const insertStage = this.db.prepare(
+        `INSERT INTO stages (id, name, width, height, order_index, elements_json, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+      );
+      for (const stage of snapshot.stages) {
+        insertStage.run(
+          stage.id,
+          stage.name,
+          stage.width,
+          stage.height,
+          stage.order,
+          JSON.stringify(stage.elements),
+          stage.createdAt,
+          stage.updatedAt,
         );
       }
     });
@@ -3055,6 +3111,114 @@ export class CastRepository {
     return this.buildPatch({ deletedOverlayIds: [overlayId] });
   }
 
+  // ─── Stages ───────────────────────────────────────────────────────
+  // A Stage is a named container of SlideElement[] that maps to its own NDI
+  // sender. Schema mirrors templates (no kind, no template-application links).
+
+  createStage(input: StageCreateInput): SnapshotPatch {
+    const now = nowIso();
+    const stageId = createId();
+    const elements = input.elements ?? [];
+    const width = input.width ?? 1920;
+    const height = input.height ?? 1080;
+    const nextOrderRow = this.db
+      .prepare('SELECT COALESCE(MAX(order_index), -1) + 1 AS next_order FROM stages')
+      .get() as { next_order: number };
+
+    this.db
+      .prepare(
+        `INSERT INTO stages (id, name, width, height, order_index, elements_json, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .run(
+        stageId,
+        input.name,
+        width,
+        height,
+        nextOrderRow.next_order,
+        JSON.stringify(elements),
+        now,
+        now,
+      );
+
+    return this.buildPatch({ upsertStageIds: [stageId] });
+  }
+
+  updateStage(input: StageUpdateInput): SnapshotPatch {
+    const existing = this.db
+      .prepare('SELECT id, name, width, height, order_index, elements_json FROM stages WHERE id = ?')
+      .get(input.id) as
+      | {
+        id: string;
+        name: string;
+        width: number;
+        height: number;
+        order_index: number;
+        elements_json: string;
+      }
+      | undefined;
+
+    if (!existing) return this.buildPatch({});
+
+    const nextElements = input.elements ?? parseJson<SlideElement[]>(existing.elements_json);
+
+    this.db
+      .prepare(
+        `UPDATE stages
+         SET name = ?, width = ?, height = ?, elements_json = ?, updated_at = ?
+         WHERE id = ?`
+      )
+      .run(
+        input.name ?? existing.name,
+        input.width ?? existing.width,
+        input.height ?? existing.height,
+        JSON.stringify(nextElements),
+        nowIso(),
+        input.id,
+      );
+
+    return this.buildPatch({ upsertStageIds: [input.id] });
+  }
+
+  deleteStage(stageId: Id): SnapshotPatch {
+    this.db.prepare('DELETE FROM stages WHERE id = ?').run(stageId);
+    return this.buildPatch({ deletedStageIds: [stageId] });
+  }
+
+  duplicateStage(stageId: Id): SnapshotPatch {
+    const existing = this.db
+      .prepare('SELECT id, name, width, height, elements_json FROM stages WHERE id = ?')
+      .get(stageId) as
+      | { id: string; name: string; width: number; height: number; elements_json: string }
+      | undefined;
+
+    if (!existing) return this.buildPatch({});
+
+    const now = nowIso();
+    const newId = createId();
+    const nextOrderRow = this.db
+      .prepare('SELECT COALESCE(MAX(order_index), -1) + 1 AS next_order FROM stages')
+      .get() as { next_order: number };
+
+    this.db
+      .prepare(
+        `INSERT INTO stages (id, name, width, height, order_index, elements_json, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .run(
+        newId,
+        `${existing.name} copy`,
+        existing.width,
+        existing.height,
+        nextOrderRow.next_order,
+        existing.elements_json,
+        now,
+        now,
+      );
+
+    return this.buildPatch({ upsertStageIds: [newId] });
+  }
+
   private newLyricsTextPayload() {
     return {
       text: 'Verse line one\nVerse line two',
@@ -3263,6 +3427,7 @@ export class CastRepository {
     upsertMediaAssetIds?: Id[];
     upsertOverlayIds?: Id[];
     upsertTemplateIds?: Id[];
+    upsertStageIds?: Id[];
     deletedLibraryIds?: Id[];
     deletedPresentationIds?: Id[];
     deletedLyricIds?: Id[];
@@ -3271,6 +3436,7 @@ export class CastRepository {
     deletedMediaAssetIds?: Id[];
     deletedOverlayIds?: Id[];
     deletedTemplateIds?: Id[];
+    deletedStageIds?: Id[];
     replaceLibraryBundles?: boolean;
   }): SnapshotPatch {
     const patch: SnapshotPatch = {
@@ -3302,6 +3468,9 @@ export class CastRepository {
     if (spec.upsertTemplateIds && spec.upsertTemplateIds.length > 0) {
       patch.upserts.templates = this.getTemplatesByIds(spec.upsertTemplateIds);
     }
+    if (spec.upsertStageIds && spec.upsertStageIds.length > 0) {
+      patch.upserts.stages = this.getStagesByIds(spec.upsertStageIds);
+    }
     if (spec.deletedLibraryIds && spec.deletedLibraryIds.length > 0) {
       patch.deletes.libraries = [...spec.deletedLibraryIds];
     }
@@ -3325,6 +3494,9 @@ export class CastRepository {
     }
     if (spec.deletedTemplateIds && spec.deletedTemplateIds.length > 0) {
       patch.deletes.templates = [...spec.deletedTemplateIds];
+    }
+    if (spec.deletedStageIds && spec.deletedStageIds.length > 0) {
+      patch.deletes.stages = [...spec.deletedStageIds];
     }
     if (spec.replaceLibraryBundles) {
       patch.upserts.libraryBundles = this.buildLibraryBundles();
@@ -4190,6 +4362,69 @@ export class CastRepository {
       id: row.id,
       name: row.name,
       kind: this.normalizeTemplateKind(row.kind),
+      width: row.width,
+      height: row.height,
+      order: row.order_index,
+      elements: parseJson<SlideElement[]>(row.elements_json),
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    }));
+  }
+
+  private getStages(): Stage[] {
+    const rows = this.db
+      .prepare(
+        `SELECT id, name, width, height, order_index, elements_json, created_at, updated_at
+         FROM stages
+         ORDER BY order_index ASC, created_at ASC`
+      )
+      .all() as Array<{
+      id: string;
+      name: string;
+      width: number;
+      height: number;
+      order_index: number;
+      elements_json: string;
+      created_at: string;
+      updated_at: string;
+    }>;
+
+    return rows.map((row) => ({
+      id: row.id,
+      name: row.name,
+      width: row.width,
+      height: row.height,
+      order: row.order_index,
+      elements: parseJson<SlideElement[]>(row.elements_json),
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    }));
+  }
+
+  private getStagesByIds(ids: Id[]): Stage[] {
+    if (ids.length === 0) return [];
+    const placeholders = ids.map(() => '?').join(',');
+    const rows = this.db
+      .prepare(
+        `SELECT id, name, width, height, order_index, elements_json, created_at, updated_at
+         FROM stages
+         WHERE id IN (${placeholders})
+         ORDER BY order_index ASC, created_at ASC`
+      )
+      .all(...ids) as Array<{
+      id: string;
+      name: string;
+      width: number;
+      height: number;
+      order_index: number;
+      elements_json: string;
+      created_at: string;
+      updated_at: string;
+    }>;
+
+    return rows.map((row) => ({
+      id: row.id,
+      name: row.name,
       width: row.width,
       height: row.height,
       order: row.order_index,

--- a/app/e2e/workspace-smoke.spec.ts
+++ b/app/e2e/workspace-smoke.spec.ts
@@ -20,6 +20,7 @@ function buildEmptySnapshot(): AppSnapshot {
     mediaAssets: [],
     overlays: [],
     templates: [],
+    stages: [],
   };
 }
 
@@ -37,7 +38,7 @@ function buildNdiDiagnostics(outputState: NdiOutputState, outputConfigs: NdiOutp
 
 async function installCastApiMock(page: Page): Promise<void> {
   const ndiOutputConfigs = createDefaultNdiOutputConfigs();
-  const ndiOutputState = { audience: false };
+  const ndiOutputState = { audience: false, stage: false };
   const payload: CastApiMockPayload = {
     snapshot: buildEmptySnapshot(),
     ndiDiagnostics: buildNdiDiagnostics(ndiOutputState, ndiOutputConfigs),
@@ -153,4 +154,31 @@ test('workbench renders current toolbar labels and panel toggles', async ({ page
   await expect(toolbar.getByRole('button', { name: 'Left' })).toBeVisible();
   await expect(toolbar.getByRole('button', { name: 'Right' })).toBeVisible();
   await expect(toolbar.getByRole('button', { name: 'Bottom' })).toHaveCount(0);
+});
+
+test('editor add menus only expose actions for their own editor type', async ({ page }) => {
+  await installCastApiMock(page);
+  await page.goto('/');
+  const toolbar = page.locator('[data-ui-region="app-toolbar"]');
+
+  await toolbar.getByRole('button', { name: 'Overlay' }).click();
+  await page.getByLabel('Add').click();
+  await expect(page.getByRole('menuitem', { name: 'New overlay' })).toBeVisible();
+  await expect(page.getByRole('menuitem', { name: 'New lyric' })).toHaveCount(0);
+  await expect(page.getByRole('menuitem', { name: 'New presentation' })).toHaveCount(0);
+  await page.keyboard.press('Escape');
+
+  await toolbar.getByRole('button', { name: 'Templates' }).click();
+  await page.getByLabel('Add').click();
+  await expect(page.getByRole('menuitem', { name: 'New presentation template' })).toBeVisible();
+  await expect(page.getByRole('menuitem', { name: 'New lyric template' })).toBeVisible();
+  await expect(page.getByRole('menuitem', { name: 'New lyric' })).toHaveCount(0);
+  await expect(page.getByRole('menuitem', { name: 'New presentation' })).toHaveCount(0);
+  await page.keyboard.press('Escape');
+
+  await toolbar.getByRole('button', { name: 'Stage' }).click();
+  await page.getByLabel('Add').click();
+  await expect(page.getByRole('menuitem', { name: 'New stage' })).toBeVisible();
+  await expect(page.getByRole('menuitem', { name: 'New lyric' })).toHaveCount(0);
+  await expect(page.getByRole('menuitem', { name: 'New presentation' })).toHaveCount(0);
 });

--- a/app/main/ipc.ts
+++ b/app/main/ipc.ts
@@ -13,6 +13,8 @@ import type {
   NdiOutputName,
   OverlayCreateInput,
   OverlayUpdateInput,
+  StageCreateInput,
+  StageUpdateInput,
   TemplateCreateInput,
   TemplateUpdateInput,
   SlideCreateInput,
@@ -207,6 +209,10 @@ export const registerIpcHandlers = (
   safeHandle(IPC.applyTemplateToOverlay, (_event, templateId: Id, overlayId: Id) =>
     repo.applyTemplateToOverlay(templateId, overlayId)
   );
+  safeHandle(IPC.createStage, (_event, input: StageCreateInput) => repo.createStage(input));
+  safeHandle(IPC.updateStage, (_event, input: StageUpdateInput) => repo.updateStage(input));
+  safeHandle(IPC.deleteStage, (_event, stageId: Id) => repo.deleteStage(stageId));
+  safeHandle(IPC.duplicateStage, (_event, stageId: Id) => repo.duplicateStage(stageId));
   safeHandle(IPC.renameLibrary, (_event, id: Id, name: string) => repo.renameLibrary(id, name));
   safeHandle(IPC.renamePlaylist, (_event, id: Id, name: string) => repo.renamePlaylist(id, name));
   safeHandle(IPC.renamePresentation, (_event, id: Id, title: string) => repo.renamePresentation(id, title));
@@ -225,7 +231,7 @@ export const registerIpcHandlers = (
     return ndiService.updateOutputConfig(name, config);
   });
   safeHandle(IPC.getNdiDiagnostics, (): NdiDiagnostics => ndiService.getDiagnostics());
-  ipcMain.on(IPC.sendNdiFrame, (_event, buffer: ArrayBuffer, width: number, height: number) => {
-    ndiService.receiveFrame(new Uint8Array(buffer), width, height);
+  ipcMain.on(IPC.sendNdiFrame, (_event, name: NdiOutputName, buffer: ArrayBuffer, width: number, height: number) => {
+    ndiService.receiveFrame(name, new Uint8Array(buffer), width, height);
   });
 };

--- a/app/main/ndi/ndi-service.ts
+++ b/app/main/ndi/ndi-service.ts
@@ -1,4 +1,4 @@
-import { NDI_OUTPUT_HEIGHT, NDI_OUTPUT_WIDTH } from '@core/ndi';
+import { NDI_OUTPUT_HEIGHT, NDI_OUTPUT_WIDTH, NDI_OUTPUT_ORDER } from '@core/ndi';
 import type {
   NdiActiveSenderDiagnostics,
   NdiDiagnostics,
@@ -22,21 +22,26 @@ interface NdiServiceOptions {
   moduleLoader?: () => NdiNativeModule;
 }
 
+interface SenderState {
+  diagnostics: NdiActiveSenderDiagnostics;
+  lastFrame: Uint8Array | null;
+  lastFrameWidth: number;
+  lastFrameHeight: number;
+  lastFrameReceivedAt: number;
+}
+
 export class NdiService {
   private module: NdiNativeModule | null = null;
   private runtimeLoaded = false;
   private runtimePath: string | null = null;
-  private outputState: NdiOutputState = { audience: false };
+  private outputState: NdiOutputState = { audience: false, stage: false };
   private outputConfigs: NdiOutputConfigMap;
   private onOutputConfigsChanged: (configs: NdiOutputConfigMap) => void;
   private moduleLoader: () => NdiNativeModule;
-  private activeSender: NdiActiveSenderDiagnostics | null = null;
+  // One sender per NdiOutputName so Preview and Stage can run concurrently.
+  private senders: Map<NdiOutputName, SenderState> = new Map();
   private sourceStatus: NdiSourceStatus = 'idle';
   private lastError: string | null = null;
-  private lastFrame: Uint8Array | null = null;
-  private lastFrameWidth = 0;
-  private lastFrameHeight = 0;
-  private lastFrameReceivedAt = 0;
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
   private destroyed = false;
 
@@ -65,9 +70,10 @@ export class NdiService {
       this.startHeartbeat();
     } else {
       this.destroySenderForOutput(name);
-      this.stopHeartbeat();
-      this.sourceStatus = 'idle';
-      this.lastFrame = null;
+      if (this.allOutputsDisabled()) {
+        this.stopHeartbeat();
+        this.sourceStatus = 'idle';
+      }
     }
 
     this.emitStateChange();
@@ -90,21 +96,25 @@ export class NdiService {
     return this.getOutputConfigs();
   }
 
-  receiveFrame(rgba: Uint8Array, width: number, height: number): void {
+  // Per-sender frame ingest. Each NdiFrameCapture instance in the renderer
+  // tags its frames with the output name; we route the frame only to that
+  // sender so Preview and Stage can show different content concurrently.
+  receiveFrame(name: NdiOutputName, rgba: Uint8Array, width: number, height: number): void {
     if (this.destroyed) return;
+    if (!this.outputState[name]) return;
 
-    if (!this.lastFrame || this.lastFrame.length !== rgba.length) {
-      this.lastFrame = new Uint8Array(rgba.length);
-    }
-    this.lastFrame.set(rgba);
-    this.lastFrameWidth = width;
-    this.lastFrameHeight = height;
-    this.lastFrameReceivedAt = Date.now();
+    const sender = this.senders.get(name);
+    if (!sender) return;
 
-    for (const name of Object.keys(this.outputState) as NdiOutputName[]) {
-      if (!this.outputState[name]) continue;
-      this.sendFrame(name, rgba, width, height);
+    if (!sender.lastFrame || sender.lastFrame.length !== rgba.length) {
+      sender.lastFrame = new Uint8Array(rgba.length);
     }
+    sender.lastFrame.set(rgba);
+    sender.lastFrameWidth = width;
+    sender.lastFrameHeight = height;
+    sender.lastFrameReceivedAt = Date.now();
+
+    this.sendFrame(name, rgba, width, height);
   }
 
   setSourceStatus(status: NdiSourceStatus): void {
@@ -114,12 +124,16 @@ export class NdiService {
   }
 
   getDiagnostics(): NdiDiagnostics {
+    // Diagnostics report on the audience sender as the primary surface, since
+    // most consumers (status bar, output settings) are scoped to that output.
+    // Per-sender diagnostics can land alongside the per-sender settings UI.
+    const audienceSender = this.senders.get('audience');
     return {
       outputState: this.getOutputState(),
       outputConfig: { ...this.outputConfigs.audience },
       runtimeLoaded: this.runtimeLoaded,
       runtimePath: this.runtimePath,
-      activeSender: this.activeSender ? { ...this.activeSender } : null,
+      activeSender: audienceSender ? { ...audienceSender.diagnostics } : null,
       sourceStatus: this.sourceStatus,
       lastError: this.lastError,
     };
@@ -145,16 +159,21 @@ export class NdiService {
     this.stopHeartbeat();
 
     try {
-      // destroySender internally sends a black frame, flushes, and waits
-      // for network delivery before tearing down the NDI sender.
+      // destroySender() with no name tears down everything cleanly.
       this.module?.destroySender();
     } catch (error) {
       console.error('[NdiService] Error during destroy:', error);
     }
 
-    this.activeSender = null;
-    this.lastFrame = null;
+    this.senders.clear();
     this.module = null;
+  }
+
+  private allOutputsDisabled(): boolean {
+    for (const name of NDI_OUTPUT_ORDER) {
+      if (this.outputState[name]) return false;
+    }
+    return true;
   }
 
   private loadModuleIfNeeded(): boolean {
@@ -178,6 +197,7 @@ export class NdiService {
 
   private ensureSender(name: NdiOutputName): void {
     if (!this.loadModuleIfNeeded()) return;
+    if (this.senders.has(name)) return;
 
     const config = this.outputConfigs[name];
     const width = NDI_OUTPUT_WIDTH;
@@ -190,41 +210,47 @@ export class NdiService {
         height,
         withAlpha: config.withAlpha,
       });
-      this.activeSender = {
-        senderName: config.senderName,
-        width,
-        height,
-        withAlpha: config.withAlpha,
-      };
+      this.senders.set(name, {
+        diagnostics: {
+          senderName: config.senderName,
+          width,
+          height,
+          withAlpha: config.withAlpha,
+        },
+        lastFrame: null,
+        lastFrameWidth: 0,
+        lastFrameHeight: 0,
+        lastFrameReceivedAt: 0,
+      });
       this.lastError = null;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       console.error('[NdiService] Failed to initialize sender:', message);
       this.lastError = message;
-      this.activeSender = null;
     }
   }
 
   private destroySenderForOutput(name: NdiOutputName): void {
-    if (!this.module || !this.activeSender) return;
+    if (!this.module) return;
+    const sender = this.senders.get(name);
+    if (!sender) return;
 
     try {
-      this.module.destroySender(this.outputConfigs[name].senderName);
+      this.module.destroySender(sender.diagnostics.senderName);
     } catch (error) {
       console.error('[NdiService] Error destroying sender:', error);
     }
 
-    this.activeSender = null;
+    this.senders.delete(name);
   }
 
   private sendFrame(name: NdiOutputName, rgba: Uint8Array, width: number, height: number): void {
-    if (!this.module || !this.activeSender) return;
-
-    const config = this.outputConfigs[name];
-    if (this.activeSender.senderName !== config.senderName) return;
+    if (!this.module) return;
+    const sender = this.senders.get(name);
+    if (!sender) return;
 
     try {
-      this.module.sendRgbaFrame(config.senderName, rgba, width, height);
+      this.module.sendRgbaFrame(sender.diagnostics.senderName, rgba, width, height);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       console.error('[NdiService] Frame send failed:', message);
@@ -239,11 +265,11 @@ export class NdiService {
       if (this.destroyed) return;
       const now = Date.now();
 
-      for (const name of Object.keys(this.outputState) as NdiOutputName[]) {
+      for (const [name, sender] of this.senders) {
         if (!this.outputState[name]) continue;
-        if (now - this.lastFrameReceivedAt <= HEARTBEAT_STALL_THRESHOLD_MS) continue;
-        if (this.lastFrame) {
-          this.sendFrame(name, this.lastFrame, this.lastFrameWidth, this.lastFrameHeight);
+        if (now - sender.lastFrameReceivedAt <= HEARTBEAT_STALL_THRESHOLD_MS) continue;
+        if (sender.lastFrame) {
+          this.sendFrame(name, sender.lastFrame, sender.lastFrameWidth, sender.lastFrameHeight);
         }
       }
     }, HEARTBEAT_INTERVAL_MS);

--- a/app/main/preload.ts
+++ b/app/main/preload.ts
@@ -15,6 +15,8 @@ import type {
   NdiOutputState,
   OverlayCreateInput,
   OverlayUpdateInput,
+  StageCreateInput,
+  StageUpdateInput,
   TemplateCreateInput,
   TemplateUpdateInput,
   SlideCreateInput,
@@ -87,6 +89,10 @@ const api = {
     ipcRenderer.invoke(IPC.syncTemplateToLinkedDeckItems, templateId),
   applyTemplateToOverlay: (templateId: Id, overlayId: Id) =>
     ipcRenderer.invoke(IPC.applyTemplateToOverlay, templateId, overlayId),
+  createStage: (input: StageCreateInput) => ipcRenderer.invoke(IPC.createStage, input),
+  updateStage: (input: StageUpdateInput) => ipcRenderer.invoke(IPC.updateStage, input),
+  deleteStage: (stageId: Id) => ipcRenderer.invoke(IPC.deleteStage, stageId),
+  duplicateStage: (stageId: Id) => ipcRenderer.invoke(IPC.duplicateStage, stageId),
   renameLibrary: (id: Id, name: string) => ipcRenderer.invoke(IPC.renameLibrary, id, name),
   renamePlaylist: (id: Id, name: string) => ipcRenderer.invoke(IPC.renamePlaylist, id, name),
   renamePresentation: (id: Id, title: string) => ipcRenderer.invoke(IPC.renamePresentation, id, title),
@@ -103,8 +109,8 @@ const api = {
   updateNdiOutputConfig: (name: NdiOutputName, config: Partial<NdiOutputConfig>) =>
     ipcRenderer.invoke(IPC.updateNdiOutputConfig, name, config) as Promise<NdiOutputConfigMap>,
   getNdiDiagnostics: () => ipcRenderer.invoke(IPC.getNdiDiagnostics) as Promise<NdiDiagnostics>,
-  sendNdiFrame: (buffer: ArrayBuffer, width: number, height: number) => {
-    ipcRenderer.send(IPC.sendNdiFrame, buffer, width, height);
+  sendNdiFrame: (name: NdiOutputName, buffer: ArrayBuffer, width: number, height: number) => {
+    ipcRenderer.send(IPC.sendNdiFrame, name, buffer, width, height);
   },
   onNdiOutputStateChanged: (callback: (state: NdiOutputState) => void) => {
     const handler = (_event: IpcRendererEvent, state: NdiOutputState) => callback(state);

--- a/app/renderer/App.tsx
+++ b/app/renderer/App.tsx
@@ -11,7 +11,7 @@ import { CommandPaletteProvider } from './features/command-palette/command-palet
 import { BundleDropImport } from './features/deck/bundle-drop-import';
 import { CreateDeckItemProvider } from './features/deck/create-deck-item';
 import { LyricEditorProvider } from './features/deck/lyric-editor';
-import { NdiFrameCapture } from './features/playback/ndi-frame-capture';
+import { NdiOutputs } from './features/playback/ndi-outputs';
 import { ErrorBoundary } from './components/feedback/error-boundary';
 import { AppToolbar } from './features/workbench/app-toolbar';
 import { SplitPanel } from './features/workbench/split-panel';
@@ -32,7 +32,7 @@ export function App() {
                     <CreateDeckItemProvider>
                       <CanvasProvider>
                         <CommandPaletteProvider>
-                          <NdiFrameCapture />
+                          <NdiOutputs />
                           <SplitPanel>
                             <AppLayoutContent />
                           </SplitPanel>

--- a/app/renderer/components/controls/button-group.tsx
+++ b/app/renderer/components/controls/button-group.tsx
@@ -1,0 +1,125 @@
+import { type ButtonHTMLAttributes, type HTMLAttributes, type ReactNode } from 'react';
+import { cn } from '@renderer/utils/cn';
+import { cv } from '@renderer/utils/cv';
+
+// Floating-pill button group used for in-context tool clusters (e.g. the
+// add-text / add-shape / add-media toolbar that hovers above the canvas).
+// Distinct from `IconGroup` which renders chunky, connected segments — this
+// one keeps each button visually independent inside one rounded chrome.
+//
+// `Item` and `Icon` render as `<div>` by default. Set `native` to render an
+// actual `<button>` — useful when you need form-element semantics (keyboard
+// activation, `disabled`, submit/reset types). The default `<div>` form is
+// handy when the cluster wraps non-button content (links, custom triggers).
+
+const buttonGroupRootStyles = cv({
+  base: 'flex items-center gap-0.5 rounded-lg border border-primary bg-tertiary/90 p-1 shadow-lg backdrop-blur-sm',
+  variants: {
+    fill: {
+      true: 'w-full',
+      false: 'w-fit',
+    },
+  },
+  defaultVariants: {
+    fill: false,
+  },
+});
+
+const buttonGroupItemStyles = cv({
+  base: 'flex cursor-pointer items-center justify-center rounded-sm bg-transparent text-secondary transition-colors hover:bg-quaternary hover:text-primary disabled:pointer-events-none disabled:opacity-50',
+  variants: {
+    active: {
+      true: 'bg-quaternary text-primary',
+      false: '',
+    },
+    size: {
+      icon: 'p-1.5 [&>svg]:size-[18px]',
+      label: 'px-2.5 py-1.5 text-sm',
+    },
+    disabled: {
+      true: 'pointer-events-none opacity-50',
+      false: '',
+    },
+  },
+  defaultVariants: {
+    active: false,
+    size: 'label',
+    disabled: false,
+  },
+});
+
+interface ButtonGroupRootProps extends Omit<HTMLAttributes<HTMLDivElement>, 'children'> {
+  children: ReactNode;
+  fill?: boolean;
+  className?: string;
+}
+
+function Root({ children, className, fill, ...rest }: ButtonGroupRootProps) {
+  return (
+    <div {...rest} className={cn(buttonGroupRootStyles({ fill }), className)}>
+      {children}
+    </div>
+  );
+}
+
+interface ButtonGroupItemProps extends Omit<HTMLAttributes<HTMLElement>, 'children'> {
+  children: ReactNode;
+  active?: boolean;
+  /** Accessible label that doubles as the hover tooltip. */
+  label?: string;
+  /** Render an actual `<button>` instead of a `<div>`. Defaults to `<div>`. */
+  native?: boolean;
+  /** Forwarded to the underlying `<button>` when `native` is true. */
+  type?: ButtonHTMLAttributes<HTMLButtonElement>['type'];
+  /**
+   * On the native `<button>`, applied via the `disabled` attribute. On the
+   * default `<div>`, gates pointer events and dims via styling, and exposes
+   * `data-disabled=""` so consumers can target it from CSS.
+   */
+  disabled?: boolean;
+}
+
+function renderItem(size: 'icon' | 'label', { children, className, active, label, native, type, disabled, ...rest }: ButtonGroupItemProps) {
+  const styles = cn(buttonGroupItemStyles({ active, size, disabled }), className);
+
+  if (native) {
+    return (
+      <button
+        type={type ?? 'button'}
+        aria-label={label}
+        title={label}
+        disabled={disabled}
+        className={styles}
+        {...(rest as ButtonHTMLAttributes<HTMLButtonElement>)}
+      >
+        {children}
+      </button>
+    );
+  }
+
+  return (
+    <div
+      aria-label={label}
+      title={label}
+      data-disabled={disabled ? '' : undefined}
+      className={styles}
+      {...(rest as HTMLAttributes<HTMLDivElement>)}
+    >
+      {children}
+    </div>
+  );
+}
+
+function Item(props: ButtonGroupItemProps) {
+  return renderItem('label', props);
+}
+
+function Icon(props: ButtonGroupItemProps) {
+  return renderItem('icon', props);
+}
+
+export const ReacstButtonGroup = {
+  Root,
+  Item,
+  Icon,
+};

--- a/app/renderer/contexts/app-context.tsx
+++ b/app/renderer/contexts/app-context.tsx
@@ -31,6 +31,7 @@ interface AppContextValue {
     setThemeMode: (mode: ThemeMode) => void;
     setNdiOutputEnabled: (name: NdiOutputName, enabled: boolean) => void;
     toggleAudienceOutput: () => void;
+    toggleStageOutput: () => void;
     updateNdiOutputConfig: (name: NdiOutputName, config: Partial<NdiOutputConfig>) => void;
   };
 }
@@ -62,6 +63,7 @@ interface NdiSlice {
   actions: {
     setOutputEnabled: (name: NdiOutputName, enabled: boolean) => void;
     toggleAudienceOutput: () => void;
+    toggleStageOutput: () => void;
     updateOutputConfig: (name: NdiOutputName, config: Partial<NdiOutputConfig>) => void;
   };
 }
@@ -279,7 +281,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
   // ── NDI ──
   const [ndiDiagnostics, setNdiDiagnostics] = useState<NdiDiagnostics | null>(null);
   const [ndiOutputConfigs, setNdiOutputConfigs] = useState<NdiOutputConfigMap>(createDefaultNdiOutputConfigs);
-  const [ndiOutputState, setNdiOutputState] = useState<NdiOutputState>({ audience: false });
+  const [ndiOutputState, setNdiOutputState] = useState<NdiOutputState>({ audience: false, stage: false });
   const ndiOutputStateRef = useRef(ndiOutputState);
   ndiOutputStateRef.current = ndiOutputState;
 
@@ -310,6 +312,10 @@ export function AppProvider({ children }: { children: ReactNode }) {
 
   const toggleAudienceOutput = useCallback(() => {
     setNdiOutputEnabled('audience', !ndiOutputStateRef.current.audience);
+  }, [setNdiOutputEnabled]);
+
+  const toggleStageOutput = useCallback(() => {
+    setNdiOutputEnabled('stage', !ndiOutputStateRef.current.stage);
   }, [setNdiOutputEnabled]);
 
   const updateNdiOutputConfig = useCallback((name: NdiOutputName, config: Partial<NdiOutputConfig>) => {
@@ -343,8 +349,9 @@ export function AppProvider({ children }: { children: ReactNode }) {
     setThemeMode,
     setNdiOutputEnabled,
     toggleAudienceOutput,
+    toggleStageOutput,
     updateNdiOutputConfig,
-  }), [mutate, mutatePatch, undo, redo, runOperation, setThemeMode, setNdiOutputEnabled, toggleAudienceOutput, updateNdiOutputConfig]);
+  }), [mutate, mutatePatch, undo, redo, runOperation, setThemeMode, setNdiOutputEnabled, toggleAudienceOutput, toggleStageOutput, updateNdiOutputConfig]);
 
   const value = useMemo<AppContextValue>(() => ({ state, actions }), [state, actions]);
 
@@ -392,6 +399,7 @@ export function useNdi(): NdiSlice {
     actions: {
       setOutputEnabled: actions.setNdiOutputEnabled,
       toggleAudienceOutput: actions.toggleAudienceOutput,
+      toggleStageOutput: actions.toggleStageOutput,
       updateOutputConfig: actions.updateNdiOutputConfig,
     },
   };

--- a/app/renderer/contexts/asset-editor/asset-editor-context.tsx
+++ b/app/renderer/contexts/asset-editor/asset-editor-context.tsx
@@ -1,6 +1,6 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { createDefaultTemplateElements } from '@core/templates';
-import type { Id, Overlay, OverlayCreateInput, OverlayUpdateInput, SlideElement, Template, TemplateKind } from '@core/types';
+import type { Id, Overlay, OverlayCreateInput, OverlayUpdateInput, SlideElement, Stage, Template, TemplateKind } from '@core/types';
 import { cloneElements, slideElementsSignature } from '../../utils/staged-editor-utils';
 import { getOverlayDefaults } from '../../utils/slides';
 import { createId } from '../../utils/create-id';
@@ -62,10 +62,28 @@ interface DeckEditorValue {
   pushChanges: () => Promise<void>;
 }
 
+interface StageEditorValue {
+  stages: Stage[];
+  currentStageId: Id | null;
+  currentStage: Stage | null;
+  hasPendingChanges: boolean;
+  isPushingChanges: boolean;
+  nameFocusRequest: number;
+  setCurrentStageId: (stageId: Id | null) => void;
+  updateStageDraft: (input: { id: Id; name?: string; elements?: SlideElement[] }) => void;
+  replaceStageElements: (elements: SlideElement[]) => void;
+  createStage: () => Promise<void>;
+  duplicateStage: (stageId: Id) => void;
+  deleteCurrentStage: () => Promise<void>;
+  requestNameFocus: (stageId: Id) => void;
+  pushChanges: () => Promise<void>;
+}
+
 interface AssetEditorContextValue {
   overlay: OverlayEditorValue;
   template: TemplateEditorValue;
   deck: DeckEditorValue;
+  stage: StageEditorValue;
 }
 
 // ─── Context ────────────────────────────────────────────────────────
@@ -80,6 +98,7 @@ export function AssetEditorProvider({ children }: { children: ReactNode }) {
   const {
     overlays: persistedOverlays,
     templates: persistedTemplates,
+    stages: persistedStages,
     slideElementsBySlideId,
   } = useProjectContent();
 
@@ -434,6 +453,171 @@ export function AssetEditorProvider({ children }: { children: ReactNode }) {
     templateStaged.setCurrentItemId, templateNameFocusRequest, templates, updateTemplateDraft,
   ]);
 
+  // ── Stage editor ──
+
+  const stageStaged = useStagedCollection<Stage>({
+    persistedItems: persistedStages,
+    signatureOf: stageSignature,
+    workbenchModeKey: 'stage-editor',
+    currentWorkbenchMode: workbenchMode,
+  });
+
+  const stages = stageStaged.items;
+  const [stageNameFocusRequest, setStageNameFocusRequest] = useState(0);
+
+  const updateStageDraft = useCallback((input: { id: Id; name?: string; elements?: SlideElement[] }) => {
+    stageStaged.setStagedItems((current) => {
+      const source = current ?? persistedStages;
+      return source.map((stage) => (
+        stage.id === input.id
+          ? {
+            ...stage,
+            name: input.name ?? stage.name,
+            elements: input.elements ? cloneElements(input.elements) : stage.elements,
+            updatedAt: new Date().toISOString(),
+          }
+          : stage
+      ));
+    });
+  }, [persistedStages, stageStaged]);
+
+  const replaceStageElements = useCallback((elements: SlideElement[]) => {
+    if (!stageStaged.currentItemId) return;
+    updateStageDraft({ id: stageStaged.currentItemId, elements });
+  }, [stageStaged.currentItemId, updateStageDraft]);
+
+  const createStageAction = useCallback(async () => {
+    const now = new Date().toISOString();
+    const draft: Stage = {
+      id: createId(),
+      name: 'New Stage',
+      width: 1920,
+      height: 1080,
+      order: (stages.at(-1)?.order ?? -1) + 1,
+      elements: [],
+      createdAt: now,
+      updatedAt: now,
+    };
+    stageStaged.setStagedItems((current) => [...(current ?? persistedStages), draft]);
+    stageStaged.setCurrentItemId(draft.id);
+    setStatusText('Created stage');
+  }, [persistedStages, setStatusText, stageStaged, stages]);
+
+  const duplicateStageAction = useCallback((stageId: Id) => {
+    const source = stages.find((stage) => stage.id === stageId);
+    if (!source) return;
+    const now = new Date().toISOString();
+    const duplicate: Stage = {
+      ...cloneStage(source),
+      id: createId(),
+      name: `${source.name} Copy`,
+      order: (stages.at(-1)?.order ?? -1) + 1,
+      createdAt: now,
+      updatedAt: now,
+    };
+    stageStaged.setStagedItems((current) => [...(current ?? persistedStages), duplicate]);
+    stageStaged.setCurrentItemId(duplicate.id);
+    setStatusText('Duplicated stage');
+  }, [persistedStages, setStatusText, stageStaged, stages]);
+
+  const deleteCurrentStage = useCallback(async () => {
+    if (!stageStaged.currentItemId) return;
+    stageStaged.setStagedItems((current) => {
+      const source = current ?? persistedStages;
+      return source.filter((stage) => stage.id !== stageStaged.currentItemId);
+    });
+    setStatusText('Deleted stage');
+  }, [persistedStages, setStatusText, stageStaged]);
+
+  const requestStageNameFocus = useCallback((stageId: Id) => {
+    stageStaged.setCurrentItemId(stageId);
+    setStageNameFocusRequest((v) => v + 1);
+  }, [stageStaged]);
+
+  const pushStageChanges = useCallback(async () => {
+    if (!stageStaged.stagedItems || stageStaged.isPushingChanges) return;
+    const stagedStages = stageStaged.stagedItems;
+    const stagedSig = stagedStages.map(stageSignature).join();
+    const persistedSig = persistedStages.map(stageSignature).join();
+    if (stagedSig === persistedSig) {
+      stageStaged.setStagedItems(null);
+      return;
+    }
+
+    stageStaged.setIsPushingChanges(true);
+    try {
+      let resolvedCurrentStageId = stageStaged.currentItemId;
+      let knownStages = persistedStages;
+      const persistedById = new Map(persistedStages.map((s) => [s.id, s]));
+      const stagedById = new Map(stagedStages.map((s) => [s.id, s]));
+
+      for (const stage of persistedStages) {
+        if (stagedById.has(stage.id)) continue;
+        const next = await mutatePatch(() => window.castApi.deleteStage(stage.id));
+        knownStages = next.stages;
+      }
+      for (const stage of stagedStages) {
+        if (persistedById.has(stage.id)) continue;
+        const previousIds = new Set(knownStages.map((item) => item.id));
+        const next = await mutatePatch(() => window.castApi.createStage({
+          name: stage.name,
+          width: stage.width,
+          height: stage.height,
+          elements: cloneElements(stage.elements),
+        }));
+        knownStages = next.stages;
+        const createdStage = knownStages.find((item) => !previousIds.has(item.id)) ?? null;
+        if (createdStage && resolvedCurrentStageId === stage.id) resolvedCurrentStageId = createdStage.id;
+      }
+      for (const stage of stagedStages) {
+        if (!persistedById.has(stage.id)) continue;
+        const persisted = persistedById.get(stage.id);
+        if (!persisted || stageSignature(stage) === stageSignature(persisted)) continue;
+        const next = await mutatePatch(() => window.castApi.updateStage({
+          id: stage.id,
+          name: stage.name,
+          width: stage.width,
+          height: stage.height,
+          elements: cloneElements(stage.elements),
+        }));
+        knownStages = next.stages;
+      }
+
+      stageStaged.setStagedItems(null);
+      const stillExists = resolvedCurrentStageId ? knownStages.some((s) => s.id === resolvedCurrentStageId) : false;
+      if (!resolvedCurrentStageId || !stillExists) resolvedCurrentStageId = knownStages[0]?.id ?? null;
+      stageStaged.setCurrentItemId(resolvedCurrentStageId);
+      setStatusText('Stage changes pushed');
+    } finally {
+      stageStaged.setIsPushingChanges(false);
+    }
+  }, [stageStaged, mutatePatch, persistedStages, setStatusText]);
+
+  useEffect(() => {
+    stageStaged.registerAutoPush(() => void pushStageChanges());
+  }, [stageStaged, pushStageChanges]);
+
+  const stageValue = useMemo<StageEditorValue>(() => ({
+    stages,
+    currentStageId: stageStaged.currentItemId,
+    currentStage: stageStaged.currentItem,
+    hasPendingChanges: stageStaged.hasPendingChanges,
+    isPushingChanges: stageStaged.isPushingChanges,
+    nameFocusRequest: stageNameFocusRequest,
+    setCurrentStageId: stageStaged.setCurrentItemId,
+    updateStageDraft,
+    replaceStageElements,
+    createStage: createStageAction,
+    duplicateStage: duplicateStageAction,
+    deleteCurrentStage,
+    requestNameFocus: requestStageNameFocus,
+    pushChanges: pushStageChanges,
+  }), [
+    createStageAction, duplicateStageAction, stageStaged.currentItem, stageStaged.currentItemId,
+    deleteCurrentStage, stageStaged.hasPendingChanges, stageStaged.isPushingChanges, stageNameFocusRequest,
+    stages, pushStageChanges, replaceStageElements, stageStaged.setCurrentItemId, requestStageNameFocus, updateStageDraft,
+  ]);
+
   // ── Deck editor ──
 
   const [stagedSlides, setStagedSlides] = useState<Record<Id, SlideElement[]>>({});
@@ -526,8 +710,8 @@ export function AssetEditorProvider({ children }: { children: ReactNode }) {
   // ── Combined value ──
 
   const value = useMemo<AssetEditorContextValue>(
-    () => ({ overlay: overlayValue, template: templateValue, deck: deckValue }),
-    [overlayValue, templateValue, deckValue],
+    () => ({ overlay: overlayValue, template: templateValue, deck: deckValue, stage: stageValue }),
+    [overlayValue, templateValue, deckValue, stageValue],
   );
 
   return <AssetEditorContext.Provider value={value}>{children}</AssetEditorContext.Provider>;
@@ -553,6 +737,10 @@ export function useDeckEditor(): DeckEditorValue {
   return useAssetEditor().deck;
 }
 
+export function useStageEditor(): StageEditorValue {
+  return useAssetEditor().stage;
+}
+
 // ─── Utils ──────────────────────────────────────────────────────────
 
 function toOverlayCreateInput(overlay: Overlay): OverlayCreateInput {
@@ -573,4 +761,12 @@ function templateSignature(template: Template): string {
 
 function cloneTemplate(template: Template): Template {
   return JSON.parse(JSON.stringify(template)) as Template;
+}
+
+function stageSignature(stage: Stage): string {
+  return JSON.stringify({ id: stage.id, name: stage.name, width: stage.width, height: stage.height, elements: stage.elements });
+}
+
+function cloneStage(stage: Stage): Stage {
+  return JSON.parse(JSON.stringify(stage)) as Stage;
 }

--- a/app/renderer/contexts/canvas/canvas-context.tsx
+++ b/app/renderer/contexts/canvas/canvas-context.tsx
@@ -1,12 +1,11 @@
 import { createContext, useContext, useMemo, useState, useCallback, useEffect, useRef, type ReactNode } from 'react';
-import { overlayToLayerElements } from '@core/presentation-layers';
 import { isLyricDeckItem } from '@core/deck-items';
-import type { ElementUpdateInput, Id, MediaAsset, Overlay, OverlayUpdateInput, Slide, SlideElement } from '@core/types';
+import type { ElementUpdateInput, Id, MediaAsset, Overlay, Slide, SlideElement } from '@core/types';
 import { applyVisualPayload, readVisualPayload } from '@core/element-payload';
 import { sortElements } from '../../utils/slides';
 import { useCast } from '../app-context';
 import { useNavigation } from '../navigation-context';
-import { useOverlayEditor, useDeckEditor, useTemplateEditor } from '../asset-editor/asset-editor-context';
+import { useDeckEditor } from '../asset-editor/asset-editor-context';
 import { usePresentationLayers } from '../playback/playback-context';
 import { useSlides } from '../slide-context';
 import { useProjectContent } from '../use-project-content';
@@ -19,6 +18,7 @@ import type { ElementContextValue } from '../../types/element-context.types';
 import { cloneElements } from '../../utils/element-context-utils';
 import { buildLayeredRenderScene, buildRenderScene, buildThumbnailScene } from '../../features/canvas/build-render-scene';
 import type { RenderScene, SceneSourcePolicy, SceneSurface } from '../../features/canvas/scene-types';
+import { useActiveEditorSource } from './use-active-editor-source';
 
 // ─── Types ──────────────────────────────────────────────────────────
 
@@ -57,18 +57,17 @@ export function selectThumbnailElements(policy: SceneSourcePolicy, effectiveElem
 // ─── Provider ───────────────────────────────────────────────────────
 
 export function CanvasProvider({ children }: { children: ReactNode }) {
-  const { mutate, mutatePatch, setStatusText } = useCast();
+  const { mutatePatch, setStatusText } = useCast();
   const { currentDeckItem } = useNavigation();
   const { currentSlide, liveSlide, liveElements, slideElementsById } = useSlides();
   const { slides: projectSlides, slideElementsBySlideId: projectSlideElementsBySlideId } = useProjectContent();
-  const { currentOverlay, updateOverlayDraft } = useOverlayEditor();
   const { getSlideElements, replaceSlideElements } = useDeckEditor();
-  const { currentTemplate, replaceTemplateElements } = useTemplateEditor();
   const { mediaLayerAsset, activeOverlays, contentLayerVisible } = usePresentationLayers();
   const { state: { workbenchMode } } = useWorkbench();
-  const isOverlayEdit = workbenchMode === 'overlay-editor';
-  const isSlideEdit = workbenchMode === 'deck-editor';
-  const isTemplateEdit = workbenchMode === 'template-editor';
+  const activeEditorSource = useActiveEditorSource();
+  const isDeckEdit = activeEditorSource.mode === 'deck-editor';
+  const isOverlayEdit = activeEditorSource.mode === 'overlay-editor';
+  const isTemplateEdit = activeEditorSource.mode === 'template-editor';
 
   // ════════════════════════════════════════════════════════════════════
   // Element editing
@@ -79,18 +78,7 @@ export function CanvasProvider({ children }: { children: ReactNode }) {
   const previousSlideIdRef = useRef<Id | null>(null);
   const previousSlideElementsRef = useRef<SlideElement[]>([]);
 
-  const baseElements = useMemo(() => {
-    if (isOverlayEdit) {
-      if (!currentOverlay) return [];
-      return sortElements(overlayToLayerElements(currentOverlay));
-    }
-    if (isTemplateEdit) {
-      if (!currentTemplate) return [];
-      return sortElements(currentTemplate.elements);
-    }
-    if (!currentSlide) return [];
-    return sortElements(getSlideElements(currentSlide.id));
-  }, [currentOverlay, currentSlide, currentTemplate, getSlideElements, isOverlayEdit, isTemplateEdit]);
+  const baseElements = useMemo(() => sortElements(activeEditorSource.elements), [activeEditorSource.elements]);
 
   const effectiveElements = useMemo(
     () => sortElements(baseElements.map((element) => ({ ...element, ...(draftElements[element.id] ?? {}) }))),
@@ -101,55 +89,55 @@ export function CanvasProvider({ children }: { children: ReactNode }) {
     const previousSlideId = previousSlideIdRef.current;
     const previousSlideElements = previousSlideElementsRef.current;
 
-    if (previousSlideId && (!isSlideEdit || previousSlideId !== currentSlide?.id)) {
+    const currentDeckSlideId = activeEditorSource.mode === 'deck-editor' ? activeEditorSource.meta.slideId : null;
+
+    if (previousSlideId && (!isDeckEdit || previousSlideId !== currentDeckSlideId)) {
       replaceSlideElements(previousSlideId, previousSlideElements);
       setDraftElements((current) => removeDraftPatchesForElements(current, previousSlideElements));
     }
 
-    if (!isSlideEdit) {
+    if (!isDeckEdit) {
       previousSlideIdRef.current = null;
       previousSlideElementsRef.current = [];
       return;
     }
 
-    previousSlideIdRef.current = currentSlide?.id ?? null;
+    previousSlideIdRef.current = currentDeckSlideId;
     previousSlideElementsRef.current = cloneElements(effectiveElements);
-  }, [currentSlide?.id, effectiveElements, isSlideEdit, replaceSlideElements]);
+  }, [activeEditorSource, effectiveElements, isDeckEdit, replaceSlideElements]);
 
   const selection = useElementSelection({ effectiveElements });
 
   useEffect(() => {
     if (!isOverlayEdit) return;
+    const currentOverlay = activeEditorSource.meta.overlay;
     if (!currentOverlay) {
       selection.clearSelection();
       return;
     }
     if (isOverlaySelectionValid(currentOverlay, selection.primarySelectedElementId)) return;
     selection.clearSelection();
-  }, [currentOverlay, isOverlayEdit, selection.clearSelection, selection.primarySelectedElementId]);
-
-  const stageOverlayElementUpdates = useCallback((updates: ElementUpdateInput[]) => {
-    if (!currentOverlay) return;
-    updateOverlayDraft(applyOverlayDraftUpdates(currentOverlay, updates));
-  }, [currentOverlay, updateOverlayDraft]);
+  }, [activeEditorSource, isOverlayEdit, selection.clearSelection, selection.primarySelectedElementId]);
 
   const saveElementUpdate = useCallback(async (input: ElementUpdateInput) => {
-    if (isOverlayEdit) { stageOverlayElementUpdates([input]); return; }
-    if (isTemplateEdit) { if (!currentTemplate) return; replaceTemplateElements(applyElementUpdates(currentTemplate.elements, [input])); return; }
-    if (isSlideEdit) { if (!currentSlide) return; replaceSlideElements(currentSlide.id, applyElementUpdates(getSlideElements(currentSlide.id), [input])); return; }
+    if (activeEditorSource.editable && activeEditorSource.hasSource) {
+      activeEditorSource.replaceElements(applyElementUpdates(activeEditorSource.elements, [input]));
+      return;
+    }
     await mutatePatch(() => window.castApi.updateElement(input));
-  }, [currentSlide, currentTemplate, getSlideElements, isOverlayEdit, isSlideEdit, isTemplateEdit, mutatePatch, replaceSlideElements, replaceTemplateElements, stageOverlayElementUpdates]);
+  }, [activeEditorSource, mutatePatch]);
 
   const saveElementUpdates = useCallback(async (updates: ElementUpdateInput[]) => {
     if (updates.length === 0) return;
-    if (isOverlayEdit) { stageOverlayElementUpdates(updates); return; }
-    if (isTemplateEdit) { if (!currentTemplate) return; replaceTemplateElements(applyElementUpdates(currentTemplate.elements, updates)); return; }
-    if (isSlideEdit) { if (!currentSlide) return; replaceSlideElements(currentSlide.id, applyElementUpdates(getSlideElements(currentSlide.id), updates)); return; }
+    if (activeEditorSource.editable && activeEditorSource.hasSource) {
+      activeEditorSource.replaceElements(applyElementUpdates(activeEditorSource.elements, updates));
+      return;
+    }
     await mutatePatch(() => {
       if (updates.length === 1) return window.castApi.updateElement(updates[0]);
       return window.castApi.updateElementsBatch(updates);
     });
-  }, [currentSlide, currentTemplate, getSlideElements, isOverlayEdit, isSlideEdit, isTemplateEdit, mutatePatch, replaceSlideElements, replaceTemplateElements, stageOverlayElementUpdates]);
+  }, [activeEditorSource, mutatePatch]);
 
   const inspector = useElementInspectorSync({
     selectedElementId: selection.primarySelectedElementId,
@@ -164,7 +152,7 @@ export function CanvasProvider({ children }: { children: ReactNode }) {
     baseElements,
     effectiveElements,
     currentSlide,
-    historyKey: isOverlayEdit ? currentOverlay?.id ?? null : isTemplateEdit ? currentTemplate?.id ?? null : currentSlide?.id ?? null,
+    historyKey: activeEditorSource.historyKey,
     selectedElementIds: selection.selectedElementIds,
     mutatePatch,
     setStatusText,
@@ -172,17 +160,15 @@ export function CanvasProvider({ children }: { children: ReactNode }) {
     setDraftElements,
     setCanvasInteracting,
     saveElementUpdates,
-    replaceElements: isSlideEdit && currentSlide
-      ? async (elements) => { replaceSlideElements(currentSlide.id, elements); }
-      : isTemplateEdit && currentTemplate
-        ? async (elements) => { replaceTemplateElements(elements); }
-        : undefined,
+    replaceElements: activeEditorSource.editable && activeEditorSource.hasSource
+      ? async (elements) => { activeEditorSource.replaceElements(elements); }
+      : undefined,
   });
 
   const deleteSelected = useCallback(async () => {
     const protectedLyricTextIds = new Set(getProtectedLyricTextSelectionIds(
       effectiveElements, selection.selectedElementIds,
-      isTemplateEdit ? currentTemplate?.kind === 'lyrics' : isLyricDeckItem(currentDeckItem),
+      isTemplateEdit ? activeEditorSource.meta.templateKind === 'lyrics' : isDeckEdit && isLyricDeckItem(currentDeckItem),
     ));
     const targetIds = getUnlockedSelectedElementIds(effectiveElements, selection.selectedElementIds)
       .filter((id) => !protectedLyricTextIds.has(id));
@@ -191,15 +177,8 @@ export function CanvasProvider({ children }: { children: ReactNode }) {
       return;
     }
     if (targetIds.length === 0) return;
-    if (isOverlayEdit) {
-      if (!currentOverlay) return;
-      updateOverlayDraft({ id: currentOverlay.id, elements: currentOverlay.elements.filter((el) => !targetIds.includes(el.id)) });
-    } else if (isTemplateEdit) {
-      if (!currentTemplate) return;
-      replaceTemplateElements(currentTemplate.elements.filter((el) => !targetIds.includes(el.id)));
-    } else if (isSlideEdit) {
-      if (!currentSlide) return;
-      replaceSlideElements(currentSlide.id, getSlideElements(currentSlide.id).filter((el) => !targetIds.includes(el.id)));
+    if (activeEditorSource.editable && activeEditorSource.hasSource) {
+      activeEditorSource.replaceElements(activeEditorSource.elements.filter((el) => !targetIds.includes(el.id)));
     } else {
       history.pushHistorySnapshot();
       await mutatePatch(() => targetIds.length === 1 ? window.castApi.deleteElement(targetIds[0]) : window.castApi.deleteElementsBatch(targetIds));
@@ -207,7 +186,7 @@ export function CanvasProvider({ children }: { children: ReactNode }) {
     setStatusText('Deleted selected object(s)');
     selection.selectElements(selection.selectedElementIds.filter((id) => protectedLyricTextIds.has(id)));
     setDraftElements({});
-  }, [currentDeckItem, currentOverlay, currentSlide, currentTemplate, effectiveElements, getSlideElements, history, isOverlayEdit, isSlideEdit, isTemplateEdit, mutatePatch, replaceSlideElements, replaceTemplateElements, selection, setStatusText, updateOverlayDraft]);
+  }, [activeEditorSource, currentDeckItem, effectiveElements, history, isDeckEdit, isTemplateEdit, mutatePatch, selection, setStatusText]);
 
   const toggleElementVisibility = useCallback(async (id: Id, visible: boolean) => {
     const target = effectiveElements.find((el) => el.id === id);
@@ -229,7 +208,7 @@ export function CanvasProvider({ children }: { children: ReactNode }) {
   }, [effectiveElements, inspector, saveElementUpdate, selection.primarySelectedElementId]);
 
   const { createText, createShape, createFromMedia, createOverlay, toggleOverlay, importMedia, deleteMedia, changeMediaSrc } = useElementCommands({
-    currentSlide, currentDeckItem, currentTemplate, mutate, mutatePatch, setStatusText,
+    activeEditorSource, currentDeckItem, mutatePatch, setStatusText,
   });
 
   const elementsValue = useMemo<ElementContextValue>(() => ({
@@ -263,7 +242,7 @@ export function CanvasProvider({ children }: { children: ReactNode }) {
   }), [
     baseElements, createFromMedia, createOverlay, createShape, createText, deleteMedia,
     deleteSelected, draftElements, effectiveElements, history, importMedia, inspector,
-    isOverlayEdit, isSlideEdit, isTemplateEdit, isCanvasInteracting, selection,
+    isOverlayEdit, isTemplateEdit, isCanvasInteracting, selection,
     setDraftElements, toggleElementLock, toggleElementVisibility, toggleOverlay, changeMediaSrc,
   ]);
 
@@ -272,8 +251,8 @@ export function CanvasProvider({ children }: { children: ReactNode }) {
   // ════════════════════════════════════════════════════════════════════
 
   const editScene = useMemo(() => {
-    return buildRenderScene(isOverlayEdit || isTemplateEdit ? null : currentSlide, effectiveElements);
-  }, [currentSlide, effectiveElements, isOverlayEdit, isTemplateEdit]);
+    return buildRenderScene(activeEditorSource.frame, effectiveElements);
+  }, [activeEditorSource.frame, effectiveElements]);
 
   const showScene = useMemo(() => {
     const currentElements = currentSlide ? (slideElementsById.get(currentSlide.id) ?? []) : [];
@@ -436,26 +415,4 @@ function removeDraftPatchesForElements(draftElements: Record<Id, Partial<SlideEl
     changed = true;
   }
   return changed ? nextDrafts : draftElements;
-}
-
-function applyOverlayDraftUpdates(overlay: Overlay, updates: ElementUpdateInput[]): OverlayUpdateInput {
-  if (updates.length === 0) return { id: overlay.id, elements: overlay.elements };
-  if (overlay.elements.length === 0) {
-    const fallbackUpdate = updates.find((update) => update.id === overlay.id);
-    if (!fallbackUpdate) return { id: overlay.id, elements: overlay.elements };
-    return {
-      id: overlay.id,
-      elements: [{
-        id: overlay.id, slideId: overlay.id,
-        type: overlay.type === 'shape' ? 'shape' : overlay.type === 'text' ? 'text' : overlay.type === 'video' ? 'video' : 'image',
-        x: fallbackUpdate.x ?? overlay.x, y: fallbackUpdate.y ?? overlay.y,
-        width: fallbackUpdate.width ?? overlay.width, height: fallbackUpdate.height ?? overlay.height,
-        rotation: fallbackUpdate.rotation ?? 0, opacity: fallbackUpdate.opacity ?? overlay.opacity,
-        zIndex: fallbackUpdate.zIndex ?? overlay.zIndex, layer: fallbackUpdate.layer ?? 'content',
-        payload: fallbackUpdate.payload ?? overlay.payload,
-        createdAt: overlay.createdAt, updatedAt: new Date().toISOString(),
-      }],
-    };
-  }
-  return { id: overlay.id, elements: applyElementUpdates(overlay.elements, updates) };
 }

--- a/app/renderer/contexts/canvas/editor-source.ts
+++ b/app/renderer/contexts/canvas/editor-source.ts
@@ -1,0 +1,61 @@
+import type { DeckItemType, Id, Overlay, Slide, SlideElement, Stage, Template, TemplateKind } from '@core/types';
+import type { WorkbenchMode } from '../../types/ui';
+
+export type EditorWorkbenchMode = 'deck-editor' | 'overlay-editor' | 'template-editor' | 'stage-editor';
+
+export interface EditorSourceFrame {
+  width: number;
+  height: number;
+}
+
+export interface EditorCreateCapabilities {
+  text: boolean;
+  shape: boolean;
+  media: boolean;
+}
+
+interface EditorSourceBase<TMode extends WorkbenchMode, TMeta> {
+  mode: TMode;
+  entityId: Id | null;
+  hasSource: boolean;
+  frame: EditorSourceFrame | Slide | null;
+  elements: SlideElement[];
+  replaceElements: (elements: SlideElement[]) => void;
+  historyKey: string | null;
+  emptyStateLabel: string;
+  editable: boolean;
+  createCapabilities: EditorCreateCapabilities;
+  meta: TMeta;
+}
+
+export interface DeckEditorSource extends EditorSourceBase<'deck-editor', {
+  slide: Slide | null;
+  slideId: Id | null;
+  deckItemType: DeckItemType | null;
+}> {}
+
+export interface OverlayEditorSource extends EditorSourceBase<'overlay-editor', {
+  overlay: Overlay | null;
+}> {}
+
+export interface TemplateEditorSource extends EditorSourceBase<'template-editor', {
+  template: Template | null;
+  templateKind: TemplateKind | null;
+}> {}
+
+export interface StageEditorSource extends EditorSourceBase<'stage-editor', {
+  stage: Stage | null;
+}> {}
+
+export interface InactiveEditorSource extends EditorSourceBase<Exclude<WorkbenchMode, EditorWorkbenchMode>, {}> {}
+
+export type ActiveEditorSource =
+  | DeckEditorSource
+  | OverlayEditorSource
+  | TemplateEditorSource
+  | StageEditorSource
+  | InactiveEditorSource;
+
+export function isEditorWorkbenchMode(mode: WorkbenchMode): mode is EditorWorkbenchMode {
+  return mode === 'deck-editor' || mode === 'overlay-editor' || mode === 'template-editor' || mode === 'stage-editor';
+}

--- a/app/renderer/contexts/canvas/use-active-editor-source.test.tsx
+++ b/app/renderer/contexts/canvas/use-active-editor-source.test.tsx
@@ -1,0 +1,213 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import type { Overlay, Slide, Stage, Template } from '@core/types';
+import { useDeckEditor, useOverlayEditor, useStageEditor, useTemplateEditor } from '@renderer/contexts/asset-editor/asset-editor-context';
+import { useNavigation } from '@renderer/contexts/navigation-context';
+import { useSlides } from '@renderer/contexts/slide-context';
+import { useWorkbench } from '@renderer/contexts/workbench-context';
+import { useActiveEditorSource } from './use-active-editor-source';
+
+vi.mock('@renderer/contexts/navigation-context', () => ({ useNavigation: vi.fn() }));
+vi.mock('@renderer/contexts/slide-context', () => ({ useSlides: vi.fn() }));
+vi.mock('@renderer/contexts/workbench-context', () => ({ useWorkbench: vi.fn() }));
+vi.mock('@renderer/contexts/asset-editor/asset-editor-context', () => ({
+  useDeckEditor: vi.fn(),
+  useOverlayEditor: vi.fn(),
+  useStageEditor: vi.fn(),
+  useTemplateEditor: vi.fn(),
+}));
+
+const useNavigationMock = vi.mocked(useNavigation);
+const useSlidesMock = vi.mocked(useSlides);
+const useWorkbenchMock = vi.mocked(useWorkbench);
+const useDeckEditorMock = vi.mocked(useDeckEditor);
+const useOverlayEditorMock = vi.mocked(useOverlayEditor);
+const useStageEditorMock = vi.mocked(useStageEditor);
+const useTemplateEditorMock = vi.mocked(useTemplateEditor);
+
+function makeSlide(id: string): Slide {
+  return {
+    id,
+    presentationId: 'presentation-1',
+    lyricId: null,
+    width: 1920,
+    height: 1080,
+    notes: '',
+    order: 0,
+    createdAt: '',
+    updatedAt: '',
+  };
+}
+
+function makeTemplate(id: string, kind: Template['kind']): Template {
+  return {
+    id,
+    name: 'Template',
+    kind,
+    width: 1920,
+    height: 1080,
+    order: 0,
+    elements: [],
+    createdAt: '',
+    updatedAt: '',
+  };
+}
+
+function makeStage(id: string): Stage {
+  return {
+    id,
+    name: 'Stage',
+    width: 1280,
+    height: 720,
+    order: 0,
+    elements: [],
+    createdAt: '',
+    updatedAt: '',
+  };
+}
+
+function makeOverlay(id: string): Overlay {
+  return {
+    id,
+    name: 'Overlay',
+    type: 'text',
+    x: 0,
+    y: 0,
+    width: 800,
+    height: 120,
+    opacity: 1,
+    zIndex: 0,
+    enabled: true,
+    payload: {
+      text: 'Overlay',
+      fontFamily: 'Avenir Next',
+      fontSize: 72,
+      color: '#FFFFFF',
+      alignment: 'center',
+      verticalAlign: 'middle',
+      lineHeight: 1.2,
+      weight: '700',
+    },
+    elements: [],
+    animation: { kind: 'none', durationMs: 0, autoClearDurationMs: null },
+    createdAt: '',
+    updatedAt: '',
+  };
+}
+
+describe('useActiveEditorSource', () => {
+  beforeEach(() => {
+    useNavigationMock.mockReturnValue({
+      currentDeckItem: { id: 'deck-1', type: 'presentation' },
+    } as never);
+    useSlidesMock.mockReturnValue({
+      currentSlide: makeSlide('slide-1'),
+    } as never);
+    useWorkbenchMock.mockReturnValue({
+      state: { workbenchMode: 'show' },
+    } as never);
+    useDeckEditorMock.mockReturnValue({
+      getSlideElements: vi.fn().mockReturnValue([{ id: 'slide-el', slideId: 'slide-1', type: 'text' }]),
+      replaceSlideElements: vi.fn(),
+    } as never);
+    useOverlayEditorMock.mockReturnValue({
+      currentOverlay: null,
+      updateOverlayDraft: vi.fn(),
+    } as never);
+    useTemplateEditorMock.mockReturnValue({
+      currentTemplate: null,
+      replaceTemplateElements: vi.fn(),
+    } as never);
+    useStageEditorMock.mockReturnValue({
+      currentStage: null,
+      replaceStageElements: vi.fn(),
+    } as never);
+  });
+
+  it('keeps stage editor empty when no stage is selected even if a deck slide exists', () => {
+    useWorkbenchMock.mockReturnValue({
+      state: { workbenchMode: 'stage-editor' },
+    } as never);
+
+    const { result } = renderHook(() => useActiveEditorSource());
+
+    expect(result.current.mode).toBe('stage-editor');
+    expect(result.current.hasSource).toBe(false);
+    expect(result.current.elements).toEqual([]);
+    expect(result.current.emptyStateLabel).toBe('No stage selected.');
+  });
+
+  it('resolves the selected stage as the active stage editor source', () => {
+    const stage = makeStage('stage-1');
+    stage.elements = [{ id: 'stage-el', slideId: 'stage-1', type: 'shape' } as never];
+    useWorkbenchMock.mockReturnValue({
+      state: { workbenchMode: 'stage-editor' },
+    } as never);
+    useStageEditorMock.mockReturnValue({
+      currentStage: stage,
+      replaceStageElements: vi.fn(),
+    } as never);
+
+    const { result } = renderHook(() => useActiveEditorSource());
+
+    expect(result.current.mode).toBe('stage-editor');
+    expect(result.current.entityId).toBe('stage-1');
+    expect(result.current.hasSource).toBe(true);
+    expect(result.current.elements).toEqual(stage.elements);
+    expect(result.current.frame).toEqual({ width: 1280, height: 720 });
+  });
+
+  it('resolves deck editor metadata and disables text creation for lyric items', () => {
+    useWorkbenchMock.mockReturnValue({
+      state: { workbenchMode: 'deck-editor' },
+    } as never);
+    useNavigationMock.mockReturnValue({
+      currentDeckItem: { id: 'deck-1', type: 'lyric' },
+    } as never);
+
+    const { result } = renderHook(() => useActiveEditorSource());
+
+    const source = result.current;
+    expect(source.mode).toBe('deck-editor');
+    if (source.mode !== 'deck-editor') throw new Error('Expected deck editor source');
+    expect(source.hasSource).toBe(true);
+    expect(source.meta.deckItemType).toBe('lyric');
+    expect(source.createCapabilities.text).toBe(false);
+  });
+
+  it('resolves template editor metadata from the selected template', () => {
+    useWorkbenchMock.mockReturnValue({
+      state: { workbenchMode: 'template-editor' },
+    } as never);
+    useTemplateEditorMock.mockReturnValue({
+      currentTemplate: makeTemplate('template-1', 'lyrics'),
+      replaceTemplateElements: vi.fn(),
+    } as never);
+
+    const { result } = renderHook(() => useActiveEditorSource());
+
+    const source = result.current;
+    expect(source.mode).toBe('template-editor');
+    if (source.mode !== 'template-editor') throw new Error('Expected template editor source');
+    expect(source.meta.templateKind).toBe('lyrics');
+    expect(source.emptyStateLabel).toBe('No template selected.');
+    expect(source.createCapabilities.text).toBe(false);
+  });
+
+  it('resolves overlay editor metadata from the selected overlay', () => {
+    useWorkbenchMock.mockReturnValue({
+      state: { workbenchMode: 'overlay-editor' },
+    } as never);
+    useOverlayEditorMock.mockReturnValue({
+      currentOverlay: makeOverlay('overlay-1'),
+      updateOverlayDraft: vi.fn(),
+    } as never);
+
+    const { result } = renderHook(() => useActiveEditorSource());
+
+    expect(result.current.mode).toBe('overlay-editor');
+    expect(result.current.entityId).toBe('overlay-1');
+    expect(result.current.hasSource).toBe(true);
+    expect(result.current.emptyStateLabel).toBe('No overlay selected.');
+  });
+});

--- a/app/renderer/contexts/canvas/use-active-editor-source.ts
+++ b/app/renderer/contexts/canvas/use-active-editor-source.ts
@@ -1,0 +1,161 @@
+import { useMemo } from 'react';
+import { overlayToLayerElements } from '@core/presentation-layers';
+import type { SlideElement } from '@core/types';
+import { useNavigation } from '../navigation-context';
+import { useSlides } from '../slide-context';
+import { useOverlayEditor, useDeckEditor, useStageEditor, useTemplateEditor } from '../asset-editor/asset-editor-context';
+import { useWorkbench } from '../workbench-context';
+import type { ActiveEditorSource, EditorCreateCapabilities } from './editor-source';
+
+const NOOP_CREATE_CAPABILITIES: EditorCreateCapabilities = {
+  text: false,
+  shape: false,
+  media: false,
+};
+
+function noopReplaceElements(_elements: SlideElement[]) {}
+
+export function useActiveEditorSource(): ActiveEditorSource {
+  const { currentDeckItem } = useNavigation();
+  const { currentSlide } = useSlides();
+  const { currentOverlay, updateOverlayDraft } = useOverlayEditor();
+  const { getSlideElements, replaceSlideElements } = useDeckEditor();
+  const { currentTemplate, replaceTemplateElements } = useTemplateEditor();
+  const { currentStage, replaceStageElements } = useStageEditor();
+  const { state: { workbenchMode } } = useWorkbench();
+
+  return useMemo<ActiveEditorSource>(() => {
+    if (workbenchMode === 'deck-editor') {
+      return {
+        mode: workbenchMode,
+        entityId: currentSlide?.id ?? null,
+        hasSource: Boolean(currentSlide),
+        frame: currentSlide,
+        elements: currentSlide ? getSlideElements(currentSlide.id) : [],
+        replaceElements: (elements) => {
+          if (!currentSlide) return;
+          replaceSlideElements(currentSlide.id, elements);
+        },
+        historyKey: currentSlide?.id ?? null,
+        emptyStateLabel: 'No slide selected.',
+        editable: true,
+        createCapabilities: {
+          text: currentDeckItem?.type !== 'lyric',
+          shape: true,
+          media: true,
+        },
+        meta: {
+          slide: currentSlide,
+          slideId: currentSlide?.id ?? null,
+          deckItemType: currentDeckItem?.type ?? null,
+        },
+      };
+    }
+
+    if (workbenchMode === 'overlay-editor') {
+      return {
+        mode: workbenchMode,
+        entityId: currentOverlay?.id ?? null,
+        hasSource: Boolean(currentOverlay),
+        // `null` falls back to the full output canvas in `buildRenderScene`
+        // (LAYER_PREVIEW_SLIDE = 1920×1080). Overlay elements are positioned
+        // in output-canvas coordinates via `overlayToLayerElements`, so the
+        // editor needs the full stage as its frame — using the overlay's own
+        // width/height instead would shrink the canvas to the overlay's
+        // bounding box and break the editing view.
+        frame: null,
+        elements: currentOverlay ? overlayToLayerElements(currentOverlay) : [],
+        replaceElements: (elements) => {
+          if (!currentOverlay) return;
+          updateOverlayDraft({ id: currentOverlay.id, elements });
+        },
+        historyKey: currentOverlay?.id ?? null,
+        emptyStateLabel: 'No overlay selected.',
+        editable: true,
+        createCapabilities: {
+          text: true,
+          shape: true,
+          media: true,
+        },
+        meta: {
+          overlay: currentOverlay,
+        },
+      };
+    }
+
+    if (workbenchMode === 'template-editor') {
+      return {
+        mode: workbenchMode,
+        entityId: currentTemplate?.id ?? null,
+        hasSource: Boolean(currentTemplate),
+        frame: currentTemplate ? { width: currentTemplate.width, height: currentTemplate.height } : null,
+        elements: currentTemplate?.elements ?? [],
+        replaceElements: (elements) => {
+          replaceTemplateElements(elements);
+        },
+        historyKey: currentTemplate?.id ?? null,
+        emptyStateLabel: 'No template selected.',
+        editable: true,
+        createCapabilities: {
+          text: currentTemplate?.kind !== 'lyrics',
+          shape: true,
+          media: true,
+        },
+        meta: {
+          template: currentTemplate,
+          templateKind: currentTemplate?.kind ?? null,
+        },
+      };
+    }
+
+    if (workbenchMode === 'stage-editor') {
+      return {
+        mode: workbenchMode,
+        entityId: currentStage?.id ?? null,
+        hasSource: Boolean(currentStage),
+        frame: currentStage ? { width: currentStage.width, height: currentStage.height } : null,
+        elements: currentStage?.elements ?? [],
+        replaceElements: (elements) => {
+          replaceStageElements(elements);
+        },
+        historyKey: currentStage?.id ?? null,
+        emptyStateLabel: 'No stage selected.',
+        editable: true,
+        createCapabilities: {
+          text: true,
+          shape: true,
+          media: true,
+        },
+        meta: {
+          stage: currentStage,
+        },
+      };
+    }
+
+    return {
+      mode: workbenchMode,
+      entityId: null,
+      hasSource: false,
+      frame: null,
+      elements: [],
+      replaceElements: noopReplaceElements,
+      historyKey: null,
+      emptyStateLabel: 'No editable source selected.',
+      editable: false,
+      createCapabilities: NOOP_CREATE_CAPABILITIES,
+      meta: {},
+    };
+  }, [
+    currentDeckItem?.type,
+    currentOverlay,
+    currentSlide,
+    currentStage,
+    currentTemplate,
+    getSlideElements,
+    replaceSlideElements,
+    replaceStageElements,
+    replaceTemplateElements,
+    updateOverlayDraft,
+    workbenchMode,
+  ]);
+}

--- a/app/renderer/contexts/create-screen-context.tsx
+++ b/app/renderer/contexts/create-screen-context.tsx
@@ -1,0 +1,13 @@
+import { createContext, useContext } from 'react';
+
+export function createScreenContext<T>(name: string) {
+  const ScreenContext = createContext<T | null>(null);
+
+  function useScreenContext(): T {
+    const context = useContext(ScreenContext);
+    if (!context) throw new Error(`${name} must be used within ${name}Provider`);
+    return context;
+  }
+
+  return [ScreenContext.Provider, useScreenContext] as const;
+}

--- a/app/renderer/contexts/element/use-element-commands.test.tsx
+++ b/app/renderer/contexts/element/use-element-commands.test.tsx
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import type { MediaAsset } from '@core/types';
+import { useProjectContent } from '@renderer/contexts/use-project-content';
+import { useWorkbench } from '@renderer/contexts/workbench-context';
+import type { ActiveEditorSource } from '../canvas/editor-source';
+import { useElementCommands } from './use-element-commands';
+
+vi.mock('@renderer/contexts/use-project-content', () => ({ useProjectContent: vi.fn() }));
+vi.mock('@renderer/contexts/workbench-context', () => ({ useWorkbench: vi.fn() }));
+
+const useProjectContentMock = vi.mocked(useProjectContent);
+const useWorkbenchMock = vi.mocked(useWorkbench);
+
+function makeStageSource(replaceElements: ReturnType<typeof vi.fn>): ActiveEditorSource {
+  return {
+    mode: 'stage-editor',
+    entityId: 'stage-1',
+    hasSource: true,
+    frame: { width: 1920, height: 1080 },
+    elements: [],
+    replaceElements: replaceElements as (elements: ActiveEditorSource['elements']) => void,
+    historyKey: 'stage-1',
+    emptyStateLabel: 'No stage selected.',
+    editable: true,
+    createCapabilities: { text: true, shape: true, media: true },
+    meta: { stage: { id: 'stage-1', name: 'Stage', width: 1920, height: 1080, order: 0, elements: [], createdAt: '', updatedAt: '' } },
+  };
+}
+
+describe('useElementCommands', () => {
+  beforeEach(() => {
+    useWorkbenchMock.mockReturnValue({
+      state: {
+        overlayDefaults: {
+          animationKind: 'dissolve',
+          durationMs: 400,
+          autoClearDurationMs: null,
+        },
+      },
+    } as never);
+    useProjectContentMock.mockReturnValue({
+      slideElementsBySlideId: new Map(),
+    } as never);
+  });
+
+  it('writes new stage text into the stage draft even when a lyric deck item is selected elsewhere', async () => {
+    const replaceElements = vi.fn();
+    const setStatusText = vi.fn();
+    const { result } = renderHook(() => useElementCommands({
+      activeEditorSource: makeStageSource(replaceElements),
+      currentDeckItem: { id: 'deck-1', type: 'lyric' } as never,
+      mutatePatch: vi.fn().mockResolvedValue({}),
+      setStatusText,
+    }));
+
+    await act(async () => {
+      await result.current.createText();
+    });
+
+    expect(replaceElements).toHaveBeenCalledTimes(1);
+    expect(replaceElements.mock.calls[0][0][0]).toMatchObject({ slideId: 'stage-1', type: 'text' });
+    expect(setStatusText).toHaveBeenCalledWith('Added stage text');
+  });
+
+  it('writes new stage shapes into the current stage draft', async () => {
+    const replaceElements = vi.fn();
+    const { result } = renderHook(() => useElementCommands({
+      activeEditorSource: makeStageSource(replaceElements),
+      currentDeckItem: null,
+      mutatePatch: vi.fn().mockResolvedValue({}),
+      setStatusText: vi.fn(),
+    }));
+
+    await act(async () => {
+      await result.current.createShape();
+    });
+
+    expect(replaceElements).toHaveBeenCalledTimes(1);
+    expect(replaceElements.mock.calls[0][0][0]).toMatchObject({ slideId: 'stage-1', type: 'shape' });
+  });
+
+  it('writes dropped media into the current stage draft', async () => {
+    const replaceElements = vi.fn();
+    const asset: MediaAsset = {
+      id: 'asset-1',
+      name: 'Photo',
+      type: 'image',
+      order: 0,
+      src: '/photo.jpg',
+      createdAt: '',
+      updatedAt: '',
+    };
+    const { result } = renderHook(() => useElementCommands({
+      activeEditorSource: makeStageSource(replaceElements),
+      currentDeckItem: null,
+      mutatePatch: vi.fn().mockResolvedValue({}),
+      setStatusText: vi.fn(),
+    }));
+
+    await act(async () => {
+      await result.current.createFromMedia(asset, 120, 180);
+    });
+
+    expect(replaceElements).toHaveBeenCalledTimes(1);
+    expect(replaceElements.mock.calls[0][0][0]).toMatchObject({ slideId: 'stage-1', type: 'image' });
+  });
+});

--- a/app/renderer/contexts/element/use-element-commands.ts
+++ b/app/renderer/contexts/element/use-element-commands.ts
@@ -1,11 +1,11 @@
 import { useCallback } from 'react';
 import { isLyricDeckItem } from '@core/deck-items';
-import type { AppSnapshot, DeckItem, ElementCreateInput, Id, MediaAsset, Slide, SlideElement } from '@core/types';
+import type { DeckItem, ElementCreateInput, Id, MediaAsset, SlideElement } from '@core/types';
 import type { SnapshotPatch } from '@core/snapshot-patch';
 import { castMediaSrc, getOverlayDefaults, typeFromFile } from '../../utils/slides';
-import { useOverlayEditor, useDeckEditor, useTemplateEditor } from '../asset-editor/asset-editor-context';
 import { useProjectContent } from '../use-project-content';
 import { useWorkbench } from '../workbench-context';
+import type { ActiveEditorSource } from '../canvas/editor-source';
 import {
   newOverlayElement,
   newShapePayload,
@@ -17,27 +17,16 @@ import {
 } from './element-factory';
 
 interface CommandsParams {
-  currentSlide: Slide | null;
+  activeEditorSource: ActiveEditorSource;
   currentDeckItem: DeckItem | null;
-  currentTemplate: { id: Id; kind: 'slides' | 'lyrics' | 'overlays'; elements: SlideElement[] } | null;
-  mutate: (action: () => Promise<AppSnapshot>) => Promise<AppSnapshot>;
-  mutatePatch: (action: () => Promise<SnapshotPatch>) => Promise<AppSnapshot>;
+  mutatePatch: (action: () => Promise<SnapshotPatch>) => Promise<unknown>;
   setStatusText: (text: string) => void;
 }
 
-export function useElementCommands({ currentSlide, currentDeckItem, currentTemplate, mutatePatch, setStatusText }: CommandsParams) {
+export function useElementCommands({ activeEditorSource, currentDeckItem, mutatePatch, setStatusText }: CommandsParams) {
   const { state: { overlayDefaults } } = useWorkbench();
   const isLyricItem = isLyricDeckItem(currentDeckItem);
-  const { currentOverlay, updateOverlayDraft } = useOverlayEditor();
-  const { getSlideElements, replaceSlideElements } = useDeckEditor();
-  const { replaceTemplateElements } = useTemplateEditor();
   const { slideElementsBySlideId } = useProjectContent();
-  const { state: { workbenchMode } } = useWorkbench();
-  const isOverlayEdit = workbenchMode === 'overlay-editor';
-  const isSlideEdit = workbenchMode === 'deck-editor';
-  const isTemplateEdit = workbenchMode === 'template-editor';
-  const isLyricsTemplate = currentTemplate?.kind === 'lyrics';
-  const existingTemplateTextElement = currentTemplate?.elements.find((element) => element.type === 'text') ?? null;
 
   function resolvePersistentMediaSource(file: File): string | null {
     const filePath = window.castApi.getPathForFile(file);
@@ -45,118 +34,177 @@ export function useElementCommands({ currentSlide, currentDeckItem, currentTempl
     return castMediaSrc(filePath);
   }
 
-  function addToOverlay(element: SlideElement) {
-    if (!currentOverlay) return;
-    updateOverlayDraft({ id: currentOverlay.id, elements: [...currentOverlay.elements, element] });
+  function replaceSourceElements(elements: SlideElement[]) {
+    if (!activeEditorSource.editable || !activeEditorSource.hasSource) return;
+    activeEditorSource.replaceElements(elements);
   }
 
-  function addToTemplate(element: SlideElement) {
-    if (!currentTemplate) return;
-    replaceTemplateElements([...currentTemplate.elements, element]);
+  function addToSource(element: SlideElement) {
+    replaceSourceElements([...activeEditorSource.elements, element]);
   }
 
-  function addToSlideEdit(slideId: Id, element: SlideElement) {
-    replaceSlideElements(slideId, [...getSlideElements(slideId), element]);
+  function resolveSlideIdForDirectCreate(): Id | null {
+    if (activeEditorSource.mode === 'deck-editor') return activeEditorSource.meta.slideId;
+    return null;
   }
 
   const createText = useCallback(async () => {
-    if (isOverlayEdit) {
+    if (activeEditorSource.mode === 'overlay-editor') {
+      const currentOverlay = activeEditorSource.meta.overlay;
       if (!currentOverlay) return;
-      addToOverlay(newOverlayElement(currentOverlay.id, 'text', 210, 460, 1500, 120, nextOverlayZIndex(currentOverlay.elements, 20), newTextPayload('New Overlay Text', 72, 'center', '700')));
+      addToSource(newOverlayElement(currentOverlay.id, 'text', 210, 460, 1500, 120, nextOverlayZIndex(currentOverlay.elements, 20), newTextPayload('New Overlay Text', 72, 'center', '700')));
       setStatusText('Added overlay text');
       return;
     }
-    if (isTemplateEdit) {
+
+    if (activeEditorSource.mode === 'template-editor') {
+      const currentTemplate = activeEditorSource.meta.template;
       if (!currentTemplate) return;
-      if (isLyricsTemplate && existingTemplateTextElement) {
+      if (currentTemplate.kind === 'lyrics' && activeEditorSource.elements.some((element) => element.type === 'text')) {
         setStatusText('Lyric templates only support the existing lyric text element.');
         return;
       }
-      addToTemplate(newSlideTextElement(currentTemplate.id));
+      addToSource(newSlideTextElement(currentTemplate.id));
       setStatusText('Added template text');
       return;
     }
-    if (!currentSlide) return;
-    if (isLyricItem) {
-      const existingLyricsText = (slideElementsBySlideId.get(currentSlide.id) ?? []).find((element) => {
-        return element.slideId === currentSlide.id && element.type === 'text' && 'text' in element.payload;
+
+    if (activeEditorSource.mode === 'stage-editor') {
+      const currentStage = activeEditorSource.meta.stage;
+      if (!currentStage) return;
+      addToSource(newSlideTextElement(currentStage.id));
+      setStatusText('Added stage text');
+      return;
+    }
+
+    const currentSlideId = resolveSlideIdForDirectCreate();
+    if (!currentSlideId) return;
+    if (activeEditorSource.mode === 'deck-editor' && isLyricItem) {
+      const existingLyricsText = (slideElementsBySlideId.get(currentSlideId) ?? []).find((element) => {
+        return element.slideId === currentSlideId && element.type === 'text' && 'text' in element.payload;
       });
       if (existingLyricsText) {
         setStatusText('Lyrics keep one text element per slide. Edit text in Outline view.');
         return;
       }
     }
-    if (isSlideEdit) {
-      addToSlideEdit(currentSlide.id, newSlideTextElement(currentSlide.id));
+
+    if (activeEditorSource.mode === 'deck-editor') {
+      addToSource(newSlideTextElement(currentSlideId));
       setStatusText('Added text element');
       return;
     }
+
     await mutatePatch(() => window.castApi.createElement({
-      slideId: currentSlide.id, type: 'text', x: 210, y: 460, width: 1500, height: 120,
-      zIndex: 20, layer: 'content', payload: newTextPayload('New Text Element', 72, 'center', '700'),
+      slideId: currentSlideId,
+      type: 'text',
+      x: 210,
+      y: 460,
+      width: 1500,
+      height: 120,
+      zIndex: 20,
+      layer: 'content',
+      payload: newTextPayload('New Text Element', 72, 'center', '700'),
     }));
     setStatusText('Added text element');
-  }, [currentOverlay, currentSlide, currentTemplate, existingTemplateTextElement, getSlideElements, isLyricItem, isLyricsTemplate, isOverlayEdit, isSlideEdit, isTemplateEdit, mutatePatch, replaceSlideElements, replaceTemplateElements, setStatusText, slideElementsBySlideId, updateOverlayDraft]);
+  }, [activeEditorSource, isLyricItem, mutatePatch, setStatusText, slideElementsBySlideId]);
 
   const createShape = useCallback(async () => {
-    if (isOverlayEdit) {
+    if (activeEditorSource.mode === 'overlay-editor') {
+      const currentOverlay = activeEditorSource.meta.overlay;
       if (!currentOverlay) return;
-      addToOverlay(newOverlayElement(currentOverlay.id, 'shape', 260, 260, 1400, 560, nextOverlayZIndex(currentOverlay.elements, 2), newShapePayload()));
+      addToSource(newOverlayElement(currentOverlay.id, 'shape', 260, 260, 1400, 560, nextOverlayZIndex(currentOverlay.elements, 2), newShapePayload()));
       setStatusText('Added overlay shape');
       return;
     }
-    if (isTemplateEdit) {
+
+    if (activeEditorSource.mode === 'template-editor') {
+      const currentTemplate = activeEditorSource.meta.template;
       if (!currentTemplate) return;
-      addToTemplate(newSlideShapeElement(currentTemplate.id));
+      addToSource(newSlideShapeElement(currentTemplate.id));
       setStatusText('Added template shape');
       return;
     }
-    if (!currentSlide) return;
-    if (isSlideEdit) {
-      addToSlideEdit(currentSlide.id, newSlideShapeElement(currentSlide.id));
+
+    if (activeEditorSource.mode === 'stage-editor') {
+      const currentStage = activeEditorSource.meta.stage;
+      if (!currentStage) return;
+      addToSource(newSlideShapeElement(currentStage.id));
+      setStatusText('Added stage shape');
+      return;
+    }
+
+    const currentSlideId = resolveSlideIdForDirectCreate();
+    if (!currentSlideId) return;
+
+    if (activeEditorSource.mode === 'deck-editor') {
+      addToSource(newSlideShapeElement(currentSlideId));
       setStatusText('Added shape element');
       return;
     }
+
     await mutatePatch(() => window.castApi.createElement({
-      slideId: currentSlide.id, type: 'shape', x: 260, y: 260, width: 1400, height: 560,
-      zIndex: 2, layer: 'background', payload: newShapePayload(),
+      slideId: currentSlideId,
+      type: 'shape',
+      x: 260,
+      y: 260,
+      width: 1400,
+      height: 560,
+      zIndex: 2,
+      layer: 'background',
+      payload: newShapePayload(),
     }));
     setStatusText('Added shape element');
-  }, [currentOverlay, currentSlide, currentTemplate, getSlideElements, isOverlayEdit, isSlideEdit, isTemplateEdit, mutatePatch, replaceSlideElements, replaceTemplateElements, setStatusText, updateOverlayDraft]);
+  }, [activeEditorSource, mutatePatch, setStatusText]);
 
   const createFromMedia = useCallback(async (asset: MediaAsset, x: number, y: number) => {
-    if (isOverlayEdit) {
+    if (activeEditorSource.mode === 'overlay-editor') {
+      const currentOverlay = activeEditorSource.meta.overlay;
       if (!currentOverlay) return;
       const elementType = asset.type === 'video' || asset.type === 'animation' ? 'video' as const : 'image' as const;
-      const w = asset.type === 'image' ? 640 : 960;
-      const h = asset.type === 'image' ? 360 : 540;
+      const width = asset.type === 'image' ? 640 : 960;
+      const height = asset.type === 'image' ? 360 : 540;
       const payload = asset.type === 'video' || asset.type === 'animation'
         ? { src: asset.src, autoplay: true, loop: true, muted: true }
         : { src: asset.src };
-      addToOverlay(newOverlayElement(currentOverlay.id, elementType, x, y, w, h, nextOverlayZIndex(currentOverlay.elements, 10), payload));
+      addToSource(newOverlayElement(currentOverlay.id, elementType, x, y, width, height, nextOverlayZIndex(currentOverlay.elements, 10), payload));
       setStatusText(`Added ${asset.type} overlay`);
       return;
     }
-    if (isTemplateEdit) {
+
+    if (activeEditorSource.mode === 'template-editor') {
+      const currentTemplate = activeEditorSource.meta.template;
       if (!currentTemplate) return;
-      addToTemplate(newSlideMediaElement(currentTemplate.id, asset, x, y));
+      addToSource(newSlideMediaElement(currentTemplate.id, asset, x, y));
       setStatusText(`Added ${asset.type} template element`);
       return;
     }
-    if (!currentSlide) return;
-    if (isSlideEdit) {
-      addToSlideEdit(currentSlide.id, newSlideMediaElement(currentSlide.id, asset, x, y));
+
+    if (activeEditorSource.mode === 'stage-editor') {
+      const currentStage = activeEditorSource.meta.stage;
+      if (!currentStage) return;
+      addToSource(newSlideMediaElement(currentStage.id, asset, x, y));
+      setStatusText(`Added ${asset.type} stage element`);
+      return;
+    }
+
+    const currentSlideId = resolveSlideIdForDirectCreate();
+    if (!currentSlideId) return;
+
+    if (activeEditorSource.mode === 'deck-editor') {
+      addToSource(newSlideMediaElement(currentSlideId, asset, x, y));
       setStatusText(`Added ${asset.type} element`);
       return;
     }
+
     let input: ElementCreateInput;
     if (asset.type === 'image') {
-      input = { slideId: currentSlide.id, type: 'image', x, y, width: 640, height: 360, zIndex: 10, layer: 'media', payload: { src: asset.src } };
+      input = { slideId: currentSlideId, type: 'image', x, y, width: 640, height: 360, zIndex: 10, layer: 'media', payload: { src: asset.src } };
     } else if (asset.type === 'video' || asset.type === 'animation') {
-      input = { slideId: currentSlide.id, type: 'video', x, y, width: 960, height: 540, zIndex: 10, layer: 'media', payload: { src: asset.src, autoplay: true, loop: true, muted: true } };
+      input = { slideId: currentSlideId, type: 'video', x, y, width: 960, height: 540, zIndex: 10, layer: 'media', payload: { src: asset.src, autoplay: true, loop: true, muted: true } };
     } else {
       input = {
-        slideId: currentSlide.id,
+        slideId: currentSlideId,
         type: 'text',
         x,
         y,
@@ -169,7 +217,7 @@ export function useElementCommands({ currentSlide, currentDeckItem, currentTempl
     }
     await mutatePatch(() => window.castApi.createElement(input));
     setStatusText(`Added ${asset.type} element`);
-  }, [currentOverlay, currentSlide, currentTemplate, getSlideElements, isOverlayEdit, isSlideEdit, isTemplateEdit, mutatePatch, replaceSlideElements, replaceTemplateElements, setStatusText, updateOverlayDraft]);
+  }, [activeEditorSource, mutatePatch, setStatusText]);
 
   const createOverlay = useCallback(async () => {
     await mutatePatch(() => window.castApi.createOverlay(getOverlayDefaults({
@@ -196,7 +244,9 @@ export function useElementCommands({ currentSlide, currentDeckItem, currentTempl
         continue;
       }
       await mutatePatch(() => window.castApi.createMediaAsset({
-        name: file.name, type: typeFromFile(file), src,
+        name: file.name,
+        type: typeFromFile(file),
+        src,
       }));
       importedCount += 1;
     }

--- a/app/renderer/contexts/playback/playback-context.tsx
+++ b/app/renderer/contexts/playback/playback-context.tsx
@@ -65,9 +65,15 @@ interface AudioValue {
   togglePlayback: () => void;
 }
 
+interface StageValue {
+  currentStageId: Id | null;
+  setCurrentStageId: (id: Id | null) => void;
+}
+
 interface PlaybackContextValue {
   layers: LayersValue;
   audio: AudioValue;
+  stage: StageValue;
 }
 
 // ─── Constants ──────────────────────────────────────────────────────
@@ -428,9 +434,18 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     togglePlayback,
   }), [audioAssets, clearAudio, currentAudioAsset, currentTime, duration, isPlaying, loopEnabled, pauseAudio, playAudio, playNext, playPrevious, seekTo, selectAudio, toggleLoop, togglePlayback]);
 
+  // ── Stage selection ──
+
+  const [currentStageId, setCurrentStageId] = useState<Id | null>(null);
+
+  const stage = useMemo<StageValue>(() => ({
+    currentStageId,
+    setCurrentStageId,
+  }), [currentStageId]);
+
   // ── Combined value ──
 
-  const value = useMemo<PlaybackContextValue>(() => ({ layers, audio }), [layers, audio]);
+  const value = useMemo<PlaybackContextValue>(() => ({ layers, audio, stage }), [layers, audio, stage]);
 
   return <PlaybackContext.Provider value={value}>{children}</PlaybackContext.Provider>;
 }
@@ -449,6 +464,10 @@ export function usePresentationLayers(): LayersValue {
 
 export function useAudio(): AudioValue {
   return usePlayback().audio;
+}
+
+export function useStagePlayback(): StageValue {
+  return usePlayback().stage;
 }
 
 // ─── Utils ──────────────────────────────────────────────────────────

--- a/app/renderer/contexts/use-project-content.ts
+++ b/app/renderer/contexts/use-project-content.ts
@@ -1,6 +1,6 @@
 import { useMemo, useRef } from 'react';
 import { getSlideDeckItemId } from '@core/deck-items';
-import type { DeckItem, Presentation, Id, Lyric, MediaAsset, Overlay, Slide, SlideElement, Template } from '@core/types';
+import type { DeckItem, Presentation, Id, Lyric, MediaAsset, Overlay, Slide, SlideElement, Stage, Template } from '@core/types';
 import { sortElements, sortSlides } from '../utils/slides';
 import { useCast } from './app-context';
 
@@ -13,12 +13,14 @@ interface ProjectContent {
   mediaAssets: MediaAsset[];
   overlays: Overlay[];
   templates: Template[];
+  stages: Stage[];
   deckItemsById: ReadonlyMap<Id, DeckItem>;
   slidesByDeckItemId: ReadonlyMap<Id, Slide[]>;
   slideElementsBySlideId: ReadonlyMap<Id, SlideElement[]>;
   mediaAssetsById: ReadonlyMap<Id, MediaAsset>;
   overlaysById: ReadonlyMap<Id, Overlay>;
   templatesById: ReadonlyMap<Id, Template>;
+  stagesById: ReadonlyMap<Id, Stage>;
 }
 
 function stableArray<T extends { id: Id; updatedAt: string }>(prev: T[] | null, next: T[]): T[] {
@@ -40,6 +42,7 @@ export function useProjectContent(): ProjectContent {
     mediaAssets: MediaAsset[];
     overlays: Overlay[];
     templates: Template[];
+    stages: Stage[];
   } | null>(null);
 
   const stableInputs = useMemo(() => {
@@ -51,6 +54,7 @@ export function useProjectContent(): ProjectContent {
       mediaAssets: snapshot?.mediaAssets ?? [],
       overlays: snapshot?.overlays ?? [],
       templates: snapshot?.templates ?? [],
+      stages: snapshot?.stages ?? [],
     };
 
     const prev = prevRef.current;
@@ -62,12 +66,13 @@ export function useProjectContent(): ProjectContent {
       mediaAssets: stableArray(prev?.mediaAssets ?? null, raw.mediaAssets),
       overlays: stableArray(prev?.overlays ?? null, raw.overlays),
       templates: stableArray(prev?.templates ?? null, raw.templates),
+      stages: stableArray(prev?.stages ?? null, raw.stages),
     };
     prevRef.current = result;
     return result;
   }, [snapshot]);
 
-  const { presentations, lyrics, slides, slideElements, mediaAssets, overlays, templates } = stableInputs;
+  const { presentations, lyrics, slides, slideElements, mediaAssets, overlays, templates, stages } = stableInputs;
 
   const deckItems = useMemo(() => {
     return [...presentations, ...lyrics].sort((left, right) => left.order - right.order || left.createdAt.localeCompare(right.createdAt));
@@ -127,6 +132,12 @@ export function useProjectContent(): ProjectContent {
     return map;
   }, [templates]);
 
+  const stagesById = useMemo(() => {
+    const map = new Map<Id, Stage>();
+    for (const stage of stages) map.set(stage.id, stage);
+    return map;
+  }, [stages]);
+
   return useMemo(() => ({
     presentations,
     lyrics,
@@ -136,15 +147,17 @@ export function useProjectContent(): ProjectContent {
     mediaAssets,
     overlays,
     templates,
+    stages,
     deckItemsById,
     slidesByDeckItemId,
     slideElementsBySlideId,
     mediaAssetsById,
     overlaysById,
     templatesById,
+    stagesById,
   }), [
-    presentations, lyrics, deckItems, slides, slideElements, mediaAssets, overlays, templates,
+    presentations, lyrics, deckItems, slides, slideElements, mediaAssets, overlays, templates, stages,
     deckItemsById, slidesByDeckItemId, slideElementsBySlideId,
-    mediaAssetsById, overlaysById, templatesById,
+    mediaAssetsById, overlaysById, templatesById, stagesById,
   ]);
 }

--- a/app/renderer/contexts/workbench-context.tsx
+++ b/app/renderer/contexts/workbench-context.tsx
@@ -1,6 +1,6 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from 'react';
 import type { OverlayAnimation } from '@core/types';
-import type { DrawerTab, DrawerViewModeMap, InspectorTab, LibraryPanelView, PlaylistBrowserMode, ResourceDrawerViewMode, SlideBrowserMode, WorkbenchMode } from '../types/ui';
+import type { DrawerTab, DrawerViewModeMap, InspectorTab, LibraryPanelView, PlaylistBrowserMode, PreviewGridDensity, PreviewMode, PreviewSurfaceKind, ResourceDrawerViewMode, SlideBrowserMode, WorkbenchMode } from '../types/ui';
 import { useGridSize } from '../hooks/use-grid-size';
 import { useLocalStorage } from '../hooks/use-local-storage';
 
@@ -53,6 +53,9 @@ type WorkbenchContextValue = {
     libraryPanelView: LibraryPanelView;
     overlayDefaults: OverlayDefaultsState;
     playlistBrowserMode: PlaylistBrowserMode;
+    previewMode: PreviewMode;
+    previewSingleSurface: PreviewSurfaceKind;
+    previewGridDensity: PreviewGridDensity;
     slideBrowserMode: SlideBrowserMode;
     workbenchMode: WorkbenchMode;
   };
@@ -65,6 +68,9 @@ type WorkbenchContextValue = {
     setLibraryPanelView: (view: LibraryPanelView) => void;
     updateOverlayDefaults: (next: Partial<OverlayDefaultsState>) => void;
     setPlaylistBrowserMode: (mode: PlaylistBrowserMode) => void;
+    setPreviewMode: (mode: PreviewMode) => void;
+    setPreviewSingleSurface: (surface: PreviewSurfaceKind) => void;
+    setPreviewGridDensity: (density: PreviewGridDensity) => void;
     setSlideBrowserMode: (mode: SlideBrowserMode) => void;
     setWorkbenchMode: (mode: WorkbenchMode) => void;
   };
@@ -79,7 +85,10 @@ const DEFAULT_DRAWER_VIEW_MODES: DrawerViewModeMap = { deck: 'grid', media: 'gri
 const LIBRARY_PANEL_VIEW_STORAGE_KEY = 'recast.library-panel-view.v1';
 const EXPANDED_SEGMENTS_STORAGE_KEY = 'recast.library-panel-expanded-segments.v1';
 const OVERLAY_DEFAULTS_STORAGE_KEY = 'recast.overlay-defaults.v1';
-const VALID_MODES = new Set<WorkbenchMode>(['show', 'deck-editor', 'overlay-editor', 'template-editor', 'settings']);
+const PREVIEW_MODE_STORAGE_KEY = 'recast.preview-mode.v1';
+const PREVIEW_SINGLE_SURFACE_STORAGE_KEY = 'recast.preview-single-surface.v1';
+const PREVIEW_GRID_DENSITY_STORAGE_KEY = 'recast.preview-grid-density.v1';
+const VALID_MODES = new Set<WorkbenchMode>(['show', 'deck-editor', 'overlay-editor', 'template-editor', 'stage-editor', 'settings']);
 const DEFAULT_OVERLAY_DEFAULTS: OverlayDefaultsState = {
   animationKind: 'dissolve',
   durationMs: 400,
@@ -118,6 +127,21 @@ export function WorkbenchProvider({ children }: { children: ReactNode }) {
     DEFAULT_OVERLAY_DEFAULTS,
     parseOverlayDefaults,
     JSON.stringify,
+  );
+  const [previewMode, setPreviewMode] = useLocalStorage<PreviewMode>(
+    PREVIEW_MODE_STORAGE_KEY,
+    'single',
+    parsePreviewMode,
+  );
+  const [previewSingleSurface, setPreviewSingleSurface] = useLocalStorage<PreviewSurfaceKind>(
+    PREVIEW_SINGLE_SURFACE_STORAGE_KEY,
+    'preview',
+    parsePreviewSurfaceKind,
+  );
+  const [previewGridDensity, setPreviewGridDensity] = useLocalStorage<PreviewGridDensity>(
+    PREVIEW_GRID_DENSITY_STORAGE_KEY,
+    1,
+    parsePreviewGridDensity,
   );
   const {
     gridSize: deckBrowserGridItemSize,
@@ -193,6 +217,9 @@ export function WorkbenchProvider({ children }: { children: ReactNode }) {
     libraryPanelView,
     overlayDefaults,
     playlistBrowserMode: deckBrowserPreferences.playlistBrowserMode,
+    previewMode,
+    previewSingleSurface,
+    previewGridDensity,
     slideBrowserMode: deckBrowserPreferences.slideBrowserMode,
     workbenchMode,
   }), [
@@ -207,6 +234,9 @@ export function WorkbenchProvider({ children }: { children: ReactNode }) {
     inspectorTab,
     libraryPanelView,
     overlayDefaults,
+    previewMode,
+    previewSingleSurface,
+    previewGridDensity,
     workbenchMode,
   ]);
 
@@ -219,6 +249,9 @@ export function WorkbenchProvider({ children }: { children: ReactNode }) {
     setLibraryPanelView,
     updateOverlayDefaults,
     setPlaylistBrowserMode,
+    setPreviewMode,
+    setPreviewSingleSurface,
+    setPreviewGridDensity,
     setSlideBrowserMode,
     setWorkbenchMode,
   }), [
@@ -230,6 +263,9 @@ export function WorkbenchProvider({ children }: { children: ReactNode }) {
     setLibraryPanelView,
     updateOverlayDefaults,
     setPlaylistBrowserMode,
+    setPreviewMode,
+    setPreviewSingleSurface,
+    setPreviewGridDensity,
     setSlideBrowserMode,
     setWorkbenchMode,
   ]);
@@ -347,4 +383,17 @@ function sanitizeOverlayDefaults(value: Partial<OverlayDefaultsState>): OverlayD
 function sanitizeDuration(value: unknown, fallback: number): number {
   if (typeof value !== 'number' || !Number.isFinite(value)) return fallback;
   return Math.max(0, Math.round(value));
+}
+
+function parsePreviewMode(raw: string): PreviewMode | null {
+  return raw === 'single' || raw === 'all' ? raw : null;
+}
+
+function parsePreviewSurfaceKind(raw: string): PreviewSurfaceKind | null {
+  return raw === 'preview' || raw === 'monitor' || raw === 'stage' ? raw : null;
+}
+
+function parsePreviewGridDensity(raw: string): PreviewGridDensity | null {
+  const parsed = Number(raw);
+  return parsed === 1 || parsed === 2 ? (parsed as PreviewGridDensity) : null;
 }

--- a/app/renderer/features/assets/stages/stage-bin-panel.tsx
+++ b/app/renderer/features/assets/stages/stage-bin-panel.tsx
@@ -1,0 +1,83 @@
+import { useMemo } from 'react';
+import type { Id, Stage } from '@core/types';
+import { Thumbnail } from '../../../components/display/thumbnail';
+import { SceneFrame } from '../../../components/display/scene-frame';
+import { buildRenderScene } from '../../canvas/build-render-scene';
+import { SceneStage } from '../../canvas/scene-stage';
+import { BinPanelLayout } from '../../workbench/bin-panel-layout';
+import { useStagePlayback } from '../../../contexts/playback/playback-context';
+import { useStageEditor } from '../../../contexts/asset-editor/asset-editor-context';
+import { useWorkbench } from '../../../contexts/workbench-context';
+import { useProjectContent } from '../../../contexts/use-project-content';
+import { filterByText } from '../../../utils/filter-by-text';
+
+interface StageBinPanelProps {
+  filterText: string;
+  gridItemSize: number;
+}
+
+export function StageBinPanel({ filterText, gridItemSize }: StageBinPanelProps) {
+  const { stages: allStages } = useProjectContent();
+  const { currentStageId, setCurrentStageId } = useStagePlayback();
+  const { setCurrentStageId: setEditorStageId } = useStageEditor();
+  const { actions: { setWorkbenchMode } } = useWorkbench();
+
+  const stages = useMemo(
+    () => filterByText(allStages, filterText, (stage: Stage) => [stage.name]),
+    [allStages, filterText],
+  );
+
+  return (
+    <BinPanelLayout gridItemSize={gridItemSize}>
+      {stages.map((stage, index) => (
+        <StageCard
+          key={stage.id}
+          stage={stage}
+          index={index}
+          isActive={stage.id === currentStageId}
+          onActivate={setCurrentStageId}
+          onEdit={(id) => {
+            setEditorStageId(id);
+            setWorkbenchMode('stage-editor');
+          }}
+        />
+      ))}
+    </BinPanelLayout>
+  );
+}
+
+interface StageCardProps {
+  stage: Stage;
+  index: number;
+  isActive: boolean;
+  onActivate: (id: Id | null) => void;
+  onEdit: (id: Id) => void;
+}
+
+function StageCard({ stage, index, isActive, onActivate, onEdit }: StageCardProps) {
+  const scene = buildRenderScene(null, stage.elements);
+
+  function handleActivate() {
+    onActivate(isActive ? null : stage.id);
+  }
+
+  function handleEdit() {
+    onEdit(stage.id);
+  }
+
+  return (
+    <Thumbnail.Tile onClick={handleActivate} onDoubleClick={handleEdit} selected={isActive}>
+      <Thumbnail.Body>
+        <SceneFrame width={scene.width} height={scene.height} className="bg-tertiary" stageClassName="absolute inset-0" checkerboard>
+          <SceneStage scene={scene} surface="stage" className="absolute inset-0 pointer-events-none" />
+        </SceneFrame>
+      </Thumbnail.Body>
+      <Thumbnail.Caption>
+        <div className="flex items-center gap-2">
+          <span className="shrink-0 text-sm font-semibold tabular-nums text-secondary">{index + 1}</span>
+          <span className="min-w-0 truncate text-sm text-tertiary">{stage.name}</span>
+        </div>
+      </Thumbnail.Caption>
+    </Thumbnail.Tile>
+  );
+}

--- a/app/renderer/features/canvas/build-render-scene.ts
+++ b/app/renderer/features/canvas/build-render-scene.ts
@@ -13,8 +13,16 @@ function toRenderNode(element: SlideElement): RenderNode {
   };
 }
 
-function resolveSceneSlide(slide: Slide | null): Slide {
-  return slide ?? LAYER_PREVIEW_SLIDE;
+type RenderSceneFrameInput = Pick<Slide, 'width' | 'height'> | Slide | null;
+
+function resolveSceneSlide(frame: RenderSceneFrameInput): Slide {
+  if (!frame) return LAYER_PREVIEW_SLIDE;
+  if ('id' in frame && 'notes' in frame) return frame;
+  return {
+    ...LAYER_PREVIEW_SLIDE,
+    width: frame.width,
+    height: frame.height,
+  };
 }
 
 function sceneSize(slide: Slide): { width: number; height: number } {
@@ -32,8 +40,8 @@ function toPresentationLayerElement(element: SlideElement): SlideElement {
   };
 }
 
-export function buildRenderScene(slide: Slide | null, elements: SlideElement[]): RenderScene {
-  const nextSlide = resolveSceneSlide(slide);
+export function buildRenderScene(frame: RenderSceneFrameInput, elements: SlideElement[]): RenderScene {
+  const nextSlide = resolveSceneSlide(frame);
   const size = sceneSize(nextSlide);
   const sorted = sortElements(elements).map(toRenderNode);
   return { slide: nextSlide, width: size.width, height: size.height, nodes: sorted };

--- a/app/renderer/features/canvas/object-list-panel.tsx
+++ b/app/renderer/features/canvas/object-list-panel.tsx
@@ -48,7 +48,7 @@ export function ObjectListPanel() {
 
   return (
     <ObjectListContext.Provider value={contextValue}>
-      <div data-ui-region="object-list-panel" className="flex flex-col gap-1.5">
+      <div data-ui-region="object-list-panel" className="flex flex-col gap-1.5 w-full">
         {orderedElements.map((element) => (
           <ObjectListRow key={element.id} element={element} />
         ))}

--- a/app/renderer/features/canvas/object-list-row.tsx
+++ b/app/renderer/features/canvas/object-list-row.tsx
@@ -19,10 +19,7 @@ export function ObjectListRow({ element }: ObjectListRowProps) {
   }
 
   return (
-    <SelectableRow.Root
-      selected={selected}
-      onClick={handleSelect}
-    >
+    <SelectableRow.Root selected={selected} onClick={handleSelect} className='w-full' >
       <SelectableRow.Leading>
         <TypeIcon type={element.type} />
       </SelectableRow.Leading>

--- a/app/renderer/features/canvas/scene-types.ts
+++ b/app/renderer/features/canvas/scene-types.ts
@@ -1,7 +1,7 @@
 import type { Id, Slide, SlideElement } from '@core/types';
 import type { VisualPayloadState } from '@core/element-payload';
 
-export type SceneSurface = 'deck-editor' | 'show' | 'list';
+export type SceneSurface = 'deck-editor' | 'show' | 'list' | 'monitor' | 'stage';
 export type SceneSourcePolicy = 'draft' | 'persisted' | 'live';
 
 export type ResolvedMediaState =

--- a/app/renderer/features/canvas/stage-panel.tsx
+++ b/app/renderer/features/canvas/stage-panel.tsx
@@ -1,12 +1,8 @@
-import { isLyricDeckItem } from '@core/deck-items';
-import { Globe, Image, PencilLine, Square, Type } from 'lucide-react';
-import { ReacstButton } from '@renderer/components 2.0/button';
+import { Image, Square, Type } from 'lucide-react';
+import { ReacstButtonGroup } from '@renderer/components/controls/button-group';
 import { MediaPickerDialog } from '../../components/overlays/media-picker-dialog';
-import { useCast } from '../../contexts/app-context';
 import { useElements } from '../../contexts/canvas/canvas-context';
-import { useNavigation } from '../../contexts/navigation-context';
-import { useTemplateEditor } from '../../contexts/asset-editor/asset-editor-context';
-import { useWorkbench } from '../../contexts/workbench-context';
+import { useActiveEditorSource } from '../../contexts/canvas/use-active-editor-source';
 import { useStagePanelController } from './use-stage-panel-controller';
 import { StageViewport } from './stage-viewport';
 import { EmptyState } from '../../components/display/empty-state';
@@ -20,24 +16,12 @@ export function StagePanel() {
   const { actions, state } = useStagePanelController();
   const { x, y, width, height } = state.selectionMetrics;
   const { createText, createShape } = useElements();
-  const { setStatusText } = useCast();
-  const { currentDeckItem } = useNavigation();
-  const { currentTemplate } = useTemplateEditor();
-  const { state: { workbenchMode } } = useWorkbench();
-  const hideAddText = workbenchMode === 'deck-editor'
-    ? isLyricDeckItem(currentDeckItem)
-    : workbenchMode === 'template-editor'
-      ? currentTemplate?.kind === 'lyrics'
-      : false;
+  const activeEditorSource = useActiveEditorSource();
 
   function handleAddMedia() {
     if (actions.openMediaPicker) {
       actions.openMediaPicker();
     }
-  }
-
-  function handleUnavailable() {
-    setStatusText('This element type is not yet available.');
   }
 
   return (
@@ -50,25 +34,23 @@ export function StagePanel() {
           <>
             <StageViewport />
             <div className="pointer-events-none absolute inset-x-0 top-4 flex justify-center">
-              <div className="pointer-events-auto flex items-center gap-0.5 rounded-lg border border-primary bg-tertiary/90 px-1 py-0.5 shadow-2xl backdrop-blur-sm">
-                {!hideAddText ? (
-                  <ReacstButton.Icon label="Add Text" onClick={createText}>
-                    <Type size={18} strokeWidth={1.5} />
-                  </ReacstButton.Icon>
+              <ReacstButtonGroup.Root className="pointer-events-auto">
+                {activeEditorSource.createCapabilities.text ? (
+                  <ReacstButtonGroup.Icon native label="Add text" onClick={createText}>
+                    <Type strokeWidth={1.5} />
+                  </ReacstButtonGroup.Icon>
                 ) : null}
-                <ReacstButton.Icon label="Add Shape" onClick={createShape}>
-                  <Square size={18} strokeWidth={1.5} />
-                </ReacstButton.Icon>
-                <ReacstButton.Icon label="Add Media" onClick={handleAddMedia}>
-                  <Image size={18} strokeWidth={1.5} />
-                </ReacstButton.Icon>
-                <ReacstButton.Icon label="Draw Path" onClick={handleUnavailable} disabled>
-                  <PencilLine size={18} strokeWidth={1.5} />
-                </ReacstButton.Icon>
-                <ReacstButton.Icon label="Add Web Source" onClick={handleUnavailable} disabled>
-                  <Globe size={18} strokeWidth={1.5} />
-                </ReacstButton.Icon>
-              </div>
+                {activeEditorSource.createCapabilities.shape ? (
+                  <ReacstButtonGroup.Icon native label="Add shape" onClick={createShape}>
+                    <Square strokeWidth={1.5} />
+                  </ReacstButtonGroup.Icon>
+                ) : null}
+                {activeEditorSource.createCapabilities.media ? (
+                  <ReacstButtonGroup.Icon native label="Add media" onClick={handleAddMedia}>
+                    <Image strokeWidth={1.5} />
+                  </ReacstButtonGroup.Icon>
+                ) : null}
+              </ReacstButtonGroup.Root>
             </div>
             {state.showMediaPicker ? (
               <MediaPickerDialog

--- a/app/renderer/features/canvas/use-stage-panel-controller.ts
+++ b/app/renderer/features/canvas/use-stage-panel-controller.ts
@@ -1,10 +1,8 @@
 import { useCallback, useMemo, useState } from 'react';
 import type { MediaAsset } from '@core/types';
 import { useElements } from '../../contexts/canvas/canvas-context';
-import { useOverlayEditor, useTemplateEditor } from '../../contexts/asset-editor/asset-editor-context';
-import { useSlides } from '../../contexts/slide-context';
+import { useActiveEditorSource } from '../../contexts/canvas/use-active-editor-source';
 import { useProjectContent } from '../../contexts/use-project-content';
-import { useWorkbench } from '../../contexts/workbench-context';
 
 interface SelectionMetrics {
   x: number | null;
@@ -33,21 +31,15 @@ interface StagePanelController {
 }
 
 export function useStagePanelController(): StagePanelController {
-  const { currentSlide } = useSlides();
-  const { currentOverlay } = useOverlayEditor();
-  const { currentTemplate } = useTemplateEditor();
+  const activeEditorSource = useActiveEditorSource();
   const { selectedElement, elementDraft, createFromMedia } = useElements();
-  const { state: { workbenchMode } } = useWorkbench();
   const { mediaAssets } = useProjectContent();
   const [showMediaPicker, setShowMediaPicker] = useState(false);
 
   const state = useMemo<StagePanelControllerState>(() => {
-    const isOverlayEdit = workbenchMode === 'overlay-editor';
-    const isTemplateEdit = workbenchMode === 'template-editor';
-
     return {
-      emptyStateLabel: isOverlayEdit ? 'No overlay selected.' : isTemplateEdit ? 'No template selected.' : 'No slide selected.',
-      hasCanvasSource: isOverlayEdit ? Boolean(currentOverlay) : isTemplateEdit ? Boolean(currentTemplate) : Boolean(currentSlide),
+      emptyStateLabel: activeEditorSource.emptyStateLabel,
+      hasCanvasSource: activeEditorSource.editable && activeEditorSource.hasSource,
       mediaAssets,
       selectionMetrics: {
         x: elementDraft?.x ?? selectedElement?.x ?? null,
@@ -57,7 +49,7 @@ export function useStagePanelController(): StagePanelController {
       },
       showMediaPicker
     };
-  }, [currentOverlay, currentSlide, currentTemplate, elementDraft, mediaAssets, selectedElement, showMediaPicker, workbenchMode]);
+  }, [activeEditorSource, elementDraft, mediaAssets, selectedElement, showMediaPicker]);
 
   const openMediaPicker = useCallback(() => {
     setShowMediaPicker(true);

--- a/app/renderer/features/canvas/use-stage-viewport-controller.ts
+++ b/app/renderer/features/canvas/use-stage-viewport-controller.ts
@@ -1,8 +1,8 @@
 import { useCallback, useMemo, useRef } from 'react';
 import type { MediaAsset } from '@core/types';
 import { useElements, useRenderScenes } from '../../contexts/canvas/canvas-context';
+import { useActiveEditorSource } from '../../contexts/canvas/use-active-editor-source';
 import { useInspector } from './inspector-context';
-import { useWorkbench } from '../../contexts/workbench-context';
 import { mapViewportPointToScene, type SceneViewportTransform } from './use-scene-stage-viewport';
 
 interface StageViewportControllerActions {
@@ -32,11 +32,11 @@ function parseDraggedMedia(raw: string): MediaAsset | null {
 }
 
 export function useStageViewportController(): StageViewportController {
-  const { state: { workbenchMode } } = useWorkbench();
+  const activeEditorSource = useActiveEditorSource();
   const { setInspectorTab } = useInspector();
   const { editScene, showScene } = useRenderScenes();
   const { createFromMedia } = useElements();
-  const editable = workbenchMode === 'deck-editor' || workbenchMode === 'overlay-editor' || workbenchMode === 'template-editor';
+  const editable = activeEditorSource.editable;
   const scene = editable ? editScene : showScene;
   const viewportRef = useRef<SceneViewportTransform>({
     viewportWidth: scene.width,

--- a/app/renderer/features/playback/ndi-frame-capture.tsx
+++ b/app/renderer/features/playback/ndi-frame-capture.tsx
@@ -2,22 +2,22 @@ import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { Stage, Layer, Group } from 'react-konva';
 import type Konva from 'konva';
 import { NDI_OUTPUT_WIDTH, NDI_OUTPUT_HEIGHT } from '@core/ndi';
+import type { NdiOutputName } from '@core/types';
 import { useNdi } from '../../contexts/app-context';
-import { useRenderScenes } from '../../contexts/canvas/canvas-context';
 import { SceneNodeMedia } from '../canvas/scene-node-media';
 import { SceneNodeShape } from '../canvas/scene-node-shape';
 import { SceneNodeText } from '../canvas/scene-node-text';
-import type { RenderNode } from '../canvas/scene-types';
+import type { RenderNode, RenderScene, SceneSurface } from '../canvas/scene-types';
 
 const FRAME_INTERVAL_MS = 1000 / 30;
 // If the scene doesn't change for this long, send a heartbeat frame so
 // NDI receivers don't flag the stream as stale.
 const HEARTBEAT_MS = 500;
 
-function renderNodeContent(node: RenderNode, onImageLoad?: () => void) {
+function renderNodeContent(node: RenderNode, surface: SceneSurface, onImageLoad?: () => void) {
   if (node.element.type === 'shape') return <SceneNodeShape node={node} />;
   if (node.element.type === 'text') return <SceneNodeText node={node} />;
-  if (node.element.type === 'image' || node.element.type === 'video') return <SceneNodeMedia node={node} surface="show" onLoad={onImageLoad} />;
+  if (node.element.type === 'image' || node.element.type === 'video') return <SceneNodeMedia node={node} surface={surface} onLoad={onImageLoad} />;
   return null;
 }
 
@@ -32,17 +32,26 @@ function sceneSignature(nodes: readonly RenderNode[], withAlpha: boolean): strin
   return out;
 }
 
-export function NdiFrameCapture() {
-  const { state: { outputState, outputConfigs } } = useNdi();
-  const { programScene } = useRenderScenes();
+interface NdiFrameCaptureProps {
+  /** Which named NDI output this capture feeds (must match a configured sender). */
+  senderName: NdiOutputName;
+  /** Scene to render off-screen and ship as frames. */
+  scene: RenderScene;
+  /** Logical surface used by element renderers (e.g. media surface routing). */
+  surface?: SceneSurface;
+  /** When false the capture loop is torn down and the off-screen stage is unmounted. */
+  enabled: boolean;
+}
+
+export function NdiFrameCapture({ senderName, scene, surface = 'show', enabled }: NdiFrameCaptureProps) {
+  const { state: { outputConfigs } } = useNdi();
   const stageRef = useRef<Konva.Stage>(null);
   const normalizedCanvasRef = useRef<HTMLCanvasElement | null>(null);
   const normalizedContextRef = useRef<CanvasRenderingContext2D | null>(null);
   const frameBufferRef = useRef<Uint8Array | null>(null);
-  const enabled = outputState.audience;
   const hasVideoNodes = useMemo(
-    () => programScene.nodes.some((node) => node.element.type === 'video'),
-    [programScene.nodes],
+    () => scene.nodes.some((node) => node.element.type === 'video'),
+    [scene.nodes],
   );
 
   const getReadbackContext = useCallback((sourceCanvas: HTMLCanvasElement): CanvasRenderingContext2D | null => {
@@ -100,11 +109,11 @@ export function NdiFrameCapture() {
         frameBufferRef.current = new Uint8Array(requiredSize);
       }
       frameBufferRef.current.set(imageData.data);
-      window.castApi.sendNdiFrame(frameBufferRef.current.buffer as ArrayBuffer, NDI_OUTPUT_WIDTH, NDI_OUTPUT_HEIGHT);
+      window.castApi.sendNdiFrame(senderName, frameBufferRef.current.buffer as ArrayBuffer, NDI_OUTPUT_WIDTH, NDI_OUTPUT_HEIGHT);
     } catch (error) {
       console.error('[NdiFrameCapture] Frame capture failed:', error);
     }
-  }, [getReadbackContext]);
+  }, [getReadbackContext, senderName]);
 
   const handleImageLoad = useCallback(() => {
     stageRef.current?.batchDraw();
@@ -115,7 +124,7 @@ export function NdiFrameCapture() {
   // the scene hasn't changed and there are no video nodes, so an idle output
   // costs ~zero IPC traffic. Sends a heartbeat frame every HEARTBEAT_MS so
   // NDI receivers don't think the source died.
-  const withAlpha = outputConfigs.audience.withAlpha;
+  const withAlpha = outputConfigs[senderName].withAlpha;
   useEffect(() => {
     if (!enabled) return;
 
@@ -129,7 +138,7 @@ export function NdiFrameCapture() {
       if (!running) return;
       if (timestamp - lastCaptureTime >= FRAME_INTERVAL_MS) {
         lastCaptureTime = timestamp;
-        const currentSignature = sceneSignature(programScene.nodes, withAlpha);
+        const currentSignature = sceneSignature(scene.nodes, withAlpha);
         const signatureChanged = currentSignature !== lastSignature;
         const heartbeatDue = timestamp - lastSentTime >= HEARTBEAT_MS;
         if (signatureChanged || hasVideoNodes || heartbeatDue) {
@@ -147,7 +156,7 @@ export function NdiFrameCapture() {
       running = false;
       if (rafId !== null) cancelAnimationFrame(rafId);
     };
-  }, [captureFrame, enabled, hasVideoNodes, programScene, withAlpha]);
+  }, [captureFrame, enabled, hasVideoNodes, scene, withAlpha]);
 
   if (!enabled) return null;
 
@@ -208,7 +217,7 @@ export function NdiFrameCapture() {
             </Group>
           ) : null}
           <Group>
-            {programScene.nodes.map((node) => {
+            {scene.nodes.map((node) => {
               if (node.visual.visible === false) return null;
               return (
                 <Group
@@ -224,7 +233,7 @@ export function NdiFrameCapture() {
                   offsetX={node.visual.flipX ? node.element.width : 0}
                   offsetY={node.visual.flipY ? node.element.height : 0}
                 >
-                  {renderNodeContent(node, handleImageLoad)}
+                  {renderNodeContent(node, surface, handleImageLoad)}
                 </Group>
               );
             })}

--- a/app/renderer/features/playback/ndi-outputs.tsx
+++ b/app/renderer/features/playback/ndi-outputs.tsx
@@ -1,0 +1,36 @@
+import { useNdi } from '../../contexts/app-context';
+import { useRenderScenes } from '../../contexts/canvas/canvas-context';
+import { NdiFrameCapture } from './ndi-frame-capture';
+import { useStageScene } from './use-stage-scene';
+
+// Mounts one NdiFrameCapture per configured NDI output. Each instance owns its
+// own off-screen Konva stage and capture loop — they only run when their
+// respective output is enabled. Routing rules:
+//  - audience  → programScene (program-out, surface 'show')
+//  - stage     → active stage layout's elements (surface 'stage')
+//
+// The stage feed is fed from the operator-selected stage layout via
+// `useStageScene()`. When no stage is selected the scene is empty and the
+// off-screen stage renders a black frame.
+export function NdiOutputs() {
+  const { state: { outputState } } = useNdi();
+  const { programScene } = useRenderScenes();
+  const stageScene = useStageScene();
+
+  return (
+    <>
+      <NdiFrameCapture
+        senderName="audience"
+        scene={programScene}
+        surface="show"
+        enabled={outputState.audience}
+      />
+      <NdiFrameCapture
+        senderName="stage"
+        scene={stageScene}
+        surface="stage"
+        enabled={outputState.stage}
+      />
+    </>
+  );
+}

--- a/app/renderer/features/playback/output-settings-panel.tsx
+++ b/app/renderer/features/playback/output-settings-panel.tsx
@@ -1,25 +1,20 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
+import type { NdiOutputName } from '@core/types';
 import { FieldCheckbox as CheckboxField, FieldInput } from '../../components/form/field';
 import { useNdi } from '../../contexts/app-context';
 
+const OUTPUT_TITLES: Record<NdiOutputName, string> = {
+  audience: 'Audience NDI',
+  stage: 'Stage NDI',
+};
+
+const OUTPUT_DESCRIPTIONS: Record<NdiOutputName, string | null> = {
+  audience: null,
+  stage: 'Output dedicated to a presenter / on-stage monitor. Renders the active stage layout selected from the Show screen.',
+};
+
 export function OutputSettingsPanel() {
-  const { state: { outputState, outputConfigs, diagnostics }, actions: { setOutputEnabled, updateOutputConfig } } = useNdi();
-  const config = outputConfigs.audience;
-  const [senderNameDraft, setSenderNameDraft] = useState(config.senderName);
-
-  function handleSetOutputEnabled(enabled: boolean) {
-    setOutputEnabled('audience', enabled);
-  }
-
-  function handleCommitSenderName() {
-    if (senderNameDraft.trim() && senderNameDraft !== config.senderName) {
-      updateOutputConfig('audience', { senderName: senderNameDraft.trim() });
-    }
-  }
-
-  const handleSetWithAlpha = useCallback((withAlpha: boolean) => {
-    updateOutputConfig('audience', { withAlpha });
-  }, [updateOutputConfig]);
+  const { state: { diagnostics } } = useNdi();
 
   return (
     <div className="flex flex-col gap-6">
@@ -30,20 +25,8 @@ export function OutputSettingsPanel() {
         <p className="text-sm text-tertiary">System display output is not wired yet.</p>
       </section>
 
-      <section className="flex flex-col gap-3 border-b border-primary pb-5">
-        <header className="flex items-center justify-between gap-3">
-          <h2 className="text-sm font-semibold text-primary">Audience NDI</h2>
-        </header>
-        <CheckboxField checked={outputState.audience} label="Enabled" onChange={handleSetOutputEnabled} />
-        <div className="flex flex-col gap-3">
-          <FieldInput label="Sender name" value={senderNameDraft} onChange={setSenderNameDraft} onBlur={handleCommitSenderName} wide />
-        </div>
-        <CheckboxField checked={config.withAlpha} label="Include alpha channel" onChange={handleSetWithAlpha} />
-        <p className="text-sm text-tertiary">
-          Leave this off for normal audience playback. In NDI Studio Monitor, also disable `Show the NDI source&apos;s Alpha Channel`
-          unless you intentionally want to view the matte.
-        </p>
-      </section>
+      <OutputControls name="audience" />
+      <OutputControls name="stage" />
 
       <section className="flex flex-col gap-3">
         <header className="flex items-center justify-between gap-3">
@@ -65,5 +48,57 @@ export function OutputSettingsPanel() {
         )}
       </section>
     </div>
+  );
+}
+
+// Per-output controls block. Rendered once per `NdiOutputName` so audience and
+// stage senders are configured side-by-side with identical UX.
+function OutputControls({ name }: { name: NdiOutputName }) {
+  const { state: { outputState, outputConfigs }, actions: { setOutputEnabled, updateOutputConfig } } = useNdi();
+  const config = outputConfigs[name];
+  const enabled = outputState[name];
+  const [senderNameDraft, setSenderNameDraft] = useState(config.senderName);
+
+  // Re-sync the input draft when the persisted name changes from elsewhere
+  // (e.g. another window committing a rename).
+  useEffect(() => {
+    setSenderNameDraft(config.senderName);
+  }, [config.senderName]);
+
+  function handleSetOutputEnabled(value: boolean) {
+    setOutputEnabled(name, value);
+  }
+
+  function handleCommitSenderName() {
+    const trimmed = senderNameDraft.trim();
+    if (trimmed && trimmed !== config.senderName) {
+      updateOutputConfig(name, { senderName: trimmed });
+    } else if (!trimmed) {
+      setSenderNameDraft(config.senderName);
+    }
+  }
+
+  const handleSetWithAlpha = useCallback((withAlpha: boolean) => {
+    updateOutputConfig(name, { withAlpha });
+  }, [name, updateOutputConfig]);
+
+  const description = OUTPUT_DESCRIPTIONS[name];
+
+  return (
+    <section className="flex flex-col gap-3 border-b border-primary pb-5">
+      <header className="flex items-center justify-between gap-3">
+        <h2 className="text-sm font-semibold text-primary">{OUTPUT_TITLES[name]}</h2>
+      </header>
+      {description ? <p className="text-sm text-tertiary">{description}</p> : null}
+      <CheckboxField checked={enabled} label="Enabled" onChange={handleSetOutputEnabled} />
+      <div className="flex flex-col gap-3">
+        <FieldInput label="Sender name" value={senderNameDraft} onChange={setSenderNameDraft} onBlur={handleCommitSenderName} wide />
+      </div>
+      <CheckboxField checked={config.withAlpha} label="Include alpha channel" onChange={handleSetWithAlpha} />
+      <p className="text-sm text-tertiary">
+        Leave alpha off for normal playback. In NDI Studio Monitor, also disable
+        &quot;Show the NDI source&apos;s Alpha Channel&quot; unless you intentionally want to view the matte.
+      </p>
+    </section>
   );
 }

--- a/app/renderer/features/playback/preview-panel.tsx
+++ b/app/renderer/features/playback/preview-panel.tsx
@@ -1,34 +1,42 @@
+import { useState } from 'react';
+import { ChevronDown, AlignLeft, Image, Layers, Layers2, LayoutGrid, Plus, RectangleHorizontal, VolumeX, XCircle } from 'lucide-react';
 import { NDI_OUTPUT_WIDTH, NDI_OUTPUT_HEIGHT } from '@core/ndi';
-import { AlignLeft, Image, Layers, Layers2, Plus, VolumeX, XCircle } from 'lucide-react';
 import { ReacstButton } from '@renderer/components 2.0/button';
-import { SceneFrame } from '../../components/display/scene-frame';
+import { RecastPanel } from '@renderer/components 2.0/panel';
+import { Tabs } from '../../components/display/tabs';
+import { Dropdown } from '../../components/form/dropdown';
 import { GridSizeSlider } from '../../components/form/grid-size-slider';
 import { IconGroup } from '@renderer/components/icon-group';
+import { useNdi } from '../../contexts/app-context';
 import { useNavigation } from '../../contexts/navigation-context';
-import { useOverlayEditor } from '../../contexts/asset-editor/asset-editor-context';
+import { useOverlayEditor, useStageEditor } from '../../contexts/asset-editor/asset-editor-context';
 import { useAudio, usePresentationLayers } from '../../contexts/playback/playback-context';
+import { useRenderScenes } from '../../contexts/canvas/canvas-context';
 import { useWorkbench } from '../../contexts/workbench-context';
 import { useGridSize } from '../../hooks/use-grid-size';
+import type { PreviewSurfaceKind } from '../../types/ui';
 import { OverlayBinPanel } from '../assets/overlays/overlay-bin-panel';
+import { StageBinPanel } from '../assets/stages/stage-bin-panel';
 import { useProgramOutput } from './use-program-output';
+import { useStageScene } from './use-stage-scene';
 import { SceneStage } from '../canvas/scene-stage';
-import { RecastPanel } from '@renderer/components 2.0/panel';
-import { Label } from '@renderer/components/display/text';
+
+type BottomTab = 'overlays' | 'stage';
 
 export function PreviewPanel() {
   const { clearLayer, clearAllLayers, mediaLayerAsset, contentLayerVisible, activeOverlays, overlayMode, setOverlayMode } = usePresentationLayers();
   const { currentOutputDeckItemId } = useNavigation();
   const audio = useAudio();
-  const { scene, background } = useProgramOutput();
   const { createOverlay } = useOverlayEditor();
+  const { createStage } = useStageEditor();
   const { actions: { setWorkbenchMode } } = useWorkbench();
-  const { gridSize, setGridSize, min, max } = useGridSize('recast.grid-size.overlay-bin', 3, 2, 4);
+  const { gridSize: overlayGridSize, setGridSize: setOverlayGridSize, min: overlayGridMin, max: overlayGridMax } = useGridSize('recast.grid-size.overlay-bin', 3, 2, 4);
+  const { gridSize: stageGridSize, setGridSize: setStageGridSize, min: stageGridMin, max: stageGridMax } = useGridSize('recast.grid-size.stage-bin', 3, 2, 4);
+  const [bottomTab, setBottomTab] = useState<BottomTab>('overlays');
   const mediaActive = Boolean(mediaLayerAsset);
   const contentActive = contentLayerVisible && Boolean(currentOutputDeckItemId);
   const overlayActive = activeOverlays.length > 0;
   const audioActive = audio.isPlaying || audio.currentTime > 0;
-  const checkerboard = background === 'transparent';
-  const stageClassName = checkerboard ? 'bg-transparent' : 'bg-black';
 
   function handleClearMedia() { clearLayer('media'); }
   function handleClearContent() { clearLayer('content'); }
@@ -39,7 +47,7 @@ export function PreviewPanel() {
     clearAllLayers();
   }
 
-  function handleModeToggle() {
+  function handleOverlayModeToggle() {
     setOverlayMode(overlayMode === 'single' ? 'multiple' : 'single');
   }
 
@@ -49,14 +57,28 @@ export function PreviewPanel() {
     });
   }
 
-  const modeLabel = overlayMode === 'single' ? 'Single overlay mode — click to allow multiple' : 'Multiple overlay mode — click for single';
+  function handleCreateStage() {
+    void createStage().then(() => {
+      setWorkbenchMode('stage-editor');
+    });
+  }
+
+  function handleTabChange(value: string) {
+    if (value === 'overlays' || value === 'stage') setBottomTab(value);
+  }
+
+  const overlayModeLabel = overlayMode === 'single' ? 'Single overlay mode — click to allow multiple' : 'Multiple overlay mode — click for single';
+  const showOverlayActions = bottomTab === 'overlays';
+  const activeGridSize = bottomTab === 'overlays' ? overlayGridSize : stageGridSize;
+  const activeGridMin = bottomTab === 'overlays' ? overlayGridMin : stageGridMin;
+  const activeGridMax = bottomTab === 'overlays' ? overlayGridMax : stageGridMax;
+  const handleActiveGridSizeChange = bottomTab === 'overlays' ? setOverlayGridSize : setStageGridSize;
 
   return (
     <RecastPanel.Root className='h-full border-l border-secondary' >
       <RecastPanel.Group>
-        <SceneFrame width={NDI_OUTPUT_WIDTH} height={NDI_OUTPUT_HEIGHT} checkerboard={checkerboard} stageClassName={stageClassName} >
-          <SceneStage scene={scene} surface="show" className="h-full w-full" />
-        </SceneFrame>
+        <PreviewModeHeader />
+        <SurfacesArea />
         <IconGroup.Root fill className='rounded-none' >
           <IconGroup.Item aria-label="Clear all layers" title="Clear all layers" onClick={handleClearAll}>
             <XCircle className="size-4" />
@@ -76,22 +98,197 @@ export function PreviewPanel() {
         </IconGroup.Root>
       </RecastPanel.Group>
       <RecastPanel.Group className='flex-1' >
-        <RecastPanel.GroupTitle>
-          <Label.xs className="mr-auto">Overlays</Label.xs>
-          <ReacstButton.Icon label={modeLabel} variant="ghost" onClick={handleModeToggle}>
-            {overlayMode === 'single' ? <Layers /> : <Layers2 />}
-          </ReacstButton.Icon>
-          <ReacstButton.Icon label="Add overlay" onClick={handleCreateOverlay}>
-            <Plus />
-          </ReacstButton.Icon>
-        </RecastPanel.GroupTitle>
-        <RecastPanel.Content className='flex-1 py-2 px-1'>
-          <OverlayBinPanel filterText="" gridItemSize={gridSize} />
-        </RecastPanel.Content>
-        <RecastPanel.GroupFooter>
-          <GridSizeSlider value={gridSize} min={min} max={max} onChange={setGridSize} />
-        </RecastPanel.GroupFooter>
+        <Tabs.Root value={bottomTab} onValueChange={handleTabChange}>
+          <RecastPanel.GroupTitle>
+            <Tabs.List label="Bottom panel" className="mr-auto" tabsClassName="gap-2">
+              <Tabs.Trigger value="overlays">Overlays</Tabs.Trigger>
+              <Tabs.Trigger value="stage">Stage</Tabs.Trigger>
+            </Tabs.List>
+            {showOverlayActions ? (
+              <>
+                <ReacstButton.Icon label={overlayModeLabel} variant="ghost" onClick={handleOverlayModeToggle}>
+                  {overlayMode === 'single' ? <Layers /> : <Layers2 />}
+                </ReacstButton.Icon>
+                <ReacstButton.Icon label="Add overlay" onClick={handleCreateOverlay}>
+                  <Plus />
+                </ReacstButton.Icon>
+              </>
+            ) : (
+              <ReacstButton.Icon label="Add stage" onClick={handleCreateStage}>
+                <Plus />
+              </ReacstButton.Icon>
+            )}
+          </RecastPanel.GroupTitle>
+          <RecastPanel.Content className='flex-1 py-2 px-1'>
+            {bottomTab === 'overlays' ? (
+              <OverlayBinPanel filterText="" gridItemSize={overlayGridSize} />
+            ) : (
+              <StageBinPanel filterText="" gridItemSize={stageGridSize} />
+            )}
+          </RecastPanel.Content>
+          <RecastPanel.GroupFooter>
+            <GridSizeSlider value={activeGridSize} min={activeGridMin} max={activeGridMax} onChange={handleActiveGridSizeChange} />
+          </RecastPanel.GroupFooter>
+        </Tabs.Root>
       </RecastPanel.Group>
     </RecastPanel.Root>
+  );
+}
+
+const SURFACE_LABELS: Record<PreviewSurfaceKind, string> = {
+  preview: 'Preview',
+  monitor: 'Monitor',
+  stage: 'Stage',
+};
+
+const SURFACE_ORDER: PreviewSurfaceKind[] = ['preview', 'monitor', 'stage'];
+
+function PreviewModeHeader() {
+  const {
+    state: { previewMode, previewSingleSurface, previewGridDensity },
+    actions: { setPreviewMode, setPreviewSingleSurface, setPreviewGridDensity },
+  } = useWorkbench();
+
+  function handleModeToggle() {
+    setPreviewMode(previewMode === 'single' ? 'all' : 'single');
+  }
+
+  function handleSurfacePick(surface: PreviewSurfaceKind) {
+    setPreviewSingleSurface(surface);
+  }
+
+  function handleDensityChange(next: number) {
+    if (next !== 1 && next !== 2) return;
+    setPreviewGridDensity(next);
+  }
+
+  return (
+    <RecastPanel.GroupTitle>
+      <ReacstButton.Icon
+        variant="ghost"
+        label={previewMode === 'single' ? 'Switch to all previews' : 'Switch to single preview'}
+        onClick={handleModeToggle}
+      >
+        {previewMode === 'single' ? <RectangleHorizontal /> : <LayoutGrid />}
+      </ReacstButton.Icon>
+      {previewMode === 'single' ? (
+        <Dropdown className="ml-auto">
+          <Dropdown.Trigger className="flex min-w-0 items-center gap-1 rounded-sm bg-tertiary px-2 py-1 text-sm text-primary transition-colors hover:bg-quaternary">
+            <span className="truncate">{SURFACE_LABELS[previewSingleSurface]}</span>
+            <ChevronDown className="size-3.5 shrink-0 text-tertiary" />
+          </Dropdown.Trigger>
+          <Dropdown.Panel placement="bottom-end">
+            {SURFACE_ORDER.map((kind) => (
+              <Dropdown.Item key={kind} onClick={() => handleSurfacePick(kind)}>
+                {SURFACE_LABELS[kind]}
+              </Dropdown.Item>
+            ))}
+          </Dropdown.Panel>
+        </Dropdown>
+      ) : (
+        <span className="ml-auto">
+          <GridSizeSlider value={previewGridDensity} min={1} max={2} onChange={handleDensityChange} />
+        </span>
+      )}
+    </RecastPanel.GroupTitle>
+  );
+}
+
+function SurfacesArea() {
+  const {
+    state: { previewMode, previewSingleSurface, previewGridDensity },
+  } = useWorkbench();
+
+  if (previewMode === 'single') {
+    return (
+      <div className="w-full">
+        <Surface kind={previewSingleSurface} showBadge={false} />
+      </div>
+    );
+  }
+
+  // All-mode grid: slider value IS the column count. 1 = stacked vertically,
+  // 2 = two columns. Each cell is a 16:9 frame so rows auto-size to identical
+  // heights regardless of which surface (Preview/Monitor/Stage) lands in them.
+  const columnCount = previewGridDensity;
+  return (
+    <div
+      className="grid w-full gap-1"
+      style={{ gridTemplateColumns: `repeat(${columnCount}, minmax(0, 1fr))` }}
+    >
+      {SURFACE_ORDER.map((kind) => (
+        <Surface key={kind} kind={kind} showBadge />
+      ))}
+    </div>
+  );
+}
+
+function Surface({ kind, showBadge }: { kind: PreviewSurfaceKind; showBadge: boolean }) {
+  if (kind === 'preview') return <PreviewSurface showBadge={showBadge} />;
+  if (kind === 'monitor') return <MonitorSurface showBadge={showBadge} />;
+  return <StageSurface showBadge={showBadge} />;
+}
+
+function PreviewSurface({ showBadge }: { showBadge: boolean }) {
+  const { scene, background } = useProgramOutput();
+  const checkerboard = background === 'transparent';
+
+  return (
+    <SurfaceFrame label="Preview" showLabel={showBadge} checkerboard={checkerboard}>
+      <SceneStage scene={scene} surface="show" className="h-full w-full" />
+    </SurfaceFrame>
+  );
+}
+
+function MonitorSurface({ showBadge }: { showBadge: boolean }) {
+  const { showScene } = useRenderScenes();
+  // Monitor mirrors what's about to go to the audience NDI feed, so its
+  // transparent-background indicator follows the audience output's alpha
+  // config. With alpha on, the checker shows through wherever the scene
+  // lacks an opaque fill — easier to spot transparent text/elements.
+  const { state: { outputConfigs } } = useNdi();
+  const checkerboard = outputConfigs.audience.withAlpha;
+
+  return (
+    <SurfaceFrame label="Monitor" showLabel={showBadge} checkerboard={checkerboard}>
+      <SceneStage scene={showScene} surface="monitor" className="h-full w-full" />
+    </SurfaceFrame>
+  );
+}
+
+function StageSurface({ showBadge }: { showBadge: boolean }) {
+  const stageScene = useStageScene();
+  // Mirrors the configured alpha for the stage NDI sender so the operator
+  // sees exactly what the stage feed would look like over a transparent base.
+  const { state: { outputConfigs } } = useNdi();
+  const checkerboard = outputConfigs.stage.withAlpha;
+
+  return (
+    <SurfaceFrame label="Stage" showLabel={showBadge} checkerboard={checkerboard}>
+      <SceneStage scene={stageScene} surface="stage" className="h-full w-full" />
+    </SurfaceFrame>
+  );
+}
+
+// Single 16:9 frame used by every surface so grid rows auto-size to identical
+// heights and the panel label (in all-mode only) can float on top instead of
+// stealing a row above. In single mode the dropdown already names the surface,
+// so the floating badge would be redundant.
+function SurfaceFrame({ label, showLabel, checkerboard = false, children }: { label: string; showLabel: boolean; checkerboard?: boolean; children: React.ReactNode }) {
+  return (
+    <div
+      className="relative w-full overflow-hidden bg-black"
+      style={{ aspectRatio: `${NDI_OUTPUT_WIDTH} / ${NDI_OUTPUT_HEIGHT}` }}
+    >
+      {checkerboard ? (
+        <div className="pointer-events-none absolute inset-0 bg-[repeating-conic-gradient(var(--color-background-tertiary)_0%_25%,var(--color-background-quaternary)_0%_50%)] bg-[length:24px_24px]" />
+      ) : null}
+      <div className="absolute inset-0">{children}</div>
+      {showLabel ? (
+        <span className="pointer-events-none absolute left-1.5 top-1.5 z-10 rounded-sm bg-black/60 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-white backdrop-blur-sm">
+          {label}
+        </span>
+      ) : null}
+    </div>
   );
 }

--- a/app/renderer/features/playback/use-stage-scene.ts
+++ b/app/renderer/features/playback/use-stage-scene.ts
@@ -1,0 +1,18 @@
+import { useMemo } from 'react';
+import { buildRenderScene } from '../canvas/build-render-scene';
+import type { RenderScene } from '../canvas/scene-types';
+import { useStagePlayback } from '../../contexts/playback/playback-context';
+import { useProjectContent } from '../../contexts/use-project-content';
+
+// Resolves the RenderScene for the operator-selected stage layout. Returns an
+// empty scene when no stage is active so consumers can always render without
+// conditional logic.
+export function useStageScene(): RenderScene {
+  const { currentStageId } = useStagePlayback();
+  const { stagesById } = useProjectContent();
+
+  return useMemo(() => {
+    const stage = currentStageId ? stagesById.get(currentStageId) ?? null : null;
+    return buildRenderScene(null, stage?.elements ?? []);
+  }, [currentStageId, stagesById]);
+}

--- a/app/renderer/features/workbench/app-toolbar.tsx
+++ b/app/renderer/features/workbench/app-toolbar.tsx
@@ -41,7 +41,7 @@ export interface PanelToggleButton {
 export function AppToolbar() {
   const { state: { workbenchMode }, actions: { setWorkbenchMode } } = useWorkbench();
   const panelToggles = useWorkbenchPanelToggles();
-  const { state: { outputState }, actions: { toggleAudienceOutput } } = useNdi();
+  const { state: { outputState }, actions: { toggleAudienceOutput, toggleStageOutput } } = useNdi();
 
   const activePanelIds = useMemo(
     () => panelToggles.filter((toggle) => toggle.active).map((toggle) => toggle.id),
@@ -76,6 +76,7 @@ export function AppToolbar() {
           <SegmentedControl.Label value="deck-editor">Edit</SegmentedControl.Label>
           <SegmentedControl.Label value="overlay-editor">Overlay</SegmentedControl.Label>
           <SegmentedControl.Label value="template-editor">Templates</SegmentedControl.Label>
+          <SegmentedControl.Label value="stage-editor">Stage</SegmentedControl.Label>
         </SegmentedControl>
       </div>
 
@@ -91,6 +92,16 @@ export function AppToolbar() {
         >
           <span className={outputDotStyles({ active: outputState.audience })} aria-hidden="true" />
           <span className="text-primary">Audience</span>
+        </ReacstButton>
+        <ReacstButton
+          variant="ghost"
+          onClick={toggleStageOutput}
+          type="button"
+          className={outputBorderStyles({ active: outputState.stage })}
+          aria-pressed={outputState.stage}
+        >
+          <span className={outputDotStyles({ active: outputState.stage })} aria-hidden="true" />
+          <span className="text-primary">Stage</span>
         </ReacstButton>
 
         <SegmentedControl
@@ -120,7 +131,7 @@ function renderPanelToggleItem(toggle: PanelToggleButton) {
 }
 
 function isWorkbenchMode(value: string): value is WorkbenchMode {
-  return value === 'show' || value === 'deck-editor' || value === 'overlay-editor' || value === 'template-editor' || value === 'settings';
+  return value === 'show' || value === 'deck-editor' || value === 'overlay-editor' || value === 'template-editor' || value === 'stage-editor' || value === 'settings';
 }
 
 function panelToggleIcon(id: PanelToggleButton['id']) {

--- a/app/renderer/features/workbench/bin-panel-layout.tsx
+++ b/app/renderer/features/workbench/bin-panel-layout.tsx
@@ -14,7 +14,7 @@ export function BinPanelLayout({ children, gridItemSize, mode = 'grid', listClas
   return (
     <>
       {mode === 'grid' ? (
-        <ThumbnailGrid columns={gridItemSize}>
+        <ThumbnailGrid columns={gridItemSize} className="w-full">
           {children}
         </ThumbnailGrid>
       ) : (

--- a/app/renderer/features/workbench/editor-header-actions.test.ts
+++ b/app/renderer/features/workbench/editor-header-actions.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { getEditorHeaderActions } from './editor-header-actions';
+
+describe('getEditorHeaderActions', () => {
+  it('limits overlay editor actions to overlay creation', () => {
+    expect(getEditorHeaderActions('overlay-editor')).toEqual([
+      { kind: 'create-overlay', label: 'New overlay' },
+    ]);
+  });
+
+  it('limits stage editor actions to stage creation', () => {
+    expect(getEditorHeaderActions('stage-editor')).toEqual([
+      { kind: 'create-stage', label: 'New stage' },
+    ]);
+  });
+
+  it('keeps template editor actions template-specific', () => {
+    expect(getEditorHeaderActions('template-editor')).toEqual([
+      { kind: 'create-template', label: 'New presentation template', templateKind: 'slides' },
+      { kind: 'create-template', label: 'New lyric template', templateKind: 'lyrics' },
+    ]);
+  });
+});

--- a/app/renderer/features/workbench/editor-header-actions.ts
+++ b/app/renderer/features/workbench/editor-header-actions.ts
@@ -1,0 +1,22 @@
+import type { TemplateKind } from '@core/types';
+import type { EditorWorkbenchMode } from '../../contexts/canvas/editor-source';
+
+export type EditorHeaderAction =
+  | { kind: 'create-overlay'; label: 'New overlay' }
+  | { kind: 'create-stage'; label: 'New stage' }
+  | { kind: 'create-template'; label: string; templateKind: Extract<TemplateKind, 'slides' | 'lyrics'> };
+
+export function getEditorHeaderActions(mode: Extract<EditorWorkbenchMode, 'overlay-editor' | 'template-editor' | 'stage-editor'>): EditorHeaderAction[] {
+  if (mode === 'overlay-editor') {
+    return [{ kind: 'create-overlay', label: 'New overlay' }];
+  }
+
+  if (mode === 'stage-editor') {
+    return [{ kind: 'create-stage', label: 'New stage' }];
+  }
+
+  return [
+    { kind: 'create-template', label: 'New presentation template', templateKind: 'slides' },
+    { kind: 'create-template', label: 'New lyric template', templateKind: 'lyrics' },
+  ];
+}

--- a/app/renderer/features/workbench/status-bar.tsx
+++ b/app/renderer/features/workbench/status-bar.tsx
@@ -16,6 +16,9 @@ export function StatusBar() {
   const { isRunningOperation, operationText, statusText } = useCast();
   const { state: { diagnostics, outputState } } = useNdi();
   const audienceStateLabel = diagnostics?.sourceStatus === 'live' ? 'Audience live' : 'Audience idle';
+  // Stage doesn't drive the global `sourceStatus` field, so we surface a simpler
+  // on/off label until per-sender diagnostics land.
+  const stageStateLabel = outputState.stage ? 'Stage live' : 'Stage idle';
   const displayText = isRunningOperation ? operationText ?? 'Processing...' : statusText;
 
   return (
@@ -28,10 +31,14 @@ export function StatusBar() {
         {displayText}
       </span>
 
-      <div className="ml-auto flex items-center gap-2 text-tertiary">
+      <div className="ml-auto flex items-center gap-3 text-tertiary">
         <span className="flex items-center gap-1">
           <span className={indicatorStyles({ active: outputState.audience })} />
           {audienceStateLabel}
+        </span>
+        <span className="flex items-center gap-1">
+          <span className={indicatorStyles({ active: outputState.stage })} />
+          {stageStateLabel}
         </span>
       </div>
     </div>

--- a/app/renderer/features/workbench/use-workbench-panel-toggles.ts
+++ b/app/renderer/features/workbench/use-workbench-panel-toggles.ts
@@ -31,6 +31,10 @@ const PANEL_TOGGLE_CONFIGS: Record<WorkbenchMode, PanelToggleConfig[]> = {
     { id: 'left', label: 'Left', splitId: 'editor-main', paneId: 'editor-left' },
     { id: 'right', label: 'Right', splitId: 'editor-main', paneId: 'editor-right' },
   ],
+  'stage-editor': [
+    { id: 'left', label: 'Left', splitId: 'editor-main', paneId: 'editor-left' },
+    { id: 'right', label: 'Right', splitId: 'editor-main', paneId: 'editor-right' },
+  ],
   settings: [],
 };
 

--- a/app/renderer/screens/deck-editor/page.tsx
+++ b/app/renderer/screens/deck-editor/page.tsx
@@ -1,23 +1,18 @@
-import { Play, Plus } from 'lucide-react';
+import { useMemo, useRef, useState } from 'react';
+import { ChevronDown, Play, Plus, Search } from 'lucide-react';
 import { ReacstButton } from '@renderer/components 2.0/button';
 import { RecastPanel } from '@renderer/components 2.0/panel';
 import type { Id } from '@core/types';
+import { cn } from '@renderer/utils/cn';
 import { ContextMenu, useContextMenuTrigger } from '../../components/overlays/context-menu';
 import { DeckItemIcon } from '../../components/display/entity-icon';
 import { Dropdown } from '../../components/form/dropdown';
 import { FieldTextarea } from '../../components/form/field';
-import { useElements, useRenderScenes } from '../../contexts/canvas/canvas-context';
-import { useCreateDeckItem } from '../../features/deck/create-deck-item';
-import { useNavigation } from '../../contexts/navigation-context';
-import { useDeckEditor } from '../../contexts/asset-editor/asset-editor-context';
-import { useSlides } from '../../contexts/slide-context';
+import { Popover } from '../../components/overlays/popover';
 import { getSlideVisualState, slideTextPreview } from '../../utils/slides';
 import { InspectorTabsPanel } from '../../features/canvas/inspector-tabs-panel';
-import { useInspectorPanelPushAction } from '../../features/canvas/use-inspector-panel-push-action';
 import { StagePanel } from '../../features/canvas/stage-panel';
 import { SplitPanel } from '../../features/workbench/split-panel';
-import { useEditorLeftPanelNav } from '../../features/workbench/use-editor-left-panel-nav';
-import { useSlideNotesPanel } from '../../features/deck/use-slide-notes-panel';
 import { ObjectListPanel } from '@renderer/features/canvas/object-list-panel';
 import { Thumbnail } from '@renderer/components/display/thumbnail';
 import { SceneFrame } from '@renderer/components/display/scene-frame';
@@ -26,35 +21,18 @@ import type { RenderScene } from '@renderer/features/canvas/scene-types';
 import { EmptyState } from '@renderer/components/display/empty-state';
 import { ScrollArea, useScrollAreaActiveItem } from '@renderer/components/layout/scroll-area';
 import { Label } from '@renderer/components/display/text';
+import { DeckEditorScreenProvider, useDeckEditorScreen } from './screen-context';
 
 export function DeckEditorScreen() {
-  const { currentDeckItem } = useNavigation();
-  const { open: openCreateDeckItem } = useCreateDeckItem();
-  const { effectiveElements } = useElements();
-  const { getSlideElements } = useDeckEditor();
-  const { slides, currentSlide, currentSlideIndex, liveSlideIndex, setCurrentSlideIndex, createSlide } = useSlides();
-  const { getThumbnailScene } = useRenderScenes();
-  const { state: inspectorState, handlePushChanges } = useInspectorPanelPushAction();
-  const {
-    canEdit,
-    notesDraft,
-    isDirty,
-    hasSlide,
-    placeholder,
-    handleNotesChange,
-    handleSaveNotes,
-    handleResetNotes,
-  } = useSlideNotesPanel();
+  return (
+    <DeckEditorScreenProvider>
+      <DeckEditorScreenContent />
+    </DeckEditorScreenProvider>
+  );
+}
 
-  useEditorLeftPanelNav({
-    items: slides,
-    currentId: currentSlide?.id ?? null,
-    activate: (_id, index) => setCurrentSlideIndex(index),
-  });
-
-  function handleAddSlide() {
-    void createSlide();
-  }
+function DeckEditorScreenContent() {
+  const { meta, state, actions } = useDeckEditorScreen();
 
   return (
     <section data-ui-region="deck-editor-layout" className="h-full min-h-0 overflow-hidden">
@@ -66,82 +44,90 @@ export function DeckEditorScreen() {
               <SplitPanel.Segment id={'slide-list'} defaultSize={440} minSize={180}>
                 <RecastPanel.Group>
                   <RecastPanel.GroupTitle>
-                    <div className="flex min-w-0 flex-1 items-center gap-2">
-                      {currentDeckItem ? <DeckItemIcon entity={currentDeckItem} className="shrink-0 text-tertiary" /> : null}
-                      <span className="truncate text-sm font-medium text-primary" title={currentDeckItem?.title ?? 'No item selected'}>
-                        {currentDeckItem?.title ?? 'No item selected'}
-                      </span>
-                    </div>
-                    <div className="flex gap-1">
-                      <Dropdown>
-                        <Dropdown.Trigger
-                          aria-label="Add"
-                          className="cursor-pointer rounded-sm bg-tertiary p-1 text-primary transition-colors hover:text-primary [&>svg]:size-4"
-                        >
-                          <Plus />
-                        </Dropdown.Trigger>
-                        <Dropdown.Panel placement="bottom-end">
-                          <Dropdown.Item onClick={() => openCreateDeckItem('lyric')}>New lyric</Dropdown.Item>
-                          <Dropdown.Item onClick={() => openCreateDeckItem('presentation')}>New presentation</Dropdown.Item>
-                          <Dropdown.Separator />
-                          <Dropdown.Item onClick={handleAddSlide} disabled={!currentDeckItem}>New slide</Dropdown.Item>
-                        </Dropdown.Panel>
-                      </Dropdown>
-                    </div>
+                    <DeckItemPicker />
+                    <Dropdown>
+                      <Dropdown.Trigger
+                        aria-label="Add"
+                        className="cursor-pointer rounded-sm bg-tertiary p-1 text-primary transition-colors hover:text-primary [&>svg]:size-4"
+                      >
+                        <Plus />
+                      </Dropdown.Trigger>
+                      <Dropdown.Panel placement="bottom-end">
+                        {meta.addActions.slice(0, 2).map((action) => {
+                          const kind = action.kind;
+                          if (!kind) return null;
+                          return (
+                            <Dropdown.Item key={action.id} onClick={() => actions.openCreateDeckItem(kind)}>
+                              {action.label}
+                            </Dropdown.Item>
+                          );
+                        })}
+                        <Dropdown.Separator />
+                        {(() => {
+                          const slideAction = meta.addActions.find((action) => action.id === 'new-slide');
+                          if (!slideAction) return null;
+                          return (
+                            <Dropdown.Item onClick={() => { void actions.createSlide(); }} disabled={slideAction.disabled}>
+                              {slideAction.label}
+                            </Dropdown.Item>
+                          );
+                        })()}
+                      </Dropdown.Panel>
+                    </Dropdown>
                   </RecastPanel.GroupTitle>
                   <RecastPanel.Content className="min-h-0">
-                  {!currentDeckItem ? (
-                    <EmptyState.Root>
-                      <EmptyState.Title>No item selected</EmptyState.Title>
-                      <EmptyState.Description>Pick a presentation or lyric from the menu above to start editing.</EmptyState.Description>
-                    </EmptyState.Root>
-                  ) : slides.length === 0 ? (
-                    <EmptyState.Root>
-                      <EmptyState.Title>No slides yet</EmptyState.Title>
-                      <EmptyState.Description>Click the + button to add your first slide.</EmptyState.Description>
-                    </EmptyState.Root>
-                  ) : (
-                    <ScrollArea.Root>
-                      <ScrollArea.Viewport className="p-2">
-                        <div className="grid min-w-0 grid-cols-1 content-start gap-3" role="grid" aria-label={`Current ${currentDeckItem?.type === 'lyric' ? 'lyrics' : 'slides'}`}>
-                          {slides.map((slide, index) => {
-                            const elements = currentSlide?.id === slide.id ? effectiveElements : getSlideElements(slide.id);
-                            const scene = getThumbnailScene(slide.id, 'deck-editor');
-                            if (!scene) return null;
-                            const state = getSlideVisualState(index, liveSlideIndex, currentSlideIndex, elements);
+                    {!state.currentDeckItem ? (
+                      <EmptyState.Root>
+                        <EmptyState.Title>No item selected</EmptyState.Title>
+                        <EmptyState.Description>Pick a presentation or lyric from the menu above to start editing.</EmptyState.Description>
+                      </EmptyState.Root>
+                    ) : state.slides.length === 0 ? (
+                      <EmptyState.Root>
+                        <EmptyState.Title>No slides yet</EmptyState.Title>
+                        <EmptyState.Description>Click the + button to add your first slide.</EmptyState.Description>
+                      </EmptyState.Root>
+                    ) : (
+                      <ScrollArea.Root>
+                        <ScrollArea.Viewport className="p-2">
+                          <div className="grid min-w-0 grid-cols-1 content-start gap-3" role="grid" aria-label={`Current ${state.currentDeckItem?.type === 'lyric' ? 'lyrics' : 'slides'}`}>
+                            {state.slides.map((slide, index) => {
+                              const elements = state.currentSlide?.id === slide.id ? state.effectiveElements : actions.getSlideElements(slide.id);
+                              const scene = actions.getThumbnailScene(slide.id, 'deck-editor');
+                              if (!scene) return null;
+                              const visualState = getSlideVisualState(index, state.liveSlideIndex, state.currentSlideIndex, elements);
 
-                            function handleSelect() {
-                              setCurrentSlideIndex(index);
-                            }
+                              function handleSelect() {
+                                actions.setCurrentSlideIndex(index);
+                              }
 
-                            return (
-                              <SlideTile
-                                key={slide.id}
-                                slideId={slide.id}
-                                scene={scene}
-                                index={index}
-                                isActive={index === currentSlideIndex}
-                                isLive={state === 'live'}
-                                isEmpty={state === 'warning'}
-                                textPreview={slideTextPreview(elements)}
-                                onSelect={handleSelect}
-                              />
-                            );
-                          })}
-                        </div>
-                      </ScrollArea.Viewport>
-                      <ScrollArea.Scrollbar>
-                        <ScrollArea.Thumb />
-                      </ScrollArea.Scrollbar>
-                    </ScrollArea.Root>
-                  )}
+                              return (
+                                <SlideTile
+                                  key={slide.id}
+                                  slideId={slide.id}
+                                  scene={scene}
+                                  index={index}
+                                  isActive={index === state.currentSlideIndex}
+                                  isLive={visualState === 'live'}
+                                  isEmpty={visualState === 'warning'}
+                                  textPreview={slideTextPreview(elements)}
+                                  onSelect={handleSelect}
+                                />
+                              );
+                            })}
+                          </div>
+                        </ScrollArea.Viewport>
+                        <ScrollArea.Scrollbar>
+                          <ScrollArea.Thumb />
+                        </ScrollArea.Scrollbar>
+                      </ScrollArea.Root>
+                    )}
                   </RecastPanel.Content>
                 </RecastPanel.Group>
               </SplitPanel.Segment>
               <SplitPanel.Segment id={"slide-objects"} defaultSize={220} minSize={160}>
                 <RecastPanel.Group>
                   <RecastPanel.GroupTitle className="border-t">
-                    <Label.xs className="mr-auto">Objects</Label.xs>
+                    <Label.xs className="mr-auto">Layers</Label.xs>
                   </RecastPanel.GroupTitle>
                   <RecastPanel.Content className="overflow-y-auto p-2">
                     <ObjectListPanel />
@@ -165,18 +151,18 @@ export function DeckEditorScreen() {
               >
                 <div className="pointer-events-none absolute inset-x-3 top-3 z-10 flex justify-end">
                   <div className="pointer-events-auto flex items-center gap-2 rounded-md border border-primary bg-primary/95 p-1 shadow-sm backdrop-blur-sm">
-                    <ReacstButton onClick={handleResetNotes} disabled={!hasSlide || !isDirty} variant="ghost">
+                    <ReacstButton onClick={state.notesPanel.handleResetNotes} disabled={!state.notesPanel.hasSlide || !state.notesPanel.isDirty} variant="ghost">
                       Reset
                     </ReacstButton>
-                    <ReacstButton onClick={handleSaveNotes} disabled={!canEdit || !isDirty}>
+                    <ReacstButton onClick={state.notesPanel.handleSaveNotes} disabled={!state.notesPanel.canEdit || !state.notesPanel.isDirty}>
                       Save
                     </ReacstButton>
                   </div>
                 </div>
                 <FieldTextarea
-                  value={notesDraft}
-                  onChange={handleNotesChange}
-                  placeholder={placeholder}
+                  value={state.notesPanel.notesDraft}
+                  onChange={state.notesPanel.handleNotesChange}
+                  placeholder={state.notesPanel.placeholder}
                   className="h-full min-h-0 w-full resize-none rounded-none border-0 bg-transparent px-3 pb-3 pt-14 leading-relaxed focus:border-0"
                 />
               </section>
@@ -188,10 +174,10 @@ export function DeckEditorScreen() {
         <SplitPanel.Segment id="edit-right" defaultSize={320} minSize={140} collapsible>
           <RecastPanel.Root className="h-full border-l border-secondary" data-ui-region="inspector-panel">
             <InspectorTabsPanel className="flex-1" />
-            {inspectorState.isVisible && (
+            {state.inspectorState.isVisible && (
               <RecastPanel.Footer className="p-3">
-                <ReacstButton onClick={handlePushChanges} disabled={inspectorState.isPushingChanges} className="w-full">
-                  {inspectorState.isPushingChanges ? 'Pushing…' : inspectorState.pushLabel}
+                <ReacstButton onClick={actions.pushChanges} disabled={state.inspectorState.isPushingChanges} className="w-full">
+                  {state.inspectorState.isPushingChanges ? 'Pushing…' : state.inspectorState.pushLabel}
                 </ReacstButton>
               </RecastPanel.Footer>
             )}
@@ -231,9 +217,9 @@ function SlideTile({ slideId, scene, index, isActive, isLive, isEmpty, textPrevi
 }
 
 function SlideTileBody({ slideId, scene, index, isActive, isLive, isEmpty, textPreview, onSelect }: SlideTileProps) {
-  const { slides, duplicateSlide, deleteSlide, moveSlide } = useSlides();
+  const { state, actions } = useDeckEditorScreen();
   const isFirst = index === 0;
-  const isLast = index === slides.length - 1;
+  const isLast = index === state.slides.length - 1;
   const activeRef = useScrollAreaActiveItem<HTMLDivElement>(isActive);
   const { ref: triggerRef, ...triggerHandlers } = useContextMenuTrigger();
 
@@ -275,13 +261,131 @@ function SlideTileBody({ slideId, scene, index, isActive, isLive, isEmpty, textP
       </Thumbnail.Tile>
       <ContextMenu.Portal>
         <ContextMenu.Menu>
-          <ContextMenu.Item onSelect={() => { void duplicateSlide(slideId); }}>Duplicate</ContextMenu.Item>
-          <ContextMenu.Item onSelect={() => { void deleteSlide(slideId); }}>Delete</ContextMenu.Item>
+          <ContextMenu.Item onSelect={() => { void actions.duplicateSlide(slideId); }}>Duplicate</ContextMenu.Item>
+          <ContextMenu.Item onSelect={() => { void actions.deleteSlide(slideId); }}>Delete</ContextMenu.Item>
           <ContextMenu.Separator />
-          <ContextMenu.Item disabled={isFirst} onSelect={() => { void moveSlide(slideId, 'up'); }}>Move up</ContextMenu.Item>
-          <ContextMenu.Item disabled={isLast} onSelect={() => { void moveSlide(slideId, 'down'); }}>Move down</ContextMenu.Item>
+          <ContextMenu.Item disabled={isFirst} onSelect={() => { void actions.moveSlide(slideId, 'up'); }}>Move up</ContextMenu.Item>
+          <ContextMenu.Item disabled={isLast} onSelect={() => { void actions.moveSlide(slideId, 'down'); }}>Move down</ContextMenu.Item>
         </ContextMenu.Menu>
       </ContextMenu.Portal>
+    </>
+  );
+}
+
+// Combobox-style picker that replaces the static deck-item title in the
+// edit screen's left panel. Click the trigger to open a popover with a
+// search input and a filtered list of deck items; pick one to switch.
+function DeckItemPicker() {
+  const { state, actions } = useDeckEditorScreen();
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const listRef = useRef<HTMLDivElement | null>(null);
+  const [open, setOpen] = useState(false);
+  const [filter, setFilter] = useState('');
+  const [highlightedIndex, setHighlightedIndex] = useState(0);
+
+  const filtered = useMemo(() => {
+    const q = filter.trim().toLowerCase();
+    if (!q) return state.deckItems;
+    return state.deckItems.filter((item) => item.title.toLowerCase().includes(q));
+  }, [filter, state.deckItems]);
+
+  function handleOpen() {
+    setOpen(true);
+    setFilter('');
+    setHighlightedIndex(0);
+    // Focus the search input on next paint, after the popover mounts.
+    requestAnimationFrame(() => inputRef.current?.focus());
+  }
+
+  function handleClose() {
+    setOpen(false);
+  }
+
+  function handleSelect(id: Id) {
+    actions.browseDeckItem(id);
+    handleClose();
+  }
+
+  function handleInputKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      setHighlightedIndex((prev) => Math.min(prev + 1, Math.max(0, filtered.length - 1)));
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      setHighlightedIndex((prev) => Math.max(prev - 1, 0));
+    } else if (event.key === 'Enter') {
+      event.preventDefault();
+      const target = filtered[highlightedIndex];
+      if (target) handleSelect(target.id);
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      handleClose();
+    }
+  }
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        type="button"
+        onClick={open ? handleClose : handleOpen}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        className="h-6.5 flex min-w-0 flex-1 items-center gap-2 rounded-sm px-1 py-0.5 text-left transition-colors hover:bg-tertiary"
+        title={state.currentDeckItem?.title ?? 'No item selected'}
+      >
+        {state.currentDeckItem ? <DeckItemIcon entity={state.currentDeckItem} className="shrink-0 text-tertiary" /> : null}
+        <span className="min-w-0 flex-1 truncate text-sm font-medium text-primary">
+          {state.currentDeckItem?.title ?? 'No item selected'}
+        </span>
+        <ChevronDown className="size-3.5 shrink-0 text-tertiary" />
+      </button>
+      <Popover anchor={triggerRef.current} open={open} onClose={handleClose} placement="bottom-start" offset={4} axisLock>
+        <div className="flex w-72 flex-col overflow-hidden rounded-md border border-primary bg-primary shadow-lg">
+          <div className="flex items-center gap-1.5 border-b border-primary px-2 py-1.5">
+            <Search className="size-3.5 shrink-0 text-tertiary" />
+            <input
+              ref={inputRef}
+              type="text"
+              value={filter}
+              onChange={(event) => { setFilter(event.target.value); setHighlightedIndex(0); }}
+              onKeyDown={handleInputKeyDown}
+              placeholder="Search deck items"
+              className="min-w-0 flex-1 bg-transparent text-sm text-primary outline-none placeholder:text-tertiary"
+            />
+          </div>
+          <div ref={listRef} className="max-h-72 overflow-y-auto p-1">
+            {filtered.length === 0 ? (
+              <div className="px-2 py-1.5 text-sm text-tertiary">No deck items match.</div>
+            ) : (
+              filtered.map((item, index) => {
+                const isCurrent = item.id === state.currentDeckItemId;
+                const isHighlighted = index === highlightedIndex;
+                return (
+                  <button
+                    key={item.id}
+                    type="button"
+                    role="option"
+                    aria-selected={isCurrent}
+                    onClick={() => handleSelect(item.id)}
+                    onMouseEnter={() => setHighlightedIndex(index)}
+                    className={cn(
+                      'flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm transition-colors',
+                      isCurrent ? 'text-primary' : 'text-secondary',
+                      isHighlighted ? 'bg-tertiary text-primary' : 'hover:bg-tertiary hover:text-primary',
+                    )}
+                  >
+                    <DeckItemIcon entity={item} className="shrink-0 text-tertiary" />
+                    <span className="min-w-0 flex-1 truncate">{item.title}</span>
+                    {isCurrent ? <span className="shrink-0 text-xs uppercase tracking-wide text-tertiary">current</span> : null}
+                  </button>
+                );
+              })
+            )}
+          </div>
+        </div>
+      </Popover>
     </>
   );
 }

--- a/app/renderer/screens/deck-editor/screen-context.tsx
+++ b/app/renderer/screens/deck-editor/screen-context.tsx
@@ -1,0 +1,143 @@
+import { useMemo, type ReactNode } from 'react';
+import type { DeckItemType, Id } from '@core/types';
+import { useElements, useRenderScenes } from '../../contexts/canvas/canvas-context';
+import { useCreateDeckItem } from '../../features/deck/create-deck-item';
+import { useNavigation } from '../../contexts/navigation-context';
+import { useDeckEditor } from '../../contexts/asset-editor/asset-editor-context';
+import { useProjectContent } from '../../contexts/use-project-content';
+import { useSlides } from '../../contexts/slide-context';
+import { useInspectorPanelPushAction } from '../../features/canvas/use-inspector-panel-push-action';
+import { useEditorLeftPanelNav } from '../../features/workbench/use-editor-left-panel-nav';
+import { useSlideNotesPanel } from '../../features/deck/use-slide-notes-panel';
+import { createScreenContext } from '../../contexts/create-screen-context';
+
+interface DeckEditorScreenContextValue {
+  meta: {
+    screenId: 'deck-editor';
+    listTitle: 'Slides';
+    addActions: Array<{
+      id: 'new-lyric' | 'new-presentation' | 'new-slide';
+      label: string;
+      disabled?: boolean;
+      kind?: DeckItemType;
+    }>;
+  };
+  state: {
+    currentDeckItem: ReturnType<typeof useNavigation>['currentDeckItem'];
+    currentDeckItemId: ReturnType<typeof useNavigation>['currentDeckItemId'];
+    deckItems: ReturnType<typeof useProjectContent>['deckItems'];
+    slides: ReturnType<typeof useSlides>['slides'];
+    currentSlide: ReturnType<typeof useSlides>['currentSlide'];
+    currentSlideIndex: ReturnType<typeof useSlides>['currentSlideIndex'];
+    liveSlideIndex: ReturnType<typeof useSlides>['liveSlideIndex'];
+    effectiveElements: ReturnType<typeof useElements>['effectiveElements'];
+    inspectorState: ReturnType<typeof useInspectorPanelPushAction>['state'];
+    notesPanel: ReturnType<typeof useSlideNotesPanel>;
+  };
+  actions: {
+    openCreateDeckItem: (kind: DeckItemType) => void;
+    browseDeckItem: (id: Id) => void;
+    setCurrentSlideIndex: (index: number) => void;
+    createSlide: () => Promise<void>;
+    duplicateSlide: ReturnType<typeof useSlides>['duplicateSlide'];
+    deleteSlide: ReturnType<typeof useSlides>['deleteSlide'];
+    moveSlide: ReturnType<typeof useSlides>['moveSlide'];
+    pushChanges: () => void;
+    getSlideElements: ReturnType<typeof useDeckEditor>['getSlideElements'];
+    getThumbnailScene: ReturnType<typeof useRenderScenes>['getThumbnailScene'];
+  };
+}
+
+const [DeckEditorScreenContextProvider, useDeckEditorScreen] = createScreenContext<DeckEditorScreenContextValue>('DeckEditorScreenContext');
+
+export function DeckEditorScreenProvider({ children }: { children: ReactNode }) {
+  const { currentDeckItem, currentDeckItemId, browseDeckItem } = useNavigation();
+  const { open: openCreateDeckItem } = useCreateDeckItem();
+  const { effectiveElements } = useElements();
+  const { getSlideElements } = useDeckEditor();
+  const {
+    slides,
+    currentSlide,
+    currentSlideIndex,
+    liveSlideIndex,
+    setCurrentSlideIndex,
+    createSlide,
+    duplicateSlide,
+    deleteSlide,
+    moveSlide,
+  } = useSlides();
+  const { getThumbnailScene } = useRenderScenes();
+  const { state: inspectorState, handlePushChanges } = useInspectorPanelPushAction();
+  const notesPanel = useSlideNotesPanel();
+  const { deckItems } = useProjectContent();
+
+  useEditorLeftPanelNav({
+    items: slides,
+    currentId: currentSlide?.id ?? null,
+    activate: (_id, index) => setCurrentSlideIndex(index),
+  });
+
+  const addActions = useMemo<DeckEditorScreenContextValue['meta']['addActions']>(() => ([
+    { id: 'new-lyric', label: 'New lyric', kind: 'lyric' },
+    { id: 'new-presentation', label: 'New presentation', kind: 'presentation' },
+    { id: 'new-slide', label: 'New slide', disabled: !currentDeckItem },
+  ]), [currentDeckItem]);
+
+  const value = useMemo<DeckEditorScreenContextValue>(() => ({
+    meta: {
+      screenId: 'deck-editor',
+      listTitle: 'Slides',
+      addActions,
+    },
+    state: {
+      currentDeckItem,
+      currentDeckItemId,
+      deckItems,
+      slides,
+      currentSlide,
+      currentSlideIndex,
+      liveSlideIndex,
+      effectiveElements,
+      inspectorState,
+      notesPanel,
+    },
+    actions: {
+      openCreateDeckItem,
+      browseDeckItem,
+      setCurrentSlideIndex,
+      createSlide,
+      duplicateSlide,
+      deleteSlide,
+      moveSlide,
+      pushChanges: handlePushChanges,
+      getSlideElements,
+      getThumbnailScene,
+    },
+  }), [
+    addActions,
+    browseDeckItem,
+    createSlide,
+    currentDeckItem,
+    currentDeckItemId,
+    currentSlide,
+    currentSlideIndex,
+    deckItems,
+    deleteSlide,
+    duplicateSlide,
+    effectiveElements,
+    getSlideElements,
+    getThumbnailScene,
+    handlePushChanges,
+    inspectorState,
+    liveSlideIndex,
+    moveSlide,
+    notesPanel,
+    openCreateDeckItem,
+    setCurrentSlideIndex,
+    slides,
+  ]);
+
+  return <DeckEditorScreenContextProvider value={value}>{children}</DeckEditorScreenContextProvider>;
+}
+
+export { useDeckEditorScreen };

--- a/app/renderer/screens/overlay-editor/page.tsx
+++ b/app/renderer/screens/overlay-editor/page.tsx
@@ -5,34 +5,27 @@ import { RecastPanel } from '@renderer/components 2.0/panel';
 import { Thumbnail } from '../../components/display/thumbnail';
 import { SceneFrame } from '../../components/display/scene-frame';
 import { Dropdown } from '../../components/form/dropdown';
-import { useCreateDeckItem } from '../../features/deck/create-deck-item';
-import { useOverlayEditor } from '../../contexts/asset-editor/asset-editor-context';
 import { ObjectListPanel } from '../../features/canvas/object-list-panel';
 import { InspectorTabsPanel } from '../../features/canvas/inspector-tabs-panel';
-import { useInspectorPanelPushAction } from '../../features/canvas/use-inspector-panel-push-action';
 import { buildRenderScene } from '../../features/canvas/build-render-scene';
 import { SceneStage } from '../../features/canvas/scene-stage';
 import { StagePanel } from '../../features/canvas/stage-panel';
 import { SplitPanel } from '../../features/workbench/split-panel';
-import { useEditorLeftPanelNav } from '../../features/workbench/use-editor-left-panel-nav';
 import { Label } from '@renderer/components/display/text';
 import { EmptyState } from '@renderer/components/display/empty-state';
 import { ScrollArea, useScrollAreaActiveItem } from '@renderer/components/layout/scroll-area';
+import { OverlayEditorScreenProvider, useOverlayEditorScreen } from './screen-context';
 
 export function OverlayEditorScreen() {
-  const { overlays, currentOverlayId, setCurrentOverlayId, createOverlay } = useOverlayEditor();
-  const { open: openCreateDeckItem } = useCreateDeckItem();
-  const { state: inspectorState, handlePushChanges } = useInspectorPanelPushAction();
+  return (
+    <OverlayEditorScreenProvider>
+      <OverlayEditorScreenContent />
+    </OverlayEditorScreenProvider>
+  );
+}
 
-  useEditorLeftPanelNav({
-    items: overlays,
-    currentId: currentOverlayId,
-    activate: (id) => setCurrentOverlayId(id),
-  });
-
-  function handleAddOverlay() {
-    void createOverlay();
-  }
+function OverlayEditorScreenContent() {
+  const { meta, state, actions } = useOverlayEditorScreen();
 
   return (
     <section data-ui-region="editor-layout" className="h-full min-h-0 overflow-hidden">
@@ -43,7 +36,7 @@ export function OverlayEditorScreen() {
               <SplitPanel.Segment id="overlay-list" defaultSize={440} minSize={180}>
                 <RecastPanel.Group>
                   <RecastPanel.GroupTitle>
-                    <Label.sm className="mr-auto">Overlays</Label.sm>
+                    <Label.sm className="mr-auto">{meta.listTitle}</Label.sm>
                     <Dropdown>
                       <Dropdown.Trigger
                         aria-label="Add"
@@ -52,52 +45,53 @@ export function OverlayEditorScreen() {
                         <Plus />
                       </Dropdown.Trigger>
                       <Dropdown.Panel placement="bottom-end">
-                        <Dropdown.Item onClick={() => openCreateDeckItem('lyric')}>New lyric</Dropdown.Item>
-                        <Dropdown.Item onClick={() => openCreateDeckItem('presentation')}>New presentation</Dropdown.Item>
-                        <Dropdown.Separator />
-                        <Dropdown.Item onClick={handleAddOverlay}>New overlay</Dropdown.Item>
+                        {meta.addActions.map((action) => (
+                          <Dropdown.Item key={action.kind} onClick={() => { void actions.createOverlay(); }}>
+                            {action.label}
+                          </Dropdown.Item>
+                        ))}
                       </Dropdown.Panel>
                     </Dropdown>
                   </RecastPanel.GroupTitle>
                   <RecastPanel.Content>
-                    {overlays.length === 0 ? (
+                    {state.overlays.length === 0 ? (
                       <EmptyState.Root>
                         <EmptyState.Title>No overlays yet</EmptyState.Title>
                         <EmptyState.Description>Click the + button to create your first overlay.</EmptyState.Description>
                       </EmptyState.Root>
                     ) : (
-                    <ScrollArea.Root>
-                      <ScrollArea.Viewport className="p-2">
-                        <div className="grid min-w-0 grid-cols-1 content-start gap-1" role="grid" aria-label="Library overlays">
-                          {overlays.map((overlay, index) => {
-                            const scene = buildRenderScene(null, overlayToLayerElements(overlay));
+                      <ScrollArea.Root>
+                        <ScrollArea.Viewport className="p-2">
+                          <div className="grid min-w-0 grid-cols-1 content-start gap-1" role="grid" aria-label="Library overlays">
+                            {state.overlays.map((overlay, index) => {
+                              const scene = buildRenderScene(null, overlayToLayerElements(overlay));
 
-                            function handleSelect() {
-                              setCurrentOverlayId(overlay.id);
-                            }
+                              function handleSelect() {
+                                actions.selectOverlay(overlay.id);
+                              }
 
-                            return (
-                              <ActiveOverlayTile key={overlay.id} isActive={currentOverlayId === overlay.id} onClick={handleSelect} selected={currentOverlayId === overlay.id}>
-                                <Thumbnail.Body>
-                                  <SceneFrame width={scene.width} height={scene.height} className="bg-tertiary" stageClassName="absolute inset-0" checkerboard>
-                                    <SceneStage scene={scene} surface="list" className="absolute inset-0 pointer-events-none" />
-                                  </SceneFrame>
-                                </Thumbnail.Body>
-                                <Thumbnail.Caption>
-                                  <div className="flex items-center gap-2">
-                                    <span className="shrink-0 text-sm font-semibold tabular-nums text-secondary">{index + 1}</span>
-                                    <span className="min-w-0 truncate text-sm text-tertiary">{overlay.name}</span>
-                                  </div>
-                                </Thumbnail.Caption>
-                              </ActiveOverlayTile>
-                            );
-                          })}
-                        </div>
-                      </ScrollArea.Viewport>
-                      <ScrollArea.Scrollbar>
-                        <ScrollArea.Thumb />
-                      </ScrollArea.Scrollbar>
-                    </ScrollArea.Root>
+                              return (
+                                <ActiveOverlayTile key={overlay.id} isActive={state.currentOverlayId === overlay.id} onClick={handleSelect} selected={state.currentOverlayId === overlay.id}>
+                                  <Thumbnail.Body>
+                                    <SceneFrame width={scene.width} height={scene.height} className="bg-tertiary" stageClassName="absolute inset-0" checkerboard>
+                                      <SceneStage scene={scene} surface="list" className="absolute inset-0 pointer-events-none" />
+                                    </SceneFrame>
+                                  </Thumbnail.Body>
+                                  <Thumbnail.Caption>
+                                    <div className="flex items-center gap-2">
+                                      <span className="shrink-0 text-sm font-semibold tabular-nums text-secondary">{index + 1}</span>
+                                      <span className="min-w-0 truncate text-sm text-tertiary">{overlay.name}</span>
+                                    </div>
+                                  </Thumbnail.Caption>
+                                </ActiveOverlayTile>
+                              );
+                            })}
+                          </div>
+                        </ScrollArea.Viewport>
+                        <ScrollArea.Scrollbar>
+                          <ScrollArea.Thumb />
+                        </ScrollArea.Scrollbar>
+                      </ScrollArea.Root>
                     )}
                   </RecastPanel.Content>
                 </RecastPanel.Group>
@@ -105,7 +99,7 @@ export function OverlayEditorScreen() {
               <SplitPanel.Segment id="overlay-objects" defaultSize={220} minSize={160}>
                 <RecastPanel.Group>
                   <RecastPanel.GroupTitle className="border-t">
-                    <Label.xs className="mr-auto">Objects</Label.xs>
+                    <Label.xs className="mr-auto">Layers</Label.xs>
                   </RecastPanel.GroupTitle>
                   <RecastPanel.Content className="overflow-y-auto p-2">
                     <ObjectListPanel />
@@ -121,10 +115,10 @@ export function OverlayEditorScreen() {
         <SplitPanel.Segment id="editor-right" defaultSize={320} minSize={140} collapsible>
           <RecastPanel.Root className="h-full border-l border-secondary" data-ui-region="inspector-panel">
             <InspectorTabsPanel className="flex-1" />
-            {inspectorState.isVisible && (
+            {state.inspectorState.isVisible && (
               <RecastPanel.Footer className="p-3">
-                <ReacstButton onClick={handlePushChanges} disabled={inspectorState.isPushingChanges} className="w-full">
-                  {inspectorState.isPushingChanges ? 'Pushing…' : inspectorState.pushLabel}
+                <ReacstButton onClick={actions.pushChanges} disabled={state.inspectorState.isPushingChanges} className="w-full">
+                  {state.inspectorState.isPushingChanges ? 'Pushing…' : state.inspectorState.pushLabel}
                 </ReacstButton>
               </RecastPanel.Footer>
             )}

--- a/app/renderer/screens/overlay-editor/screen-context.tsx
+++ b/app/renderer/screens/overlay-editor/screen-context.tsx
@@ -1,0 +1,60 @@
+import { useMemo, type ReactNode } from 'react';
+import { useOverlayEditor } from '../../contexts/asset-editor/asset-editor-context';
+import { useInspectorPanelPushAction } from '../../features/canvas/use-inspector-panel-push-action';
+import { getEditorHeaderActions } from '../../features/workbench/editor-header-actions';
+import { useEditorLeftPanelNav } from '../../features/workbench/use-editor-left-panel-nav';
+import { createScreenContext } from '../../contexts/create-screen-context';
+
+interface OverlayEditorScreenContextValue {
+  meta: {
+    screenId: 'overlay-editor';
+    listTitle: 'Overlays';
+    addActions: ReturnType<typeof getEditorHeaderActions>;
+  };
+  state: {
+    overlays: ReturnType<typeof useOverlayEditor>['overlays'];
+    currentOverlayId: ReturnType<typeof useOverlayEditor>['currentOverlayId'];
+    inspectorState: ReturnType<typeof useInspectorPanelPushAction>['state'];
+  };
+  actions: {
+    selectOverlay: (id: string | null) => void;
+    createOverlay: () => Promise<void>;
+    pushChanges: () => void;
+  };
+}
+
+const [OverlayEditorScreenContextProvider, useOverlayEditorScreen] = createScreenContext<OverlayEditorScreenContextValue>('OverlayEditorScreenContext');
+
+export function OverlayEditorScreenProvider({ children }: { children: ReactNode }) {
+  const { overlays, currentOverlayId, setCurrentOverlayId, createOverlay } = useOverlayEditor();
+  const { state: inspectorState, handlePushChanges } = useInspectorPanelPushAction();
+  const addActions = useMemo(() => getEditorHeaderActions('overlay-editor'), []);
+
+  useEditorLeftPanelNav({
+    items: overlays,
+    currentId: currentOverlayId,
+    activate: (id) => setCurrentOverlayId(id),
+  });
+
+  const value = useMemo<OverlayEditorScreenContextValue>(() => ({
+    meta: {
+      screenId: 'overlay-editor',
+      listTitle: 'Overlays',
+      addActions,
+    },
+    state: {
+      overlays,
+      currentOverlayId,
+      inspectorState,
+    },
+    actions: {
+      selectOverlay: setCurrentOverlayId,
+      createOverlay,
+      pushChanges: handlePushChanges,
+    },
+  }), [addActions, createOverlay, currentOverlayId, handlePushChanges, inspectorState, overlays, setCurrentOverlayId]);
+
+  return <OverlayEditorScreenContextProvider value={value}>{children}</OverlayEditorScreenContextProvider>;
+}
+
+export { useOverlayEditorScreen };

--- a/app/renderer/screens/show/page.tsx
+++ b/app/renderer/screens/show/page.tsx
@@ -1,25 +1,24 @@
 import { ResourceDrawer } from '../../features/workbench/resource-drawer';
 import { ContinuousSlideBrowser } from '../../features/deck/continuous-slide-browser';
-import { LibraryBrowserProvider } from '../../features/library/library-browser-context';
 import { PreviewPanel } from '../../features/playback/preview-panel';
 import { DeckBrowserToolbar } from '../../features/deck/deck-browser-toolbar';
 import { SlideBrowserContent } from '../../features/deck/slide-browser-content';
-import { useDeckBrowserView } from '../../features/deck/use-deck-browser-view';
 import { SplitPanel } from '../../features/workbench/split-panel';
 import { LibrariesPanel } from '@renderer/features/library/libraries-panel';
 import { PlaylistPanels } from '@renderer/features/library/playlist-panels';
 import { Logo } from '@renderer/components/assets';
+import { ShowScreenProvider, useShowScreen } from './screen-context';
 
 export function ShowScreen() {
   return (
-    <LibraryBrowserProvider>
+    <ShowScreenProvider>
       <ShowScreenContent />
-    </LibraryBrowserProvider>
+    </ShowScreenProvider>
   );
 }
 
 function ShowScreenContent() {
-  const state = useDeckBrowserView();
+  const { state: { browser } } = useShowScreen();
 
   return (
     <SplitPanel.Panel splitId="show-main" orientation="horizontal" className="h-full">
@@ -30,14 +29,14 @@ function ShowScreenContent() {
       <SplitPanel.Segment id="show-center" defaultSize={840} minSize={360}>
         <SplitPanel.Panel splitId="show-center" orientation="vertical" className="h-full">
           <SplitPanel.Segment id="show-middle" defaultSize={600} minSize={360}>
-            <DeckBrowserToolbar items={state.items} headerVariant={state.headerVariant} />
-            {state.contentVariant === 'empty' && (
+            <DeckBrowserToolbar items={browser.items} headerVariant={browser.headerVariant} />
+            {browser.contentVariant === 'empty' && (
               <div className="flex h-full min-h-0 items-center justify-center p-2">
-                <Logo className='size-60 opacity-10' />
+                <Logo className="size-60 opacity-10" />
               </div>
             )}
-            <SlideBrowserContent variant={state.contentVariant} />
-            <ContinuousSlideBrowser variant={state.contentVariant} items={state.items} />
+            <SlideBrowserContent variant={browser.contentVariant} />
+            <ContinuousSlideBrowser variant={browser.contentVariant} items={browser.items} />
           </SplitPanel.Segment>
           <SplitPanel.Segment id="show-bottom" defaultSize={260} minSize={96} collapsible>
             <ResourceDrawer.Root>

--- a/app/renderer/screens/show/screen-context.tsx
+++ b/app/renderer/screens/show/screen-context.tsx
@@ -1,0 +1,35 @@
+import { useMemo, type ReactNode } from 'react';
+import { LibraryBrowserProvider } from '../../features/library/library-browser-context';
+import { useDeckBrowserView } from '../../features/deck/use-deck-browser-view';
+import { createScreenContext } from '../../contexts/create-screen-context';
+
+interface ShowScreenContextValue {
+  meta: {
+    screenId: 'show';
+  };
+  state: {
+    browser: ReturnType<typeof useDeckBrowserView>;
+  };
+}
+
+const [ShowScreenContextProvider, useShowScreen] = createScreenContext<ShowScreenContextValue>('ShowScreenContext');
+
+function ShowScreenContextBridge({ children }: { children: ReactNode }) {
+  const browser = useDeckBrowserView();
+  const value = useMemo<ShowScreenContextValue>(() => ({
+    meta: { screenId: 'show' },
+    state: { browser },
+  }), [browser]);
+
+  return <ShowScreenContextProvider value={value}>{children}</ShowScreenContextProvider>;
+}
+
+export function ShowScreenProvider({ children }: { children: ReactNode }) {
+  return (
+    <LibraryBrowserProvider>
+      <ShowScreenContextBridge>{children}</ShowScreenContextBridge>
+    </LibraryBrowserProvider>
+  );
+}
+
+export { useShowScreen };

--- a/app/renderer/screens/stage-editor/page.tsx
+++ b/app/renderer/screens/stage-editor/page.tsx
@@ -1,9 +1,8 @@
-import type { Template } from '@core/types';
-import { Layers, Music, Plus, Presentation } from 'lucide-react';
+import { Plus } from 'lucide-react';
 import { ReacstButton } from '@renderer/components 2.0/button';
 import { RecastPanel } from '@renderer/components 2.0/panel';
-import { SceneFrame } from '../../components/display/scene-frame';
 import { Thumbnail } from '../../components/display/thumbnail';
+import { SceneFrame } from '../../components/display/scene-frame';
 import { Dropdown } from '../../components/form/dropdown';
 import { ObjectListPanel } from '../../features/canvas/object-list-panel';
 import { InspectorTabsPanel } from '../../features/canvas/inspector-tabs-panel';
@@ -11,29 +10,29 @@ import { buildRenderScene } from '../../features/canvas/build-render-scene';
 import { SceneStage } from '../../features/canvas/scene-stage';
 import { StagePanel } from '../../features/canvas/stage-panel';
 import { SplitPanel } from '../../features/workbench/split-panel';
-import { EmptyState } from '@renderer/components/display/empty-state';
 import { Label } from '@renderer/components/display/text';
+import { EmptyState } from '@renderer/components/display/empty-state';
 import { ScrollArea, useScrollAreaActiveItem } from '@renderer/components/layout/scroll-area';
-import { TemplateEditorScreenProvider, useTemplateEditorScreen } from './screen-context';
+import { StageEditorScreenProvider, useStageEditorScreen } from './screen-context';
 
-export function TemplateEditorScreen() {
+export function StageEditorScreen() {
   return (
-    <TemplateEditorScreenProvider>
-      <TemplateEditorScreenContent />
-    </TemplateEditorScreenProvider>
+    <StageEditorScreenProvider>
+      <StageEditorScreenContent />
+    </StageEditorScreenProvider>
   );
 }
 
-function TemplateEditorScreenContent() {
-  const { meta, state, actions } = useTemplateEditorScreen();
+function StageEditorScreenContent() {
+  const { meta, state, actions } = useStageEditorScreen();
 
   return (
     <section data-ui-region="editor-layout" className="h-full min-h-0 overflow-hidden">
       <SplitPanel.Panel splitId="editor-main" orientation="horizontal" className="h-full">
         <SplitPanel.Segment id="editor-left" defaultSize={280} minSize={140} collapsible>
           <RecastPanel.Root className="h-full border-r border-secondary">
-            <SplitPanel.Panel splitId="template-list-panel" orientation="vertical" className="h-full">
-              <SplitPanel.Segment id="template-list" defaultSize={440} minSize={180}>
+            <SplitPanel.Panel splitId="stage-list-panel" orientation="vertical" className="h-full">
+              <SplitPanel.Segment id="stage-list" defaultSize={440} minSize={180}>
                 <RecastPanel.Group>
                   <RecastPanel.GroupTitle>
                     <Label.sm className="mr-auto">{meta.listTitle}</Label.sm>
@@ -45,54 +44,45 @@ function TemplateEditorScreenContent() {
                         <Plus />
                       </Dropdown.Trigger>
                       <Dropdown.Panel placement="bottom-end">
-                        {meta.addActions.map((action) => {
-                          if (action.kind !== 'create-template') return null;
-                          return (
-                            <Dropdown.Item key={action.templateKind} onClick={() => actions.createTemplate(action.templateKind)}>
-                              {action.label}
-                            </Dropdown.Item>
-                          );
-                        })}
+                        {meta.addActions.map((action) => (
+                          <Dropdown.Item key={action.kind} onClick={() => { void actions.createStage(); }}>
+                            {action.label}
+                          </Dropdown.Item>
+                        ))}
                       </Dropdown.Panel>
                     </Dropdown>
                   </RecastPanel.GroupTitle>
                   <RecastPanel.Content>
-                    {state.templates.length === 0 ? (
+                    {state.stages.length === 0 ? (
                       <EmptyState.Root>
-                        <EmptyState.Title>No templates yet</EmptyState.Title>
-                        <EmptyState.Description>Click the + button to create your first template.</EmptyState.Description>
+                        <EmptyState.Title>No stages yet</EmptyState.Title>
+                        <EmptyState.Description>Click the + button to create your first stage layout.</EmptyState.Description>
                       </EmptyState.Root>
                     ) : (
                       <ScrollArea.Root>
                         <ScrollArea.Viewport className="p-2">
-                          <div className="grid min-w-0 grid-cols-1 content-start gap-1" role="grid" aria-label="Templates">
-                            {state.templates.map((template, index) => {
-                              const scene = buildRenderScene(null, template.elements);
+                          <div className="grid min-w-0 grid-cols-1 content-start gap-1" role="grid" aria-label="Stages">
+                            {state.stages.map((stage, index) => {
+                              const scene = buildRenderScene(null, stage.elements);
 
                               function handleSelect() {
-                                actions.selectTemplate(template.id);
-                              }
-
-                              function handleCaptionDoubleClick(event: React.MouseEvent) {
-                                event.stopPropagation();
-                                actions.requestTemplateNameFocus(template.id);
+                                actions.selectStage(stage.id);
                               }
 
                               return (
-                                <ActiveTemplateTile key={template.id} isActive={template.id === state.currentTemplateId} onClick={handleSelect} selected={template.id === state.currentTemplateId}>
+                                <ActiveStageTile key={stage.id} isActive={state.currentStageId === stage.id} onClick={handleSelect} selected={state.currentStageId === stage.id}>
                                   <Thumbnail.Body>
                                     <SceneFrame width={scene.width} height={scene.height} className="bg-tertiary" stageClassName="absolute inset-0" checkerboard>
-                                      <SceneStage scene={scene} surface="list" className="absolute inset-0 pointer-events-none" />
+                                      <SceneStage scene={scene} surface="stage" className="absolute inset-0 pointer-events-none" />
                                     </SceneFrame>
                                   </Thumbnail.Body>
                                   <Thumbnail.Caption>
-                                    <div className="flex items-center gap-2" onDoubleClick={handleCaptionDoubleClick}>
+                                    <div className="flex items-center gap-2">
                                       <span className="shrink-0 text-sm font-semibold tabular-nums text-secondary">{index + 1}</span>
-                                      <TemplateKindIcon kind={template.kind} />
-                                      <span className="min-w-0 truncate text-sm text-tertiary">{template.name}</span>
+                                      <span className="min-w-0 truncate text-sm text-tertiary">{stage.name}</span>
                                     </div>
                                   </Thumbnail.Caption>
-                                </ActiveTemplateTile>
+                                </ActiveStageTile>
                               );
                             })}
                           </div>
@@ -105,7 +95,7 @@ function TemplateEditorScreenContent() {
                   </RecastPanel.Content>
                 </RecastPanel.Group>
               </SplitPanel.Segment>
-              <SplitPanel.Segment id="template-objects" defaultSize={220} minSize={160}>
+              <SplitPanel.Segment id="stage-objects" defaultSize={220} minSize={160}>
                 <RecastPanel.Group>
                   <RecastPanel.GroupTitle className="border-t">
                     <Label.xs className="mr-auto">Layers</Label.xs>
@@ -124,19 +114,13 @@ function TemplateEditorScreenContent() {
         <SplitPanel.Segment id="editor-right" defaultSize={320} minSize={140} collapsible>
           <RecastPanel.Root className="h-full border-l border-secondary" data-ui-region="inspector-panel">
             <InspectorTabsPanel className="flex-1" />
-            {state.currentTemplate ? (
+            {state.inspectorState.isVisible && (
               <RecastPanel.Footer className="p-3">
-                <ReacstButton
-                  variant="ghost"
-                  onClick={() => { void actions.syncLinkedItems(); }}
-                  disabled={state.linkedItemCount === 0 || state.isSyncing || state.hasPendingChanges}
-                  title={state.hasPendingChanges ? 'Push template changes first' : state.linkedItemCount === 0 ? 'No deck items use this template' : undefined}
-                  className="w-full"
-                >
-                  {state.isSyncing ? 'Syncing…' : `Sync ${state.linkedItemCount} linked ${state.linkedItemCount === 1 ? 'item' : 'items'}`}
+                <ReacstButton onClick={actions.pushChanges} disabled={state.inspectorState.isPushingChanges} className="w-full">
+                  {state.inspectorState.isPushingChanges ? 'Pushing…' : state.inspectorState.pushLabel}
                 </ReacstButton>
               </RecastPanel.Footer>
-            ) : null}
+            )}
           </RecastPanel.Root>
         </SplitPanel.Segment>
       </SplitPanel.Panel>
@@ -144,17 +128,7 @@ function TemplateEditorScreenContent() {
   );
 }
 
-function ActiveTemplateTile({ isActive, ...props }: React.ComponentProps<typeof Thumbnail.Tile> & { isActive: boolean }) {
+function ActiveStageTile({ isActive, ...props }: React.ComponentProps<typeof Thumbnail.Tile> & { isActive: boolean }) {
   const ref = useScrollAreaActiveItem(isActive);
   return <Thumbnail.Tile ref={ref} {...props} />;
-}
-
-function TemplateKindIcon({ kind }: { kind: Template['kind'] }) {
-  if (kind === 'lyrics') {
-    return <Music size={14} strokeWidth={1.75} className="shrink-0 text-tertiary" />;
-  }
-  if (kind === 'overlays') {
-    return <Layers size={14} strokeWidth={1.75} className="shrink-0 text-tertiary" />;
-  }
-  return <Presentation size={14} strokeWidth={1.75} className="shrink-0 text-tertiary" />;
 }

--- a/app/renderer/screens/stage-editor/screen-context.tsx
+++ b/app/renderer/screens/stage-editor/screen-context.tsx
@@ -1,0 +1,60 @@
+import { useMemo, type ReactNode } from 'react';
+import { useStageEditor } from '../../contexts/asset-editor/asset-editor-context';
+import { useInspectorPanelPushAction } from '../../features/canvas/use-inspector-panel-push-action';
+import { getEditorHeaderActions } from '../../features/workbench/editor-header-actions';
+import { useEditorLeftPanelNav } from '../../features/workbench/use-editor-left-panel-nav';
+import { createScreenContext } from '../../contexts/create-screen-context';
+
+interface StageEditorScreenContextValue {
+  meta: {
+    screenId: 'stage-editor';
+    listTitle: 'Stages';
+    addActions: ReturnType<typeof getEditorHeaderActions>;
+  };
+  state: {
+    stages: ReturnType<typeof useStageEditor>['stages'];
+    currentStageId: ReturnType<typeof useStageEditor>['currentStageId'];
+    inspectorState: ReturnType<typeof useInspectorPanelPushAction>['state'];
+  };
+  actions: {
+    selectStage: (id: string | null) => void;
+    createStage: () => Promise<void>;
+    pushChanges: () => void;
+  };
+}
+
+const [StageEditorScreenContextProvider, useStageEditorScreen] = createScreenContext<StageEditorScreenContextValue>('StageEditorScreenContext');
+
+export function StageEditorScreenProvider({ children }: { children: ReactNode }) {
+  const { stages, currentStageId, setCurrentStageId, createStage } = useStageEditor();
+  const { state: inspectorState, handlePushChanges } = useInspectorPanelPushAction();
+  const addActions = useMemo(() => getEditorHeaderActions('stage-editor'), []);
+
+  useEditorLeftPanelNav({
+    items: stages,
+    currentId: currentStageId,
+    activate: (id) => setCurrentStageId(id),
+  });
+
+  const value = useMemo<StageEditorScreenContextValue>(() => ({
+    meta: {
+      screenId: 'stage-editor',
+      listTitle: 'Stages',
+      addActions,
+    },
+    state: {
+      stages,
+      currentStageId,
+      inspectorState,
+    },
+    actions: {
+      selectStage: setCurrentStageId,
+      createStage,
+      pushChanges: handlePushChanges,
+    },
+  }), [addActions, createStage, currentStageId, handlePushChanges, inspectorState, setCurrentStageId, stages]);
+
+  return <StageEditorScreenContextProvider value={value}>{children}</StageEditorScreenContextProvider>;
+}
+
+export { useStageEditorScreen };

--- a/app/renderer/screens/template-editor/screen-context.tsx
+++ b/app/renderer/screens/template-editor/screen-context.tsx
@@ -1,0 +1,104 @@
+import { useMemo, useState, type ReactNode } from 'react';
+import { isTemplateCompatibleWithDeckItem } from '@core/templates';
+import { useTemplateEditor } from '../../contexts/asset-editor/asset-editor-context';
+import { useProjectContent } from '../../contexts/use-project-content';
+import { getEditorHeaderActions } from '../../features/workbench/editor-header-actions';
+import { useEditorLeftPanelNav } from '../../features/workbench/use-editor-left-panel-nav';
+import { createScreenContext } from '../../contexts/create-screen-context';
+
+interface TemplateEditorScreenContextValue {
+  meta: {
+    screenId: 'template-editor';
+    listTitle: 'Templates';
+    addActions: ReturnType<typeof getEditorHeaderActions>;
+  };
+  state: {
+    templates: ReturnType<typeof useTemplateEditor>['templates'];
+    currentTemplateId: ReturnType<typeof useTemplateEditor>['currentTemplateId'];
+    currentTemplate: ReturnType<typeof useTemplateEditor>['currentTemplate'];
+    hasPendingChanges: boolean;
+    linkedItemCount: number;
+    isSyncing: boolean;
+  };
+  actions: {
+    selectTemplate: (id: string) => void;
+    requestTemplateNameFocus: (id: string) => void;
+    createTemplate: ReturnType<typeof useTemplateEditor>['createTemplate'];
+    syncLinkedItems: () => Promise<void>;
+  };
+}
+
+const [TemplateEditorScreenContextProvider, useTemplateEditorScreen] = createScreenContext<TemplateEditorScreenContextValue>('TemplateEditorScreenContext');
+
+export function TemplateEditorScreenProvider({ children }: { children: ReactNode }) {
+  const {
+    templates,
+    currentTemplateId,
+    currentTemplate,
+    hasPendingChanges,
+    openTemplateEditor,
+    requestNameFocus,
+    syncLinkedDeckItems,
+    createTemplate,
+  } = useTemplateEditor();
+  const { deckItems } = useProjectContent();
+  const [isSyncing, setIsSyncing] = useState(false);
+  const addActions = useMemo(() => getEditorHeaderActions('template-editor'), []);
+
+  const linkedItemCount = currentTemplate
+    ? deckItems.filter((item) => item.templateId === currentTemplate.id && isTemplateCompatibleWithDeckItem(currentTemplate, item.type)).length
+    : 0;
+
+  useEditorLeftPanelNav({
+    items: templates,
+    currentId: currentTemplateId,
+    activate: (id) => openTemplateEditor(id),
+  });
+
+  async function handleSyncLinkedItems() {
+    if (!currentTemplate || linkedItemCount === 0) return;
+    setIsSyncing(true);
+    try {
+      await syncLinkedDeckItems(currentTemplate.id);
+    } finally {
+      setIsSyncing(false);
+    }
+  }
+
+  const value = useMemo<TemplateEditorScreenContextValue>(() => ({
+    meta: {
+      screenId: 'template-editor',
+      listTitle: 'Templates',
+      addActions,
+    },
+    state: {
+      templates,
+      currentTemplateId,
+      currentTemplate,
+      hasPendingChanges,
+      linkedItemCount,
+      isSyncing,
+    },
+    actions: {
+      selectTemplate: openTemplateEditor,
+      requestTemplateNameFocus: requestNameFocus,
+      createTemplate,
+      syncLinkedItems: handleSyncLinkedItems,
+    },
+  }), [
+    addActions,
+    createTemplate,
+    currentTemplate,
+    currentTemplateId,
+    hasPendingChanges,
+    isSyncing,
+    linkedItemCount,
+    openTemplateEditor,
+    requestNameFocus,
+    templates,
+  ]);
+
+  return <TemplateEditorScreenContextProvider value={value}>{children}</TemplateEditorScreenContextProvider>;
+}
+
+export { useTemplateEditorScreen };

--- a/app/renderer/types/ui.ts
+++ b/app/renderer/types/ui.ts
@@ -4,12 +4,15 @@ export type ThemeMode = 'light' | 'dark' | 'system';
 export type SlideBrowserMode = 'grid' | 'list';
 export type ResourceDrawerViewMode = 'grid' | 'list';
 export type PlaylistBrowserMode = 'current' | 'tabs' | 'continuous';
-export type WorkbenchMode = 'show' | 'deck-editor' | 'overlay-editor' | 'template-editor' | 'settings';
+export type WorkbenchMode = 'show' | 'deck-editor' | 'overlay-editor' | 'template-editor' | 'stage-editor' | 'settings';
 export type InteractionMode = 'move' | 'resize';
 export type DrawerTab = 'deck' | 'media' | 'audio' | 'templates';
 export type DrawerViewModeMap = Record<DrawerTab, ResourceDrawerViewMode>;
 export type InspectorTab = 'presentation' | 'slide' | 'shape' | 'text' | 'template';
 export type LibraryPanelView = 'libraries' | 'playlist';
+export type PreviewSurfaceKind = 'preview' | 'monitor' | 'stage';
+export type PreviewMode = 'single' | 'all';
+export type PreviewGridDensity = 1 | 2;
 export type SlideVisualState = 'live' | 'queued' | 'selected' | 'warning';
 export type ResizeHandle = 'n' | 'ne' | 'e' | 'se' | 's' | 'sw' | 'w' | 'nw';
 

--- a/app/renderer/workbench-screen-router.tsx
+++ b/app/renderer/workbench-screen-router.tsx
@@ -4,6 +4,7 @@ import { DeckEditorScreen } from './screens/deck-editor/page';
 import { OverlayEditorScreen } from './screens/overlay-editor/page';
 import { SettingsScreen } from './screens/settings/page';
 import { ShowScreen } from './screens/show/page';
+import { StageEditorScreen } from './screens/stage-editor/page';
 import { TemplateEditorScreen } from './screens/template-editor/page';
 
 export function WorkbenchScreenRouter() {
@@ -25,6 +26,10 @@ export function WorkbenchScreenRouter() {
 
   if (workbenchMode === 'template-editor') {
     return <TemplateEditorScreen />;
+  }
+
+  if (workbenchMode === 'stage-editor') {
+    return <StageEditorScreen />;
   }
 
   return <SettingsScreen />;


### PR DESCRIPTION
## Summary
- add typed editor-source routing for deck, overlay, template, and stage editing
- introduce dedicated screen providers that shape global state into screen-local meta/state/actions
- add stage playback/output UI plumbing and related renderer updates

## Verification
- `npm test`
- `npm run typecheck` is still blocked by pre-existing unused-symbol errors in `app/renderer/components/form/doc-sortable-block.tsx`
