### PR TITLE
[codex] Fix NDI frame IPC delivery

### DIFF
--- a/app/main/ndi/ndi-service-proxy.test.ts
+++ b/app/main/ndi/ndi-service-proxy.test.ts
@@ -1,0 +1,63 @@
+import { EventEmitter } from 'node:events';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createDefaultNdiOutputConfigs, NDI_OUTPUT_HEIGHT, NDI_OUTPUT_WIDTH } from '@core/ndi';
+import { NdiServiceProxy } from './ndi-service-proxy';
+
+const electronMock = vi.hoisted(() => ({
+  host: null as {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    postMessage: ReturnType<typeof vi.fn>;
+    kill: ReturnType<typeof vi.fn>;
+    on: EventEmitter['on'];
+  } | null,
+  fork: vi.fn(),
+}));
+
+vi.mock('electron', () => ({
+  utilityProcess: {
+    fork: electronMock.fork,
+  },
+}));
+
+describe('NdiServiceProxy', () => {
+  beforeEach(() => {
+    const events = new EventEmitter();
+    electronMock.host = {
+      stdout: new EventEmitter(),
+      stderr: new EventEmitter(),
+      postMessage: vi.fn(),
+      kill: vi.fn(),
+      on: events.on.bind(events),
+    };
+    electronMock.fork.mockReset();
+    electronMock.fork.mockReturnValue(electronMock.host);
+  });
+
+  it('posts frames to the utility host without an ArrayBuffer transfer list', () => {
+    const proxy = new NdiServiceProxy({
+      outputConfigs: createDefaultNdiOutputConfigs(),
+      onOutputConfigsChanged: vi.fn(),
+      hostModulePath: '/mock/ndi-host.js',
+    });
+    const host = electronMock.host!;
+    host.postMessage.mockClear();
+
+    const frame = new Uint8Array(NDI_OUTPUT_WIDTH * NDI_OUTPUT_HEIGHT * 4);
+    proxy.receiveFrame('audience', frame, NDI_OUTPUT_WIDTH, NDI_OUTPUT_HEIGHT, {
+      captureDurationMs: 1,
+      readbackDurationMs: 1,
+      skippedCaptures: 0,
+      framesDroppedBackpressure: 0,
+    });
+
+    expect(host.postMessage).toHaveBeenCalledTimes(1);
+    expect(host.postMessage.mock.calls[0]).toHaveLength(1);
+    expect(host.postMessage.mock.calls[0][0]).toMatchObject({
+      type: 'frame',
+      name: 'audience',
+      width: NDI_OUTPUT_WIDTH,
+      height: NDI_OUTPUT_HEIGHT,
+    });
+  });
+});

--- a/app/main/ndi/ndi-service-proxy.ts
+++ b/app/main/ndi/ndi-service-proxy.ts
@@ -97,13 +97,12 @@ export class NdiServiceProxy implements NdiServiceLike {
     telemetry?: NdiFrameTelemetry,
   ): void {
     if (this.destroyed) return;
-    // Transfer the buffer to the utility process so no copy occurs on this hop.
-    // rgba is a freshly-wrapped view over the IPC-owned ArrayBuffer; transferring is safe.
     const buffer = rgba.buffer as ArrayBuffer;
-    this.send(
-      { type: 'frame', name, buffer, width, height, telemetry },
-      [buffer],
-    );
+    // Keep the main -> utility-process hop on plain structured clone. Electron
+    // utilityProcess.postMessage only documents MessagePort transfer support;
+    // attempting ArrayBuffer transfer can throw before the NDI host receives the
+    // frame, leaving the sender advertised with zero frame diagnostics.
+    this.send({ type: 'frame', name, buffer, width, height, telemetry });
   }
 
   onOutputStateChanged(callback: StateChangeCallback): () => void {
@@ -135,21 +134,9 @@ export class NdiServiceProxy implements NdiServiceLike {
     }
   }
 
-  private send(cmd: NdiHostCommand, transfer?: ArrayBuffer[]): void {
+  private send(cmd: NdiHostCommand): void {
     if (this.destroyed) return;
-    // Electron's typings restrict the transfer list to MessagePortMain[], but the
-    // underlying V8 structured-clone serializer transfers ArrayBuffers as well.
-    // Call with proper `this` binding — postMessage uses private class fields
-    // internally and will throw if invoked without the receiver.
-    if (transfer && transfer.length > 0) {
-      (this.host.postMessage as unknown as (
-        this: UtilityProcess,
-        message: NdiHostCommand,
-        transferList: unknown[],
-      ) => void).call(this.host, cmd, transfer);
-    } else {
-      this.host.postMessage(cmd);
-    }
+    this.host.postMessage(cmd);
   }
 
   private handleHostEvent(event: NdiHostEvent): void {

--- a/app/main/preload.ts
+++ b/app/main/preload.ts
@@ -125,22 +125,10 @@ const api = {
     ipcRenderer.invoke(IPC.updateNdiOutputConfig, name, config) as Promise<NdiOutputConfigMap>,
   getNdiDiagnostics: () => ipcRenderer.invoke(IPC.getNdiDiagnostics) as Promise<NdiDiagnostics>,
   sendNdiFrame: (name: NdiOutputName, buffer: ArrayBuffer, width: number, height: number, telemetry?: NdiFrameTelemetry) => {
-    // postMessage transfers ownership of the ArrayBuffer to the main process
-    // (no copy). The transfer-list typing only documents MessagePort, but the
-    // underlying V8 structured-clone serializer transfers ArrayBuffers as well.
-    // Must keep the ipcRenderer receiver — postMessage uses private fields and
-    // throws if called without the right `this`.
-    (ipcRenderer.postMessage as unknown as (
-      this: typeof ipcRenderer,
-      channel: string,
-      message: unknown,
-      transfer: unknown[],
-    ) => void).call(
-      ipcRenderer,
-      IPC.sendNdiFrame,
-      { name, buffer, width, height, telemetry },
-      [buffer],
-    );
+    // Use ordinary IPC cloning for frame delivery. Electron's renderer
+    // transfer-list path rejects ArrayBuffer here, which prevents frames from
+    // reaching main and leaves NDI diagnostics stuck at zero.
+    ipcRenderer.send(IPC.sendNdiFrame, { name, buffer, width, height, telemetry });
   },
   onNdiOutputStateChanged: (callback: (state: NdiOutputState) => void) => {
     const handler = (_event: IpcRendererEvent, state: NdiOutputState) => callback(state);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lumacast",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lumacast",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "license": "UNLICENSED",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lumacast",
   "productName": "LumaCast",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "private": true,
   "description": "Cross-platform presentation tool with reusable content hierarchy, slide rendering, and NDI output",
   "author": "IT-PSAPE",


### PR DESCRIPTION
## Summary

Fixes NDI frame delivery after the utility-process migration by removing unsupported `ArrayBuffer` transfer-list usage across Electron IPC boundaries.

## Root Cause

The sender could be registered on the network while diagnostics stayed at zero because frame payloads were rejected before reaching the NDI service. The renderer -> main hop threw `Invalid value for transfer`, and the main -> utility-process hop used the same risky transfer-list pattern.

## Changes

- Send NDI frames from preload to main with ordinary `ipcRenderer.send` structured cloning.
- Send NDI frames from main to the NDI utility process without an `ArrayBuffer` transfer list.
- Add a regression test to ensure the NDI service proxy does not pass a transfer list for frame messages.
- Bump app version from `0.1.7` to `0.1.8`.

## Validation

- `npm test -- app/main/ndi/ndi-service.test.ts app/main/ndi/ndi-service-proxy.test.ts`
- `npm run typecheck`