### PR TITLE
[codex] Improve renderer startup resilience

### DIFF
--- a/app/renderer/App.tsx
+++ b/app/renderer/App.tsx
@@ -56,12 +56,37 @@ export function App() {
 }
 
 function AppLayoutContent() {
-  const { snapshot } = useCast();
+  const { snapshot, isLoadingSnapshot, snapshotLoadError, retrySnapshotLoad } = useCast();
 
-  if (!snapshot) {
+  if (isLoadingSnapshot) {
     return (
       <div className="flex items-center justify-center h-full text-secondary">
         Loading Recast App
+      </div>
+    );
+  }
+
+  if (!snapshot) {
+    return (
+      <div className="flex h-full items-center justify-center p-6">
+        <div className="flex max-w-xl flex-col gap-3 rounded-lg border border-secondary bg-secondary/30 p-5 text-left">
+          <div className="text-base font-semibold text-primary">Recast could not load its project data.</div>
+          <div className="text-sm text-secondary">
+            {snapshotLoadError ?? 'Unknown startup error.'}
+          </div>
+          <div className="text-xs text-tertiary">
+            This often points to a corrupted or incompatible local database on this machine.
+          </div>
+          <div>
+            <button
+              type="button"
+              onClick={() => { void retrySnapshotLoad(); }}
+              className="rounded-sm bg-brand_solid px-3 py-1.5 text-sm font-medium text-primary transition-opacity hover:opacity-90"
+            >
+              Retry startup
+            </button>
+          </div>
+        </div>
       </div>
     );
   }

--- a/app/renderer/contexts/app-context.tsx
+++ b/app/renderer/contexts/app-context.tsx
@@ -10,6 +10,8 @@ import { useLocalStorage } from '../hooks/use-local-storage';
 interface AppContextValue {
   state: {
     snapshot: AppSnapshot | null;
+    isLoadingSnapshot: boolean;
+    snapshotLoadError: string | null;
     isRunningOperation: boolean;
     operationText: string | null;
     statusText: string;
@@ -28,6 +30,7 @@ interface AppContextValue {
     redo: () => Promise<void>;
     runOperation: <T>(text: string, action: () => Promise<T>) => Promise<T>;
     setStatusText: (text: string) => void;
+    retrySnapshotLoad: () => Promise<void>;
     setThemeMode: (mode: ThemeMode) => void;
     setNdiOutputEnabled: (name: NdiOutputName, enabled: boolean) => void;
     toggleAudienceOutput: () => void;
@@ -40,6 +43,8 @@ interface AppContextValue {
 
 interface CastSlice {
   snapshot: AppSnapshot | null;
+  isLoadingSnapshot: boolean;
+  snapshotLoadError: string | null;
   isRunningOperation: boolean;
   operationText: string | null;
   statusText: string;
@@ -51,6 +56,7 @@ interface CastSlice {
   redo: () => Promise<void>;
   runOperation: <T>(text: string, action: () => Promise<T>) => Promise<T>;
   setStatusText: (text: string) => void;
+  retrySnapshotLoad: () => Promise<void>;
 }
 
 interface ThemeSlice {
@@ -95,6 +101,8 @@ const AppContext = createContext<AppContextValue | null>(null);
 export function AppProvider({ children }: { children: ReactNode }) {
   // ── Snapshot & mutation queue ──
   const [snapshot, setSnapshot] = useState<AppSnapshot | null>(null);
+  const [isLoadingSnapshot, setIsLoadingSnapshot] = useState(true);
+  const [snapshotLoadError, setSnapshotLoadError] = useState<string | null>(null);
   const [isRunningOperation, setIsRunningOperation] = useState(false);
   const [operationText, setOperationText] = useState<string | null>(null);
   const [statusText, setStatusText] = useState('Ready');
@@ -127,15 +135,35 @@ export function AppProvider({ children }: { children: ReactNode }) {
     syncHistoryFlags();
   }, [syncHistoryFlags]);
 
-  useEffect(() => {
-    void window.castApi.getSnapshot().then((loaded) => {
+  const loadInitialSnapshot = useCallback(async () => {
+    setIsLoadingSnapshot(true);
+    setSnapshotLoadError(null);
+
+    try {
+      const loaded = await Promise.race<AppSnapshot>([
+        window.castApi.getSnapshot(),
+        new Promise<AppSnapshot>((_, reject) => {
+          window.setTimeout(() => reject(new Error('Timed out while loading project data.')), 15000);
+        }),
+      ]);
       snapshotRef.current = loaded;
       setSnapshot(loaded);
-    }).catch((error) => {
+      setStatusText('Ready');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
       console.error('[AppProvider] Failed to load snapshot:', error);
+      snapshotRef.current = null;
+      setSnapshot(null);
+      setSnapshotLoadError(message);
       setStatusText('Failed to load data');
-    });
+    } finally {
+      setIsLoadingSnapshot(false);
+    }
   }, []);
+
+  useEffect(() => {
+    void loadInitialSnapshot();
+  }, [loadInitialSnapshot]);
 
   const mutate = useCallback((action: () => Promise<AppSnapshot>) => {
     const run = async () => {
@@ -346,6 +374,8 @@ export function AppProvider({ children }: { children: ReactNode }) {
   // ── Context value ──
   const state = useMemo<AppContextValue['state']>(() => ({
     snapshot,
+    isLoadingSnapshot,
+    snapshotLoadError,
     isRunningOperation,
     operationText,
     statusText,
@@ -356,7 +386,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
     ndiDiagnostics,
     ndiOutputConfigs,
     ndiOutputState,
-  }), [snapshot, isRunningOperation, operationText, statusText, canUndo, canRedo, themeMode, resolvedTheme, ndiDiagnostics, ndiOutputConfigs, ndiOutputState]);
+  }), [snapshot, isLoadingSnapshot, snapshotLoadError, isRunningOperation, operationText, statusText, canUndo, canRedo, themeMode, resolvedTheme, ndiDiagnostics, ndiOutputConfigs, ndiOutputState]);
 
   const actions = useMemo<AppContextValue['actions']>(() => ({
     mutate,
@@ -365,12 +395,13 @@ export function AppProvider({ children }: { children: ReactNode }) {
     redo,
     runOperation,
     setStatusText,
+    retrySnapshotLoad: loadInitialSnapshot,
     setThemeMode,
     setNdiOutputEnabled,
     toggleAudienceOutput,
     toggleStageOutput,
     updateNdiOutputConfig,
-  }), [mutate, mutatePatch, undo, redo, runOperation, setThemeMode, setNdiOutputEnabled, toggleAudienceOutput, toggleStageOutput, updateNdiOutputConfig]);
+  }), [mutate, mutatePatch, undo, redo, runOperation, loadInitialSnapshot, setThemeMode, setNdiOutputEnabled, toggleAudienceOutput, toggleStageOutput, updateNdiOutputConfig]);
 
   const value = useMemo<AppContextValue>(() => ({ state, actions }), [state, actions]);
 
@@ -389,6 +420,8 @@ export function useCast(): CastSlice {
   const { state, actions } = useApp();
   return {
     snapshot: state.snapshot,
+    isLoadingSnapshot: state.isLoadingSnapshot,
+    snapshotLoadError: state.snapshotLoadError,
     isRunningOperation: state.isRunningOperation,
     operationText: state.operationText,
     statusText: state.statusText,
@@ -400,6 +433,7 @@ export function useCast(): CastSlice {
     redo: actions.redo,
     runOperation: actions.runOperation,
     setStatusText: actions.setStatusText,
+    retrySnapshotLoad: actions.retrySnapshotLoad,
   };
 }
 

--- a/app/renderer/features/canvas/scene-stage.tsx
+++ b/app/renderer/features/canvas/scene-stage.tsx
@@ -1,6 +1,6 @@
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { Fragment } from 'react';
-import { FastLayer, Layer, Line, Rect, Stage, Transformer, Group } from 'react-konva';
+import { Layer, Line, Rect, Stage, Transformer, Group } from 'react-konva';
 import type Konva from 'konva';
 import type { Id, NdiOutputName } from '@core/types';
 import { ContextMenu } from '../../components/overlays/context-menu';
@@ -200,8 +200,6 @@ export function SceneStage({ scene, surface = 'show', editable = false, classNam
     handleNodeDragStart,
     handleNodeDragMove,
   } = editor;
-  const SceneLayer = editable ? Layer : FastLayer;
-
   // Konva renders Stage at its literal width/height in CSS pixels. When
   // fixedViewport is set (preview/monitor/stage NDI surfaces) those dimensions
   // are 1920x1080 — far larger than the actual on-screen container — so we
@@ -230,7 +228,7 @@ export function SceneStage({ scene, surface = 'show', editable = false, classNam
         onMouseMove={editor.handleStageMouseMove}
         onMouseUp={editor.handleStageMouseUp}
       >
-        <SceneLayer listening={editable}>
+        <Layer listening={editable}>
           <Group name="scene-root" x={viewport.sceneOffsetX} y={viewport.sceneOffsetY} scaleX={viewport.sceneScale} scaleY={viewport.sceneScale}>
             {scene.nodes.map((node) => (
               <SceneNode
@@ -273,7 +271,7 @@ export function SceneStage({ scene, surface = 'show', editable = false, classNam
               </>
             ) : null}
           </Group>
-        </SceneLayer>
+        </Layer>
 
         {editable && editor.selectionBox ? (
           <Layer listening={false}>

--- a/app/renderer/features/deck/deck-bin-panel.tsx
+++ b/app/renderer/features/deck/deck-bin-panel.tsx
@@ -40,7 +40,6 @@ export function DeckBinPanel({ filterText, gridItemSize }: DeckBinPanelProps) {
     >
       {filteredDeckItems.map((presentation) => {
         const shared = {
-          key: presentation.id,
           item: presentation,
           slides: slidesByDeckItemId.get(presentation.id) ?? [],
           isSelected: isDetachedDeckBrowser && currentDrawerDeckItemId === presentation.id,
@@ -49,8 +48,8 @@ export function DeckBinPanel({ filterText, gridItemSize }: DeckBinPanelProps) {
           onRename: handleRename,
         };
         return drawerViewMode === 'list'
-          ? <DeckItemRow {...shared} />
-          : <DeckItemTile {...shared} />;
+          ? <DeckItemRow key={presentation.id} {...shared} />
+          : <DeckItemTile key={presentation.id} {...shared} />;
       })}
     </BinPanelLayout>
   );

--- a/app/renderer/index.html
+++ b/app/renderer/index.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; base-uri 'self'; object-src 'none'; frame-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: cast-media:; media-src 'self' data: blob: cast-media:; font-src 'self' data:; connect-src 'self' ws://localhost:* http://localhost:* ws://127.0.0.1:* http://127.0.0.1:*"
+    />
     <meta name="description" content="Cross-platform presentation tool with reusable content hierarchy, slide rendering, and NDI output" />
     <meta property="og:title" content="Recast" />
     <meta property="og:description" content="Cross-platform presentation tool with reusable content hierarchy, slide rendering, and NDI output" />


### PR DESCRIPTION
## What changed
- added explicit snapshot loading, timeout, and retry handling during renderer startup
- show a user-facing error state when project data fails to load
- tightened the renderer CSP in `index.html`
- fixed a React key placement issue in the deck bin and removed the `FastLayer` path so the scene stage consistently uses `Layer`

## Why
Startup could fail without a recoverable UI path, leaving the app in an unclear state. This change makes the failure mode visible and retryable while also rolling in a couple of small renderer correctness fixes.

## Impact
- users get a clearer startup experience when local project data is unavailable or corrupted
- the renderer has a stricter content security policy
- list rendering and canvas layering behavior are more predictable

## Validation
- not run in this environment because `npm` is unavailable, so `npm run typecheck` could not be executed here