### PR TITLE
Release 0.1.7: startup logging + Windows launch hardening

### DIFF
--- a/app/main/index.ts
+++ b/app/main/index.ts
@@ -1,11 +1,15 @@
 import { app, BrowserWindow, Menu, nativeImage, protocol, type BrowserWindowConstructorOptions } from 'electron';
+import fs from 'node:fs';
 import path from 'node:path';
 import { CastRepository } from '@database/store';
 import { AppUpdater } from './app-updater';
 import { createApplicationMenu } from './application-menu';
 import { registerIpcHandlers } from './ipc';
+import { initializeLogger, getLogFilePath } from './logger';
 import { NdiServiceProxy } from './ndi/ndi-service-proxy';
+import { NoopNdiService } from './ndi/ndi-noop-service';
 import { NdiConfigStore } from './ndi/ndi-config-store';
+import type { NdiServiceLike } from './ndi/ndi-protocol';
 import {
   createForbiddenResponse,
   createNotFoundResponse,
@@ -33,12 +37,25 @@ if (cliOptions.userDataDir) {
   app.setPath('userData', path.resolve(cliOptions.userDataDir));
 }
 
+const documentsDataDir = path.join(app.getPath('documents'), APP_NAME);
+try {
+  fs.mkdirSync(documentsDataDir, { recursive: true });
+} catch (error) {
+  // Logger will fall back to stderr-only if the Documents dir is not writable.
+  console.error('[Main process documents dir mkdir failed]', error);
+}
+initializeLogger(documentsDataDir);
+console.log(`[main] userData=${app.getPath('userData')}`);
+console.log(`[main] documentsDataDir=${documentsDataDir}`);
+console.log(`[main] logFile=${getLogFilePath()}`);
+console.log(`[main] argv=${process.argv.slice(1).join(' ')}`);
+
 let mainWindow: BrowserWindow | null = null;
 const WORKBENCH_MIN_WIDTH = 140 + 360 + 140;
 const WORKBENCH_MIN_HEIGHT = Math.max(360 + 96, 240 + 120) + 96;
 const repository = new CastRepository();
 const ndiConfigStore = new NdiConfigStore();
-let ndiService: NdiServiceProxy | null = null;
+let ndiService: NdiServiceLike | null = null;
 let isShuttingDown = false;
 const appUpdater = new AppUpdater({
   getMainWindow: () => mainWindow,
@@ -174,9 +191,40 @@ function createMainWindow(): void {
   if (process.platform === 'win32') {
     window.setMenuBarVisibility(false);
   }
-  window.once('ready-to-show', () => {
+
+  let shown = false;
+  const showWindow = (reason: string) => {
+    if (shown || window.isDestroyed()) return;
+    shown = true;
+    console.log(`[window] showing (${reason})`);
     window.show();
+  };
+
+  window.once('ready-to-show', () => showWindow('ready-to-show'));
+
+  // Fallback: if ready-to-show never fires (renderer crash, blocked load),
+  // show the window anyway so the user isn't stuck with a hidden process.
+  setTimeout(() => showWindow('fallback-timeout'), 5000);
+
+  window.webContents.on('did-fail-load', (_event, errorCode, errorDescription, validatedURL, isMainFrame) => {
+    if (!isMainFrame) return;
+    console.error('[renderer] did-fail-load', { errorCode, errorDescription, validatedURL });
+    showWindow('did-fail-load');
   });
+  window.webContents.on('render-process-gone', (_event, details) => {
+    console.error('[renderer] render-process-gone', details);
+    showWindow('render-process-gone');
+  });
+  window.webContents.on('preload-error', (_event, preloadPath, error) => {
+    console.error('[renderer] preload-error', { preloadPath, message: error?.message, stack: error?.stack });
+  });
+  window.webContents.on('console-message', (_event, level, message, line, sourceId) => {
+    console.log(`[renderer:console l=${level}] ${message} (${sourceId}:${line})`);
+  });
+  window.on('unresponsive', () => {
+    console.warn('[window] unresponsive');
+  });
+
   loadRendererView(window, cliOptions.rendererView);
   window.on('closed', () => {
     if (mainWindow === window) {
@@ -218,13 +266,20 @@ app.whenReady().then(() => {
   });
 
   Menu.setApplicationMenu(createApplicationMenu());
-  ndiService = new NdiServiceProxy({
-    outputConfigs: ndiConfigStore.load(),
-    onOutputConfigsChanged: (configs) => {
-      ndiConfigStore.save(configs);
-    },
-    hostModulePath: path.join(__dirname, 'ndi-host.js'),
-  });
+  const initialNdiConfigs = ndiConfigStore.load();
+  try {
+    ndiService = new NdiServiceProxy({
+      outputConfigs: initialNdiConfigs,
+      onOutputConfigsChanged: (configs) => {
+        ndiConfigStore.save(configs);
+      },
+      hostModulePath: path.join(__dirname, 'ndi-host.js'),
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error('[Main process NDI init failed — continuing without NDI]', error);
+    ndiService = new NoopNdiService(initialNdiConfigs, `NDI service unavailable: ${message}`);
+  }
   registerIpcHandlers(repository, ndiService, () => mainWindow, appUpdater);
   createMainWindow();
   appUpdater.initialize();
@@ -235,6 +290,8 @@ app.whenReady().then(() => {
       createMainWindow();
     }
   });
+}).catch((error) => {
+  console.error('[Main process app.whenReady failure]', error);
 });
 
 app.on('window-all-closed', () => {

--- a/app/main/logger.ts
+++ b/app/main/logger.ts
@@ -1,0 +1,96 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+type ConsoleMethod = 'log' | 'info' | 'warn' | 'error';
+
+const LEVEL_BY_METHOD: Record<ConsoleMethod, string> = {
+  log: 'INFO',
+  info: 'INFO',
+  warn: 'WARN',
+  error: 'ERROR',
+};
+
+let logFilePath: string | null = null;
+let writeStream: fs.WriteStream | null = null;
+let initialized = false;
+
+export function initializeLogger(baseDir: string): void {
+  if (initialized) return;
+  initialized = true;
+
+  const logsDir = path.join(baseDir, 'logs');
+  try {
+    fs.mkdirSync(logsDir, { recursive: true });
+  } catch (error) {
+    // Without a log dir we still patch console so messages reach stderr.
+    console.error('[logger] Could not create logs dir:', error);
+  }
+
+  logFilePath = path.join(logsDir, 'main.log');
+  try {
+    rotateIfLarge(logFilePath);
+    writeStream = fs.createWriteStream(logFilePath, { flags: 'a' });
+  } catch (error) {
+    writeStream = null;
+    console.error('[logger] Could not open log file:', error);
+  }
+
+  patchConsole('log');
+  patchConsole('info');
+  patchConsole('warn');
+  patchConsole('error');
+
+  writeLine('INFO', [
+    `[logger] Logging to ${logFilePath}`,
+    `pid=${process.pid}`,
+    `platform=${process.platform}`,
+    `arch=${process.arch}`,
+    `electron=${process.versions.electron ?? 'n/a'}`,
+    `node=${process.versions.node}`,
+  ]);
+}
+
+export function getLogFilePath(): string | null {
+  return logFilePath;
+}
+
+function patchConsole(method: ConsoleMethod): void {
+  const original = console[method].bind(console);
+  console[method] = (...args: unknown[]) => {
+    original(...args);
+    writeLine(LEVEL_BY_METHOD[method], args);
+  };
+}
+
+function writeLine(level: string, args: unknown[]): void {
+  if (!writeStream) return;
+  try {
+    const ts = new Date().toISOString();
+    const text = args.map(formatArg).join(' ');
+    writeStream.write(`${ts} ${level} ${text}\n`);
+  } catch {
+    // Swallow — logging must never crash the app.
+  }
+}
+
+function formatArg(arg: unknown): string {
+  if (typeof arg === 'string') return arg;
+  if (arg instanceof Error) return arg.stack ?? `${arg.name}: ${arg.message}`;
+  if (arg === null || arg === undefined) return String(arg);
+  try {
+    return JSON.stringify(arg);
+  } catch {
+    return String(arg);
+  }
+}
+
+function rotateIfLarge(filePath: string): void {
+  try {
+    const stats = fs.statSync(filePath);
+    if (stats.size > 5 * 1024 * 1024) {
+      fs.renameSync(filePath, `${filePath}.1`);
+    }
+  } catch {
+    // File doesn't exist yet — nothing to rotate.
+  }
+}

--- a/app/main/ndi/ndi-noop-service.ts
+++ b/app/main/ndi/ndi-noop-service.ts
@@ -1,0 +1,73 @@
+import type {
+  NdiDiagnostics,
+  NdiOutputConfig,
+  NdiOutputConfigMap,
+  NdiOutputName,
+  NdiOutputState,
+} from '@core/types';
+import type { NdiServiceLike } from './ndi-protocol';
+
+/**
+ * Used as a fallback when the NDI utility process can't be started — the rest
+ * of the app stays usable; only NDI output is disabled.
+ */
+export class NoopNdiService implements NdiServiceLike {
+  private outputConfigs: NdiOutputConfigMap;
+  private readonly state: NdiOutputState = { audience: false, stage: false };
+  private readonly errorMessage: string;
+
+  constructor(outputConfigs: NdiOutputConfigMap, errorMessage: string) {
+    this.outputConfigs = outputConfigs;
+    this.errorMessage = errorMessage;
+  }
+
+  getOutputState(): NdiOutputState {
+    return { ...this.state };
+  }
+
+  getOutputConfigs(): NdiOutputConfigMap {
+    return { ...this.outputConfigs };
+  }
+
+  getDiagnostics(): NdiDiagnostics {
+    return {
+      outputState: this.getOutputState(),
+      outputConfig: { ...this.outputConfigs.audience },
+      outputConfigs: this.getOutputConfigs(),
+      runtimeLoaded: false,
+      runtimePath: null,
+      activeSender: null,
+      senders: { audience: null, stage: null },
+      sourceStatus: 'idle',
+      lastError: this.errorMessage,
+    };
+  }
+
+  setOutputEnabled(_name: NdiOutputName, _enabled: boolean): NdiOutputState {
+    return this.getOutputState();
+  }
+
+  updateOutputConfig(name: NdiOutputName, config: Partial<NdiOutputConfig>): NdiOutputConfigMap {
+    this.outputConfigs = {
+      ...this.outputConfigs,
+      [name]: { ...this.outputConfigs[name], ...config },
+    };
+    return this.getOutputConfigs();
+  }
+
+  receiveFrame(): void {
+    // Silently dropped — NDI output is unavailable.
+  }
+
+  onOutputStateChanged(): () => void {
+    return () => undefined;
+  }
+
+  onDiagnosticsChanged(): () => void {
+    return () => undefined;
+  }
+
+  destroy(): void {
+    // Nothing to tear down.
+  }
+}

--- a/app/main/ndi/ndi-service-proxy.ts
+++ b/app/main/ndi/ndi-service-proxy.ts
@@ -36,15 +36,22 @@ export class NdiServiceProxy implements NdiServiceLike {
     this.cachedOutputConfigs = options.outputConfigs;
     this.onOutputConfigsChanged = options.onOutputConfigsChanged;
     this.cachedDiagnostics = createInitialDiagnostics(options.outputConfigs);
-    this.host = utilityProcess.fork(options.hostModulePath, [], {
-      serviceName: 'ndi-host',
-      stdio: 'pipe',
-    });
+    console.log(`[NdiServiceProxy] Forking host at ${options.hostModulePath}`);
+    try {
+      this.host = utilityProcess.fork(options.hostModulePath, [], {
+        serviceName: 'ndi-host',
+        stdio: 'pipe',
+      });
+    } catch (error) {
+      console.error(`[NdiServiceProxy] Failed to fork host at ${options.hostModulePath}:`, error);
+      throw error;
+    }
     this.host.stdout?.on('data', (chunk: Buffer) => {
-      process.stdout.write(`[ndi-host] ${chunk.toString()}`);
+      // Route through console so the file logger captures host stdout.
+      console.log(`[ndi-host] ${stripTrailingNewline(chunk.toString())}`);
     });
     this.host.stderr?.on('data', (chunk: Buffer) => {
-      process.stderr.write(`[ndi-host] ${chunk.toString()}`);
+      console.error(`[ndi-host] ${stripTrailingNewline(chunk.toString())}`);
     });
     this.host.on('exit', (code) => {
       if (!this.destroyed) {
@@ -168,6 +175,10 @@ export class NdiServiceProxy implements NdiServiceLike {
         break;
     }
   }
+}
+
+function stripTrailingNewline(text: string): string {
+  return text.endsWith('\n') ? text.slice(0, -1) : text;
 }
 
 function createInitialDiagnostics(configs: NdiOutputConfigMap): NdiDiagnostics {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lumacast",
-  "version": "0.1.3",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lumacast",
-      "version": "0.1.3",
+      "version": "0.1.7",
       "license": "UNLICENSED",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
@@ -2859,6 +2859,64 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lumacast",
   "productName": "LumaCast",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "private": true,
   "description": "Cross-platform presentation tool with reusable content hierarchy, slide rendering, and NDI output",
   "author": "IT-PSAPE",


### PR DESCRIPTION
## Summary
- Adds a file logger at `~/Documents/LumaCast/logs/main.log` (technical app data — `lumacast.sqlite` and `ndi-output-config.json` — stays in the platform `userData` dir).
- Hardens the main-process launch path so a failed NDI utility-process fork no longer leaves Windows users with a hidden process: window force-shows after 5s, `did-fail-load` / `render-process-gone` / `preload-error` are logged, and `NdiServiceProxy` falls back to a `NoopNdiService` when the host can't start.
- Picks up earlier dev-only work (NDI subprocess isolation, lyric parser, collection/video pool fixes, release workflow gating).
- Bumps to 0.1.7.

## Test plan
- [ ] Install on Windows and confirm the window opens (was previously stuck in Task Manager with no UI).
- [ ] Confirm `~/Documents/LumaCast/logs/main.log` is written on launch and contains the renderer load events.
- [ ] Confirm `lumacast.sqlite` and `ndi-output-config.json` still live in the platform AppData/`userData` dir.
- [ ] On macOS, confirm existing data continues to load (no migration performed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)