### PR TITLE
Release 0.1.9: NDI audio output, observability panel, and stability fixes

### DIFF
--- a/app/core/ipc.ts
+++ b/app/core/ipc.ts
@@ -12,6 +12,8 @@ import type {
   CollectionDeleteInput,
   CollectionRenameInput,
   CollectionReorderInput,
+  LogReadResult,
+  LogSessionSummary,
   NdiDiagnostics,
   NdiOutputConfig,
   NdiOutputConfigMap,
@@ -22,6 +24,7 @@ import type {
   OverlayUpdateInput,
   StageCreateInput,
   StageUpdateInput,
+  SystemMetricsSnapshot,
   ThemeCreateInput,
   ThemeUpdateInput,
   SlideCreateInput,
@@ -126,6 +129,12 @@ export interface MainApi {
   getAudioCoverArt: (src: string) => Promise<string | null>;
   onNdiDiagnosticsChanged: (callback: (diagnostics: NdiDiagnostics) => void) => () => void;
   onNdiFrameAck: (callback: (name: NdiOutputName) => void) => () => void;
+  // Observability
+  obsListLogSessions: () => Promise<LogSessionSummary[]>;
+  obsReadLogSession: (filePath: string, offset: number, limit: number) => Promise<LogReadResult>;
+  obsGetCurrentLogPath: () => Promise<string | null>;
+  obsOpenLogFolder: () => Promise<void>;
+  obsGetSystemMetrics: () => Promise<SystemMetricsSnapshot>;
   createCollection: (input: CollectionCreateInput) => Promise<SnapshotPatch>;
   renameCollection: (input: CollectionRenameInput) => Promise<SnapshotPatch>;
   deleteCollection: (input: CollectionDeleteInput) => Promise<SnapshotPatch>;
@@ -289,6 +298,11 @@ export const IPC = {
   deleteCollection: 'cast:deleteCollection',
   reorderCollections: 'cast:reorderCollections',
   setItemCollection: 'cast:setItemCollection',
+  obsListLogSessions: 'obs:listLogSessions',
+  obsReadLogSession: 'obs:readLogSession',
+  obsGetCurrentLogPath: 'obs:getCurrentLogPath',
+  obsOpenLogFolder: 'obs:openLogFolder',
+  obsGetSystemMetrics: 'obs:getSystemMetrics',
 } as const;
 
 export const NDI_EVENTS = {

--- a/app/core/types.ts
+++ b/app/core/types.ts
@@ -578,6 +578,7 @@ export interface NdiActiveSenderDiagnostics {
   withAlpha: boolean;
   asyncVideoSend: boolean;
   connectionCount: number | null;
+  startedAtMs: number;
   performance: NdiSenderPerformanceDiagnostics;
   audio: NdiSenderAudioDiagnostics;
 }
@@ -602,7 +603,18 @@ export interface NdiSenderPerformanceDiagnostics {
   avgCaptureDurationMs: number;
   avgReadbackDurationMs: number;
   avgSendDurationMs: number;
+  // p50/p95/p99 of send durations over the rolling window — captures
+  // latency tail not visible from the average.
+  p50SendDurationMs: number;
+  p95SendDurationMs: number;
+  p99SendDurationMs: number;
+  // Standard deviation of the inter-send interval. High jitter is a
+  // strong signal that something upstream (capture, IPC, GC) is stalling.
+  sendIntervalJitterMs: number;
   lastFrameBytes: number;
+  minFrameBytes: number;
+  maxFrameBytes: number;
+  blackoutFramesSent: number;
 }
 
 export interface NdiSenderAudioDiagnostics {
@@ -610,6 +622,7 @@ export interface NdiSenderAudioDiagnostics {
   audioFramesSent: number;
   audioFramesRejected: number;
   audioSamplesSent: number;
+  audioSilenceFramesSent: number;
   lastSampleRate: number;
   lastChannels: number;
 }
@@ -679,4 +692,34 @@ export interface MediaAssetCreateInput {
   type: MediaAssetType;
   src: string;
   collectionId?: Id;
+}
+
+export interface SystemProcessMetrics {
+  rssBytes: number;
+  heapUsedBytes: number;
+  heapTotalBytes: number;
+  externalBytes: number;
+  cpuPercent: number;
+}
+
+export interface SystemMetricsSnapshot {
+  capturedAtMs: number;
+  uptimeSeconds: number;
+  main: SystemProcessMetrics;
+}
+
+export interface LogSessionSummary {
+  path: string;
+  fileName: string;
+  sizeBytes: number;
+  modifiedAtMs: number;
+  isCurrent: boolean;
+}
+
+export interface LogReadResult {
+  totalBytes: number;
+  // Byte offset returned to the caller for incremental reads. Pass back as
+  // `offset` to fetch the next chunk after `lines`.
+  nextOffset: number;
+  lines: string[];
 }

--- a/app/main/index.ts
+++ b/app/main/index.ts
@@ -66,7 +66,10 @@ function teardownNdi(reason: string, error?: unknown) {
     console.error(`[Main process ${reason}]`, error);
   }
   if (!ndiService) return;
+  console.log(`[Main process NDI teardown] reason=${reason}`);
   try {
+    // destroy() now performs its own best-effort blackout burst before
+    // releasing the native sender, so receivers see a clean cutoff.
     ndiService.destroy();
   } catch (destroyError) {
     console.error('[Main process NDI teardown failure]', destroyError);
@@ -213,6 +216,16 @@ function createMainWindow(): void {
   });
   window.webContents.on('render-process-gone', (_event, details) => {
     console.error('[renderer] render-process-gone', details);
+    // The renderer is the source of NDI frames — once it's gone, receivers
+    // would otherwise see whatever frame was in flight. Flush a quick
+    // blackout burst so the cutoff is visually clean.
+    if (ndiService) {
+      try {
+        ndiService.flushBlackoutAndDestroy(undefined, { totalBudgetMs: 500 });
+      } catch (error) {
+        console.error('[Main process render-process-gone blackout]', error);
+      }
+    }
     showWindow('render-process-gone');
   });
   window.webContents.on('preload-error', (_event, preloadPath, error) => {

--- a/app/main/ipc.ts
+++ b/app/main/ipc.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, clipboard, dialog, ipcMain, type IpcMainInvokeEvent } from 'electron';
+import { BrowserWindow, clipboard, dialog, ipcMain, shell, type IpcMainInvokeEvent } from 'electron';
 import { CastRepository } from '@database/store';
 import { IPC, NDI_EVENTS, type AppMenuState, type InlineWindowMenuBounds, type InlineWindowMenuItem } from '@core/ipc';
 import type {
@@ -31,8 +31,15 @@ import type {
 import { getInlineWindowMenuItems, popupInlineWindowMenu, updateApplicationMenu } from './application-menu';
 import type { AppUpdater } from './app-updater';
 import { readDeckBundleArchive, writeDeckBundleArchive } from './deck-bundle-archive';
+import {
+  getLogFilePath,
+  getLogsDir,
+  listLogSessions,
+  readLogSession,
+} from './logger';
 import type { NdiServiceLike } from './ndi/ndi-protocol';
 import { assertTrustedIpcSender } from './security';
+import { sampleSystemMetrics } from './system-metrics';
 
 const NDI_OUTPUT_NAMES = new Set<NdiOutputName>(['audience', 'stage']);
 
@@ -272,6 +279,7 @@ export const registerIpcHandlers = (
     if (!NDI_OUTPUT_NAMES.has(name) || typeof enabled !== 'boolean') {
       throw new Error('Invalid NDI output toggle payload');
     }
+    console.log(`[ipc] setNdiOutputEnabled ${name}=${enabled}`);
     return ndiService.setOutputEnabled(name, enabled);
   });
   safeHandle(IPC.getNdiOutputState, () => ndiService.getOutputState());
@@ -316,6 +324,21 @@ export const registerIpcHandlers = (
     }
     },
   );
+  safeHandle(IPC.obsListLogSessions, () => listLogSessions());
+  safeHandle(IPC.obsReadLogSession, (_event, filePath: string, offset: number, limit: number) => {
+    if (typeof filePath !== 'string' || typeof offset !== 'number' || typeof limit !== 'number') {
+      throw new Error('Invalid log read payload');
+    }
+    const cappedLimit = Math.max(1, Math.min(5000, Math.floor(limit)));
+    return readLogSession(filePath, Math.floor(offset), cappedLimit);
+  });
+  safeHandle(IPC.obsGetCurrentLogPath, () => getLogFilePath());
+  safeHandle(IPC.obsOpenLogFolder, async () => {
+    const dir = getLogsDir();
+    if (!dir) return;
+    await shell.openPath(dir);
+  });
+  safeHandle(IPC.obsGetSystemMetrics, () => sampleSystemMetrics());
   ipcMain.on(
     IPC.sendNdiAudio,
     (event, payload: {

--- a/app/main/logger.ts
+++ b/app/main/logger.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import type { LogReadResult, LogSessionSummary } from '@core/types';
 
 type ConsoleMethod = 'log' | 'info' | 'warn' | 'error';
 
@@ -11,14 +12,20 @@ const LEVEL_BY_METHOD: Record<ConsoleMethod, string> = {
 };
 
 let logFilePath: string | null = null;
+let logsDirPath: string | null = null;
 let writeStream: fs.WriteStream | null = null;
 let initialized = false;
+// Bytes the log file held when this session started (always 0 in practice
+// because we open with 'a' on a unique session-stamped path, but capture
+// it explicitly so the tailer's offset semantics are unambiguous).
+let sessionStartByteOffset = 0;
 
 export function initializeLogger(baseDir: string): void {
   if (initialized) return;
   initialized = true;
 
   const logsDir = path.join(baseDir, 'logs');
+  logsDirPath = logsDir;
   try {
     fs.mkdirSync(logsDir, { recursive: true });
   } catch (error) {
@@ -34,6 +41,7 @@ export function initializeLogger(baseDir: string): void {
   logFilePath = path.join(logsDir, `session-${sessionStamp}.log`);
   try {
     writeStream = fs.createWriteStream(logFilePath, { flags: 'a' });
+    sessionStartByteOffset = 0;
   } catch (error) {
     writeStream = null;
     console.error('[logger] Could not open log file:', error);
@@ -57,6 +65,112 @@ export function initializeLogger(baseDir: string): void {
 export function getLogFilePath(): string | null {
   return logFilePath;
 }
+
+export function getLogsDir(): string | null {
+  return logsDirPath;
+}
+
+export function listLogSessions(): LogSessionSummary[] {
+  if (!logsDirPath) return [];
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(logsDirPath, { withFileTypes: true });
+  } catch (error) {
+    console.error('[logger] Failed to list log sessions:', error);
+    return [];
+  }
+  const summaries: LogSessionSummary[] = [];
+  for (const entry of entries) {
+    if (!entry.isFile()) continue;
+    if (!entry.name.endsWith('.log')) continue;
+    const fullPath = path.join(logsDirPath, entry.name);
+    try {
+      const stat = fs.statSync(fullPath);
+      summaries.push({
+        path: fullPath,
+        fileName: entry.name,
+        sizeBytes: stat.size,
+        modifiedAtMs: stat.mtimeMs,
+        isCurrent: fullPath === logFilePath,
+      });
+    } catch {
+      // Drop entries we can't stat — likely deleted between readdir + stat.
+    }
+  }
+  summaries.sort((a, b) => b.modifiedAtMs - a.modifiedAtMs);
+  return summaries;
+}
+
+// Reads up to `limit` lines starting at `offset` bytes into `filePath`.
+// Returns the next byte offset so the caller can incrementally tail the
+// file. Negative `offset` is treated as "from end" (tailing entry point).
+export function readLogSession(filePath: string, offset: number, limit: number): LogReadResult {
+  // Containment check — refuse paths outside the logs dir.
+  if (!logsDirPath) {
+    throw new Error('Logger not initialized');
+  }
+  const resolved = path.resolve(filePath);
+  const dir = path.resolve(logsDirPath);
+  if (!resolved.startsWith(dir + path.sep) && resolved !== dir) {
+    throw new Error('Refusing to read file outside logs directory');
+  }
+
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(resolved);
+  } catch (error) {
+    throw new Error(`Log file not found: ${(error as Error).message}`);
+  }
+
+  const totalBytes = stat.size;
+  let startByte = offset;
+  if (startByte < 0) {
+    // Caller asked for a tail: read approx (limit * 256) bytes from the
+    // end. 256 bytes/line is generous for our format.
+    const approxBytes = Math.max(8 * 1024, limit * 256);
+    startByte = Math.max(0, totalBytes - approxBytes);
+  } else if (startByte > totalBytes) {
+    startByte = totalBytes;
+  }
+
+  if (startByte >= totalBytes) {
+    return { totalBytes, nextOffset: totalBytes, lines: [] };
+  }
+
+  const length = totalBytes - startByte;
+  const buffer = Buffer.alloc(length);
+  let fd = -1;
+  try {
+    fd = fs.openSync(resolved, 'r');
+    fs.readSync(fd, buffer, 0, length, startByte);
+  } finally {
+    if (fd >= 0) fs.closeSync(fd);
+  }
+  let text = buffer.toString('utf8');
+
+  // If we sliced into the middle of a line, drop the partial first line so
+  // the caller doesn't see a truncated entry. The next call with the
+  // returned offset will pick it up cleanly.
+  if (offset < 0 && startByte > 0) {
+    const firstNewline = text.indexOf('\n');
+    if (firstNewline > 0) {
+      text = text.slice(firstNewline + 1);
+    }
+  }
+
+  const lines = text.split('\n');
+  // Trailing empty string when the chunk ends with a newline — discard.
+  if (lines.length > 0 && lines[lines.length - 1] === '') {
+    lines.pop();
+  }
+
+  // Cap to last `limit` lines if we read more than the caller asked for.
+  const trimmed = lines.length > limit ? lines.slice(lines.length - limit) : lines;
+
+  return { totalBytes, nextOffset: totalBytes, lines: trimmed };
+}
+
+export const __sessionStartByteOffsetForTests = (): number => sessionStartByteOffset;
 
 function patchConsole(method: ConsoleMethod): void {
   const original = console[method].bind(console);
@@ -87,4 +201,3 @@ function formatArg(arg: unknown): string {
     return String(arg);
   }
 }
-

--- a/app/main/ndi/ndi-host.ts
+++ b/app/main/ndi/ndi-host.ts
@@ -65,6 +65,11 @@ parentPort.on('message', (event: { data: NdiHostCommand }) => {
         cmd.samplesPerChannel,
       );
       break;
+    case 'flushBlackout': {
+      const { target, ...rest } = cmd.options ?? {};
+      service.flushBlackoutAndDestroy(target, rest);
+      break;
+    }
     case 'destroy':
       service.destroy();
       service = null;

--- a/app/main/ndi/ndi-noop-service.ts
+++ b/app/main/ndi/ndi-noop-service.ts
@@ -71,6 +71,10 @@ export class NoopNdiService implements NdiServiceLike {
     return () => undefined;
   }
 
+  flushBlackoutAndDestroy(): void {
+    // No sender to blackout.
+  }
+
   destroy(): void {
     // Nothing to tear down.
   }

--- a/app/main/ndi/ndi-protocol.ts
+++ b/app/main/ndi/ndi-protocol.ts
@@ -7,6 +7,16 @@ import type {
   NdiOutputState,
 } from '@core/types';
 
+export interface BlackoutFlushOptions {
+  // Optional sender to flush; omit to flush every active sender.
+  target?: NdiOutputName;
+  frameCount?: number;
+  intervalMs?: number;
+  totalBudgetMs?: number;
+  // When true (default) the sender(s) are destroyed after the burst.
+  destroy?: boolean;
+}
+
 // Sent from main process to the NDI utility process.
 export type NdiHostCommand =
   | { type: 'init'; outputConfigs: NdiOutputConfigMap }
@@ -29,6 +39,7 @@ export type NdiHostCommand =
       channels: number;
       samplesPerChannel: number;
     }
+  | { type: 'flushBlackout'; options?: BlackoutFlushOptions }
   | { type: 'destroy' };
 
 // Emitted from the NDI utility process to the main process.
@@ -65,5 +76,6 @@ export interface NdiServiceLike {
   ): void;
   onOutputStateChanged(callback: (state: NdiOutputState) => void): () => void;
   onDiagnosticsChanged(callback: (diagnostics: NdiDiagnostics) => void): () => void;
+  flushBlackoutAndDestroy(target?: NdiOutputName, options?: BlackoutFlushOptions): void;
   destroy(): void;
 }

--- a/app/main/ndi/ndi-service-proxy.ts
+++ b/app/main/ndi/ndi-service-proxy.ts
@@ -8,6 +8,7 @@ import type {
   NdiOutputState,
 } from '@core/types';
 import type {
+  BlackoutFlushOptions,
   NdiHostCommand,
   NdiHostEvent,
   NdiServiceLike,
@@ -141,9 +142,29 @@ export class NdiServiceProxy implements NdiServiceLike {
     };
   }
 
+  flushBlackoutAndDestroy(target?: NdiOutputName, options?: BlackoutFlushOptions): void {
+    if (this.destroyed) return;
+    try {
+      this.send({ type: 'flushBlackout', options: { ...options, target } });
+    } catch (error) {
+      console.error('[NdiServiceProxy] Failed to dispatch blackout:', error);
+    }
+    if (target) {
+      this.cachedOutputState = { ...this.cachedOutputState, [target]: false };
+    }
+  }
+
   destroy(): void {
     if (this.destroyed) return;
     this.destroyed = true;
+    // Best-effort blackout before tearing the host down. Use the fast budget —
+    // teardown can be triggered from `before-quit` and we cannot block app
+    // exit longer than the user's window-close grace period.
+    try {
+      this.send({ type: 'flushBlackout', options: { totalBudgetMs: 500 } });
+    } catch {
+      // ignore — proceed to destroy
+    }
     try {
       this.send({ type: 'destroy' });
     } catch {

--- a/app/main/ndi/ndi-service.ts
+++ b/app/main/ndi/ndi-service.ts
@@ -20,6 +20,9 @@ const DIAGNOSTICS_EMIT_INTERVAL_MS = 250;
 const BYTES_PER_PIXEL = 4;
 const MAX_FRAME_BYTES = NDI_OUTPUT_WIDTH * NDI_OUTPUT_HEIGHT * BYTES_PER_PIXEL;
 const ROLLING_AVERAGE_WINDOW = 60;
+// Send-duration sample window — sized to fit ~2s of 30 fps so percentiles
+// reflect recent behavior, not lifetime stats.
+const SEND_LATENCY_SAMPLE_WINDOW = 64;
 
 // Hard caps for audio frames, applied before handing the buffer to the
 // native sender. These are loose enough for any sane Web Audio source but
@@ -27,6 +30,16 @@ const ROLLING_AVERAGE_WINDOW = 60;
 const MAX_AUDIO_CHANNELS = 32;
 const MAX_AUDIO_SAMPLES_PER_CHANNEL = 192000; // 1 second at 192 kHz
 const MAX_AUDIO_SAMPLE_RATE = 192000;
+
+// Blackout burst defaults — receivers see a clean fade to black/silence
+// before signal drop instead of a frozen last frame.
+const DEFAULT_BLACKOUT_FRAME_COUNT = 15;
+const DEFAULT_BLACKOUT_INTERVAL_MS = 1000 / 30;
+const DEFAULT_BLACKOUT_TOTAL_BUDGET_MS = 750;
+const FAST_BLACKOUT_TOTAL_BUDGET_MS = 250;
+const BLACKOUT_AUDIO_SAMPLE_RATE = 48000;
+const BLACKOUT_AUDIO_CHANNELS = 2;
+const BLACKOUT_AUDIO_SAMPLES_PER_CHANNEL = 1024;
 
 type StateChangeCallback = (state: NdiOutputState) => void;
 type DiagnosticsChangeCallback = (diagnostics: NdiDiagnostics) => void;
@@ -37,6 +50,13 @@ interface NdiServiceOptions {
   moduleLoader?: () => NdiNativeModule;
 }
 
+export interface BlackoutOptions {
+  frameCount?: number;
+  intervalMs?: number;
+  totalBudgetMs?: number;
+  destroy?: boolean;
+}
+
 interface SenderState {
   diagnostics: NdiActiveSenderDiagnostics;
   outputName: NdiOutputName;
@@ -44,9 +64,12 @@ interface SenderState {
   lastFrameWidth: number;
   lastFrameHeight: number;
   lastFrameReceivedAt: number;
+  lastSendAt: number;
   captureDurationRolling: RollingAverage;
   readbackDurationRolling: RollingAverage;
   sendDurationRolling: RollingAverage;
+  sendDurationSamples: RollingSampleBuffer;
+  sendIntervalSamples: RollingSampleBuffer;
 }
 
 class RollingAverage {
@@ -74,6 +97,55 @@ class RollingAverage {
   }
 }
 
+// Plain ring buffer of recent samples — used for percentile + jitter
+// calculations that need access to all recent values, not just an average.
+class RollingSampleBuffer {
+  private readonly buffer: number[] = [];
+  private writeIndex = 0;
+
+  constructor(private readonly windowSize: number) {}
+
+  push(value: number): void {
+    if (!Number.isFinite(value)) return;
+    if (this.buffer.length < this.windowSize) {
+      this.buffer.push(value);
+    } else {
+      this.buffer[this.writeIndex] = value;
+      this.writeIndex = (this.writeIndex + 1) % this.windowSize;
+    }
+  }
+
+  snapshot(): number[] {
+    return this.buffer.slice();
+  }
+
+  get size(): number {
+    return this.buffer.length;
+  }
+}
+
+function percentile(sortedAscending: number[], p: number): number {
+  if (sortedAscending.length === 0) return 0;
+  const idx = Math.min(
+    sortedAscending.length - 1,
+    Math.floor((p / 100) * sortedAscending.length),
+  );
+  return sortedAscending[idx];
+}
+
+function standardDeviation(samples: number[]): number {
+  if (samples.length < 2) return 0;
+  let sum = 0;
+  for (const v of samples) sum += v;
+  const mean = sum / samples.length;
+  let varianceSum = 0;
+  for (const v of samples) {
+    const d = v - mean;
+    varianceSum += d * d;
+  }
+  return Math.sqrt(varianceSum / samples.length);
+}
+
 export class NdiService {
   private module: NdiNativeModule | null = null;
   private runtimeLoaded = false;
@@ -90,6 +162,11 @@ export class NdiService {
   private diagnosticsTimer: ReturnType<typeof setTimeout> | null = null;
   private lastDiagnosticsEmitAt = 0;
   private destroyed = false;
+  // Reusable buffers for blackout frames — allocated once on first flush so
+  // every controlled-shutdown path can fire even when allocations are
+  // restricted (e.g. inside an unhandledRejection handler).
+  private blackoutVideoFrame: Uint8Array | null = null;
+  private blackoutAudioFrame: Float32Array | null = null;
 
   private stateChangeListeners: StateChangeCallback[] = [];
   private diagnosticsChangeListeners: DiagnosticsChangeCallback[] = [];
@@ -115,7 +192,10 @@ export class NdiService {
       this.rebuildActiveSenders();
       this.startHeartbeat();
     } else {
-      this.destroySenderForOutput(name);
+      // Run a blackout burst before destroying so receivers see a clean
+      // visual cutoff. Synchronous so callers can rely on the sender being
+      // gone when this returns (subject to the budget timeout).
+      this.flushBlackoutAndDestroy(name);
       this.rebuildActiveSenders();
       if (this.allOutputsDisabled()) {
         this.stopHeartbeat();
@@ -156,15 +236,22 @@ export class NdiService {
       return;
     }
 
-    sender.diagnostics.performance.framesCaptured += 1;
-    sender.diagnostics.performance.bytesReceived += rgba.byteLength;
-    sender.diagnostics.performance.lastFrameBytes = rgba.byteLength;
+    const performanceData = sender.diagnostics.performance;
+    performanceData.framesCaptured += 1;
+    performanceData.bytesReceived += rgba.byteLength;
+    performanceData.lastFrameBytes = rgba.byteLength;
+    if (performanceData.minFrameBytes === 0 || rgba.byteLength < performanceData.minFrameBytes) {
+      performanceData.minFrameBytes = rgba.byteLength;
+    }
+    if (rgba.byteLength > performanceData.maxFrameBytes) {
+      performanceData.maxFrameBytes = rgba.byteLength;
+    }
 
     if (telemetry) {
-      sender.diagnostics.performance.skippedCaptures += telemetry.skippedCaptures;
-      sender.diagnostics.performance.framesDroppedBackpressure += telemetry.framesDroppedBackpressure;
-      sender.diagnostics.performance.avgCaptureDurationMs = sender.captureDurationRolling.push(telemetry.captureDurationMs);
-      sender.diagnostics.performance.avgReadbackDurationMs = sender.readbackDurationRolling.push(telemetry.readbackDurationMs);
+      performanceData.skippedCaptures += telemetry.skippedCaptures;
+      performanceData.framesDroppedBackpressure += telemetry.framesDroppedBackpressure;
+      performanceData.avgCaptureDurationMs = sender.captureDurationRolling.push(telemetry.captureDurationMs);
+      performanceData.avgReadbackDurationMs = sender.readbackDurationRolling.push(telemetry.readbackDurationMs);
     }
 
     sender.lastFrame = rgba;
@@ -269,8 +356,87 @@ export class NdiService {
     };
   }
 
+  // Sends a brief black-video + silent-audio burst to one or all senders so
+  // receivers get a clean visual cutoff before signal loss, then destroys
+  // the sender(s). Bounded by `totalBudgetMs` so a stuck native call cannot
+  // hang process exit. Safe to call multiple times.
+  flushBlackoutAndDestroy(target?: NdiOutputName, opts?: BlackoutOptions): void {
+    if (this.destroyed) return;
+    const targets = target ? [target] : NDI_OUTPUT_ORDER.filter((name) => this.senders.has(name));
+    if (targets.length === 0) return;
+
+    const frameCount = opts?.frameCount ?? DEFAULT_BLACKOUT_FRAME_COUNT;
+    const intervalMs = opts?.intervalMs ?? DEFAULT_BLACKOUT_INTERVAL_MS;
+    const totalBudgetMs = opts?.totalBudgetMs ?? DEFAULT_BLACKOUT_TOTAL_BUDGET_MS;
+    const destroyAfter = opts?.destroy ?? true;
+
+    // Stop heartbeat first — otherwise the timer would resurrect the
+    // pre-blackout frame on the next tick.
+    this.stopHeartbeat();
+
+    const startedAt = performance.now();
+    for (const name of targets) {
+      const sender = this.senders.get(name);
+      if (!sender) continue;
+
+      const opaqueBlack = !sender.diagnostics.withAlpha;
+      const videoFrame = this.getOrCreateBlackoutVideoFrame(opaqueBlack);
+      const audioFrame = this.getOrCreateBlackoutAudioFrame();
+
+      for (let i = 0; i < frameCount; i++) {
+        if (performance.now() - startedAt > totalBudgetMs) break;
+        try {
+          this.module?.sendRgbaFrame(sender.diagnostics.senderName, videoFrame, sender.diagnostics.width, sender.diagnostics.height);
+          sender.diagnostics.performance.blackoutFramesSent += 1;
+          sender.diagnostics.performance.framesSent += 1;
+        } catch (error) {
+          // Native binding gone — abort the burst for this sender.
+          console.error('[NdiService] Blackout video send failed:', error);
+          break;
+        }
+        const sendAudio = this.module?.sendAudioFrame;
+        if (sendAudio) {
+          try {
+            sendAudio(
+              sender.diagnostics.senderName,
+              audioFrame,
+              BLACKOUT_AUDIO_SAMPLE_RATE,
+              BLACKOUT_AUDIO_CHANNELS,
+              BLACKOUT_AUDIO_SAMPLES_PER_CHANNEL,
+            );
+            sender.diagnostics.audio.audioSilenceFramesSent += 1;
+            sender.diagnostics.audio.audioFramesSent += 1;
+          } catch (error) {
+            console.error('[NdiService] Blackout audio send failed:', error);
+          }
+        }
+
+        if (i < frameCount - 1 && intervalMs > 0) {
+          this.busyWait(intervalMs);
+        }
+      }
+    }
+
+    if (destroyAfter) {
+      for (const name of targets) {
+        this.destroySenderForOutput(name);
+      }
+    }
+  }
+
   destroy(): void {
     if (this.destroyed) return;
+    // Last-chance blackout for any sender we still have open — this handles
+    // the case where teardown was reached without an explicit
+    // flushBlackoutAndDestroy call (legacy callers, signal handlers).
+    if (this.senders.size > 0) {
+      try {
+        this.flushBlackoutAndDestroy(undefined, { destroy: false });
+      } catch (error) {
+        console.error('[NdiService] Final blackout failed:', error);
+      }
+    }
+
     this.destroyed = true;
     this.stopHeartbeat();
     this.stopDiagnosticsTimer();
@@ -334,6 +500,7 @@ export class NdiService {
         withAlpha: config.withAlpha,
       });
       this.refreshRuntimeInfo();
+      console.log(`[NdiService] Sender created`, JSON.stringify({ output: name, senderName, width, height, withAlpha: config.withAlpha }));
       this.senders.set(name, {
         diagnostics: {
           senderName,
@@ -342,6 +509,7 @@ export class NdiService {
           withAlpha: config.withAlpha,
           asyncVideoSend: this.asyncVideoSend,
           connectionCount: null,
+          startedAtMs: Date.now(),
           performance: createEmptySenderPerformanceDiagnostics(),
           audio: createEmptySenderAudioDiagnostics(),
         },
@@ -350,9 +518,12 @@ export class NdiService {
         lastFrameWidth: 0,
         lastFrameHeight: 0,
         lastFrameReceivedAt: 0,
+        lastSendAt: 0,
         captureDurationRolling: new RollingAverage(),
         readbackDurationRolling: new RollingAverage(),
         sendDurationRolling: new RollingAverage(),
+        sendDurationSamples: new RollingSampleBuffer(SEND_LATENCY_SAMPLE_WINDOW),
+        sendIntervalSamples: new RollingSampleBuffer(SEND_LATENCY_SAMPLE_WINDOW),
       });
       this.lastError = null;
     } catch (error) {
@@ -373,6 +544,13 @@ export class NdiService {
       console.error('[NdiService] Error destroying sender:', error);
     }
 
+    console.log(`[NdiService] Sender destroyed`, JSON.stringify({
+      output: name,
+      senderName: sender.diagnostics.senderName,
+      uptimeMs: Date.now() - sender.diagnostics.startedAtMs,
+      framesSent: sender.diagnostics.performance.framesSent,
+      blackoutFramesSent: sender.diagnostics.performance.blackoutFramesSent,
+    }));
     this.senders.delete(name);
   }
 
@@ -395,6 +573,7 @@ export class NdiService {
       restored.lastFrameReceivedAt = previous.lastFrameReceivedAt;
       restored.diagnostics.performance = { ...previous.diagnostics.performance };
       restored.diagnostics.audio = { ...previous.diagnostics.audio };
+      restored.diagnostics.startedAtMs = previous.diagnostics.startedAtMs;
       if (previous.lastFrame) {
         restored.diagnostics.performance.cacheCopyBytes += previous.lastFrame.byteLength;
       }
@@ -460,7 +639,22 @@ export class NdiService {
       sender.diagnostics.connectionCount = typeof connectionCount === 'number' && connectionCount >= 0 ? connectionCount : null;
       const startedAt = performance.now();
       this.module.sendRgbaFrame(sender.diagnostics.senderName, rgba, width, height);
-      sender.diagnostics.performance.avgSendDurationMs = sender.sendDurationRolling.push(performance.now() - startedAt);
+      const duration = performance.now() - startedAt;
+      sender.diagnostics.performance.avgSendDurationMs = sender.sendDurationRolling.push(duration);
+      sender.sendDurationSamples.push(duration);
+      if (sender.lastSendAt > 0) {
+        sender.sendIntervalSamples.push(startedAt - sender.lastSendAt);
+      }
+      sender.lastSendAt = startedAt;
+
+      const sortedDurations = sender.sendDurationSamples.snapshot().sort((a, b) => a - b);
+      sender.diagnostics.performance.p50SendDurationMs = percentile(sortedDurations, 50);
+      sender.diagnostics.performance.p95SendDurationMs = percentile(sortedDurations, 95);
+      sender.diagnostics.performance.p99SendDurationMs = percentile(sortedDurations, 99);
+      sender.diagnostics.performance.sendIntervalJitterMs = standardDeviation(
+        sender.sendIntervalSamples.snapshot(),
+      );
+
       sender.diagnostics.performance.framesSent += 1;
       if (replayed) {
         sender.diagnostics.performance.framesReplayed += 1;
@@ -543,7 +737,43 @@ export class NdiService {
     const sender = this.senders.get(name);
     return sender ? cloneSenderDiagnostics(sender.diagnostics) : null;
   }
+
+  private getOrCreateBlackoutVideoFrame(opaque: boolean): Uint8Array {
+    if (!this.blackoutVideoFrame || this.blackoutVideoFrame.length !== MAX_FRAME_BYTES) {
+      this.blackoutVideoFrame = new Uint8Array(MAX_FRAME_BYTES);
+    }
+    // Black with appropriate alpha. For non-alpha senders we fill the alpha
+    // byte so receivers showing alpha treat the frame as fully opaque.
+    if (opaque) {
+      const buf = this.blackoutVideoFrame;
+      for (let i = 3; i < buf.length; i += 4) buf[i] = 255;
+    } else {
+      this.blackoutVideoFrame.fill(0);
+    }
+    return this.blackoutVideoFrame;
+  }
+
+  private getOrCreateBlackoutAudioFrame(): Float32Array {
+    const required = BLACKOUT_AUDIO_CHANNELS * BLACKOUT_AUDIO_SAMPLES_PER_CHANNEL;
+    if (!this.blackoutAudioFrame || this.blackoutAudioFrame.length !== required) {
+      this.blackoutAudioFrame = new Float32Array(required);
+    }
+    return this.blackoutAudioFrame;
+  }
+
+  private busyWait(ms: number): void {
+    // Synchronous wait — required because shutdown handlers run on a path
+    // where async work isn't guaranteed to complete (process.exit fires on
+    // the next tick). A 33 ms spin every blackout frame is acceptable: the
+    // app is going down anyway and the budget caps total time.
+    const target = performance.now() + ms;
+    while (performance.now() < target) {
+      // Intentional empty loop — see comment above.
+    }
+  }
 }
+
+export const NDI_FAST_BLACKOUT_BUDGET_MS = FAST_BLACKOUT_TOTAL_BUDGET_MS;
 
 function createEmptySenderPerformanceDiagnostics(): NdiSenderPerformanceDiagnostics {
   return {
@@ -559,7 +789,14 @@ function createEmptySenderPerformanceDiagnostics(): NdiSenderPerformanceDiagnost
     avgCaptureDurationMs: 0,
     avgReadbackDurationMs: 0,
     avgSendDurationMs: 0,
+    p50SendDurationMs: 0,
+    p95SendDurationMs: 0,
+    p99SendDurationMs: 0,
+    sendIntervalJitterMs: 0,
     lastFrameBytes: 0,
+    minFrameBytes: 0,
+    maxFrameBytes: 0,
+    blackoutFramesSent: 0,
   };
 }
 
@@ -569,6 +806,7 @@ function createEmptySenderAudioDiagnostics(): NdiSenderAudioDiagnostics {
     audioFramesSent: 0,
     audioFramesRejected: 0,
     audioSamplesSent: 0,
+    audioSilenceFramesSent: 0,
     lastSampleRate: 0,
     lastChannels: 0,
   };

--- a/app/main/preload.ts
+++ b/app/main/preload.ts
@@ -8,6 +8,8 @@ import type {
   ElementCreateInput,
   ElementUpdateInput,
   Id,
+  LogReadResult,
+  LogSessionSummary,
   MediaAssetCreateInput,
   CollectionAssignmentInput,
   CollectionCreateInput,
@@ -24,6 +26,7 @@ import type {
   OverlayUpdateInput,
   StageCreateInput,
   StageUpdateInput,
+  SystemMetricsSnapshot,
   ThemeCreateInput,
   ThemeUpdateInput,
   SlideCreateInput,
@@ -167,6 +170,12 @@ const api = {
     ipcRenderer.on(APP_MENU_EVENTS.command, handler);
     return () => { ipcRenderer.removeListener(APP_MENU_EVENTS.command, handler); };
   },
+  obsListLogSessions: () => ipcRenderer.invoke(IPC.obsListLogSessions) as Promise<LogSessionSummary[]>,
+  obsReadLogSession: (filePath: string, offset: number, limit: number) =>
+    ipcRenderer.invoke(IPC.obsReadLogSession, filePath, offset, limit) as Promise<LogReadResult>,
+  obsGetCurrentLogPath: () => ipcRenderer.invoke(IPC.obsGetCurrentLogPath) as Promise<string | null>,
+  obsOpenLogFolder: () => ipcRenderer.invoke(IPC.obsOpenLogFolder) as Promise<void>,
+  obsGetSystemMetrics: () => ipcRenderer.invoke(IPC.obsGetSystemMetrics) as Promise<SystemMetricsSnapshot>,
 };
 
 contextBridge.exposeInMainWorld('castApi', api);

--- a/app/main/system-metrics.ts
+++ b/app/main/system-metrics.ts
@@ -1,0 +1,39 @@
+import type { SystemMetricsSnapshot } from '@core/types';
+
+// Returns a snapshot of the main process's memory + CPU usage.
+//
+// CPU: derived by sampling `process.cpuUsage` against the wall-clock delta
+// since the previous sample. The very first call returns 0 because we have
+// no baseline yet. Callers should poll on a fixed interval.
+let lastCpuUsage: NodeJS.CpuUsage | null = null;
+let lastSampleHrtimeNs: bigint | null = null;
+
+export function sampleSystemMetrics(): SystemMetricsSnapshot {
+  const memory = process.memoryUsage();
+  const cpu = process.cpuUsage();
+  const nowNs = process.hrtime.bigint();
+
+  let cpuPercent = 0;
+  if (lastCpuUsage && lastSampleHrtimeNs !== null) {
+    const elapsedMicros = Number((nowNs - lastSampleHrtimeNs) / 1000n);
+    if (elapsedMicros > 0) {
+      const userDeltaMicros = cpu.user - lastCpuUsage.user;
+      const systemDeltaMicros = cpu.system - lastCpuUsage.system;
+      cpuPercent = ((userDeltaMicros + systemDeltaMicros) / elapsedMicros) * 100;
+    }
+  }
+  lastCpuUsage = cpu;
+  lastSampleHrtimeNs = nowNs;
+
+  return {
+    capturedAtMs: Date.now(),
+    uptimeSeconds: process.uptime(),
+    main: {
+      rssBytes: memory.rss,
+      heapUsedBytes: memory.heapUsed,
+      heapTotalBytes: memory.heapTotal,
+      externalBytes: memory.external,
+      cpuPercent: Math.max(0, cpuPercent),
+    },
+  };
+}

--- a/app/renderer/contexts/app-context.tsx
+++ b/app/renderer/contexts/app-context.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useMemo, type ReactNode } from 'react';
+import { useEffect, useMemo, useRef, type ReactNode } from 'react';
+import { recordObsEvent } from '../features/observability/metrics-store';
 import type {
   AppSnapshot,
   NdiDiagnostics,
@@ -109,6 +110,8 @@ export function AppProvider({ children }: { children: ReactNode }) {
   }, [resolvedTheme]);
 
   // NDI diagnostics + output state subscriptions.
+  const lastSenderNamesRef = useRef<{ audience: string | null; stage: string | null }>({ audience: null, stage: null });
+  const lastErrorRef = useRef<string | null>(null);
   useEffect(() => {
     void window.castApi.getNdiDiagnostics().then(setNdiDiagnostics).catch((error) => {
       console.error('[AppProvider] Failed to get NDI diagnostics:', error);
@@ -121,7 +124,31 @@ export function AppProvider({ children }: { children: ReactNode }) {
     });
 
     const unsubscribeOutput = window.castApi.onNdiOutputStateChanged(setNdiOutputStateValue);
-    const unsubscribeDiagnostics = window.castApi.onNdiDiagnosticsChanged(setNdiDiagnostics);
+    const unsubscribeDiagnostics = window.castApi.onNdiDiagnosticsChanged((diagnostics) => {
+      // Synthesize sender lifecycle events by diffing current diagnostics
+      // against the previous snapshot — keeps the timeline in sync with
+      // the main process without needing dedicated IPC events.
+      const prev = lastSenderNamesRef.current;
+      for (const name of ['audience', 'stage'] as const) {
+        const sender = diagnostics.senders[name];
+        const previousName = prev[name];
+        const nextName = sender?.senderName ?? null;
+        if (previousName === nextName) continue;
+        if (!previousName && nextName) {
+          recordObsEvent('ndi', 'Sender created', { output: name, senderName: nextName });
+        } else if (previousName && !nextName) {
+          recordObsEvent('ndi', 'Sender destroyed', { output: name, senderName: previousName });
+        } else if (previousName && nextName) {
+          recordObsEvent('ndi', 'Sender renamed', { output: name, from: previousName, to: nextName });
+        }
+        prev[name] = nextName;
+      }
+      if (diagnostics.lastError && diagnostics.lastError !== lastErrorRef.current) {
+        recordObsEvent('error', 'NDI error', { error: diagnostics.lastError }, 'error');
+      }
+      lastErrorRef.current = diagnostics.lastError;
+      setNdiDiagnostics(diagnostics);
+    });
     return () => {
       unsubscribeOutput();
       unsubscribeDiagnostics();

--- a/app/renderer/contexts/app-store.ts
+++ b/app/renderer/contexts/app-store.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { useShallow } from 'zustand/react/shallow';
+import { recordObsEvent } from '../features/observability/metrics-store';
 import { createDefaultNdiOutputConfigs } from '@core/ndi';
 import {
   applyPatch,
@@ -291,11 +292,13 @@ export const useAppStore = create<AppStoreState>()((set, get) => ({
   setNdiOutputStateValue: (value) => set({ ndiOutputState: value }),
 
   setNdiOutputEnabled: (name, enabled) => {
+    recordObsEvent('ndi', `NDI output ${enabled ? 'enabled' : 'disabled'}`, { name });
     void window.castApi
       .setNdiOutputEnabled(name, enabled)
       .then((next) => set({ ndiOutputState: next }))
       .catch((error) => {
         console.error('[AppStore] Failed to update output state:', error);
+        recordObsEvent('error', 'Failed to toggle NDI output', { name, enabled, error: String(error) }, 'error');
       });
   },
 

--- a/app/renderer/contexts/playback/playback-context.tsx
+++ b/app/renderer/contexts/playback/playback-context.tsx
@@ -5,6 +5,7 @@ import { useNavigation } from '../navigation-context';
 import { useProjectContent } from '../use-project-content';
 import { getLayerVideoElement, retainVideoSource, subscribeToVideoPool } from '../../features/canvas/use-k-video';
 import { addNdiAudioElement, removeNdiAudioElement } from '../../features/playback/ndi-audio-capture';
+import { recordObsEvent } from '../../features/observability/metrics-store';
 import {
   activateOverlayPlayback,
   advanceOverlayPlayback,
@@ -240,10 +241,12 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     if (asset.type === 'video') {
       setVideoLayerAssetId(asset.id);
       setStatusText(`Video layer: ${asset.name}`);
+      recordObsEvent('layer', 'Video layer set', { assetId: asset.id, name: asset.name });
       return;
     }
     setMediaLayerAssetId(asset.id);
     setStatusText(`Media layer: ${asset.name}`);
+    recordObsEvent('layer', 'Media layer set', { assetId: asset.id, name: asset.name, type: asset.type });
   }, [mediaAssetsById, setStatusText]);
 
   const activateOverlay = useCallback((overlayId: Id) => {
@@ -253,6 +256,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     setPlaybackNow(now);
     setOverlayEntries((current) => activateOverlayPlayback(current, overlaysById, overlayId, overlayMode, now));
     setStatusText(`Overlay: ${overlay.name}`);
+    recordObsEvent('overlay', 'Overlay activated', { overlayId, name: overlay.name, mode: overlayMode });
   }, [overlayMode, overlaysById, setStatusText]);
 
   const clearOverlay = useCallback((overlayId: Id) => {
@@ -262,6 +266,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     setPlaybackNow(now);
     setOverlayEntries((current) => clearOverlayPlayback(current, overlaysById, overlayId, now));
     setStatusText(`Overlay cleared: ${overlay.name}`);
+    recordObsEvent('overlay', 'Overlay cleared', { overlayId, name: overlay.name });
   }, [overlaysById, setStatusText]);
 
   const setOverlayMode = useCallback((mode: OverlayPlaybackMode) => {
@@ -272,6 +277,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
       setOverlayEntries((current) => collapseOverlayPlaybackToSingle(current, overlaysById, now));
     }
     setStatusText(mode === 'single' ? 'Overlay mode: single' : 'Overlay mode: multiple');
+    recordObsEvent('overlay', 'Overlay mode changed', { mode });
   }, [overlaysById, setStatusText]);
 
   const clearAllOverlays = useCallback(() => {
@@ -279,6 +285,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     setPlaybackNow(now);
     setOverlayEntries((current) => clearAllOverlayPlayback(current, overlaysById, now));
     setStatusText('All overlays cleared');
+    recordObsEvent('overlay', 'All overlays cleared');
   }, [overlaysById, setStatusText]);
 
   const showContentLayer = useCallback(() => {
@@ -286,6 +293,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const clearLayer = useCallback((layer: PresentationLayerKey) => {
+    recordObsEvent('layer', 'Layer cleared', { layer });
     if (layer === 'media') {
       setMediaLayerAssetId(null);
       setStatusText('Media layer cleared');
@@ -315,6 +323,7 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
     setOverlayEntries([]);
     clearOutputDeckItem();
     setStatusText('All layers cleared');
+    recordObsEvent('layer', 'All layers cleared');
   }, [clearOutputDeckItem, setStatusText]);
 
   const layers = useMemo<LayersValue>(() => ({

--- a/app/renderer/features/observability/metrics-store.ts
+++ b/app/renderer/features/observability/metrics-store.ts
@@ -1,0 +1,158 @@
+import { create } from 'zustand';
+import { useShallow } from 'zustand/react/shallow';
+import type { SystemMetricsSnapshot } from '@core/types';
+
+// Ring-buffered domain events for the observability timeline. Events are
+// also logged to the console so the main-process file logger captures them
+// for post-mortem reproduction; this store only holds the recent tail for
+// in-app display.
+
+export type ObsEventCategory =
+  | 'ndi'
+  | 'layer'
+  | 'overlay'
+  | 'playback'
+  | 'slide'
+  | 'system'
+  | 'audio'
+  | 'video'
+  | 'error';
+
+export type ObsEventLevel = 'info' | 'warn' | 'error';
+
+export interface ObsEvent {
+  id: number;
+  capturedAtMs: number;
+  category: ObsEventCategory;
+  level: ObsEventLevel;
+  message: string;
+  details?: Record<string, unknown>;
+}
+
+export interface VideoQualitySample {
+  capturedAtMs: number;
+  src: string;
+  // Best-effort label — uses src basename or a counter when unknown.
+  label: string;
+  droppedVideoFrames: number;
+  totalVideoFrames: number;
+  // Browser-internal rolling decoded fps if available, otherwise our own
+  // recent decode count divided by the elapsed sample interval.
+  decodedFps: number;
+  isPlaying: boolean;
+  hasAudio: boolean;
+  currentTimeSeconds: number;
+  durationSeconds: number;
+}
+
+export interface AudioHealthSnapshot {
+  contextState: AudioContextState | null;
+  baseLatencyMs: number;
+  outputLatencyMs: number;
+  sampleRate: number;
+  peakLevel: number;
+  rmsLevel: number;
+  clippingDetected: boolean;
+  underrunCount: number;
+}
+
+export interface CanvasRenderSnapshot {
+  capturedAtMs: number;
+  // Rolling p50/p95 of inter-frame intervals from the renderer rAF loop —
+  // measured by the observability page itself when active.
+  p50FrameIntervalMs: number;
+  p95FrameIntervalMs: number;
+  lastFrameIntervalMs: number;
+  // Konva stage layer count if available — useful for spotting regressions
+  // where unexpected layers are mounted.
+  layerCount: number;
+}
+
+export interface RendererMemorySnapshot {
+  capturedAtMs: number;
+  jsHeapSizeBytes: number;
+  totalJSHeapSizeBytes: number;
+  jsHeapLimitBytes: number;
+}
+
+const EVENT_RING_LIMIT = 200;
+let eventIdSeq = 0;
+
+interface MetricsStoreState {
+  events: ObsEvent[];
+  videoQualities: Record<string, VideoQualitySample>;
+  audioHealth: AudioHealthSnapshot | null;
+  canvasRender: CanvasRenderSnapshot | null;
+  rendererMemory: RendererMemorySnapshot | null;
+  systemMetrics: SystemMetricsSnapshot | null;
+
+  recordEvent: (
+    category: ObsEventCategory,
+    message: string,
+    details?: Record<string, unknown>,
+    level?: ObsEventLevel,
+  ) => void;
+  clearEvents: () => void;
+  setVideoQualities: (entries: VideoQualitySample[]) => void;
+  setAudioHealth: (snapshot: AudioHealthSnapshot | null) => void;
+  setCanvasRender: (snapshot: CanvasRenderSnapshot | null) => void;
+  setRendererMemory: (snapshot: RendererMemorySnapshot | null) => void;
+  setSystemMetrics: (snapshot: SystemMetricsSnapshot | null) => void;
+}
+
+export const useMetricsStore = create<MetricsStoreState>()((set) => ({
+  events: [],
+  videoQualities: {},
+  audioHealth: null,
+  canvasRender: null,
+  rendererMemory: null,
+  systemMetrics: null,
+
+  recordEvent: (category, message, details, level = 'info') => {
+    const event: ObsEvent = {
+      id: ++eventIdSeq,
+      capturedAtMs: Date.now(),
+      category,
+      level,
+      message,
+      details,
+    };
+    set((state) => {
+      const next = state.events.length >= EVENT_RING_LIMIT
+        ? state.events.slice(1)
+        : state.events.slice();
+      next.push(event);
+      return { events: next };
+    });
+    // Also push to the file logger via console — main process bridges
+    // renderer console-messages into session-*.log.
+    const detailsText = details ? ` ${JSON.stringify(details)}` : '';
+    const line = `[obs] ${category} :: ${message}${detailsText}`;
+    if (level === 'error') console.error(line);
+    else if (level === 'warn') console.warn(line);
+    else console.log(line);
+  },
+  clearEvents: () => set({ events: [] }),
+  setVideoQualities: (entries) => set(() => {
+    const map: Record<string, VideoQualitySample> = {};
+    for (const entry of entries) map[entry.src] = entry;
+    return { videoQualities: map };
+  }),
+  setAudioHealth: (snapshot) => set({ audioHealth: snapshot }),
+  setCanvasRender: (snapshot) => set({ canvasRender: snapshot }),
+  setRendererMemory: (snapshot) => set({ rendererMemory: snapshot }),
+  setSystemMetrics: (snapshot) => set({ systemMetrics: snapshot }),
+}));
+
+export { useShallow };
+
+// Convenience non-React entry — call from any code path (effects, callbacks,
+// IPC handlers) that doesn't already pull the store into scope.
+export function recordObsEvent(
+  category: ObsEventCategory,
+  message: string,
+  details?: Record<string, unknown>,
+  level?: ObsEventLevel,
+): void {
+  useMetricsStore.getState().recordEvent(category, message, details, level);
+}

--- a/app/renderer/features/observability/observability-collectors.ts
+++ b/app/renderer/features/observability/observability-collectors.ts
@@ -1,0 +1,228 @@
+import { useEffect, useRef } from 'react';
+import { useMetricsStore, type AudioHealthSnapshot, type RendererMemorySnapshot, type VideoQualitySample } from './metrics-store';
+import { getActiveNdiAudioContext } from '../playback/ndi-audio-capture';
+
+const SYSTEM_METRICS_INTERVAL_MS = 2000;
+const RENDERER_MEMORY_INTERVAL_MS = 1000;
+const VIDEO_QUALITY_INTERVAL_MS = 1000;
+const AUDIO_HEALTH_INTERVAL_MS = 250;
+const CANVAS_RENDER_SAMPLE_WINDOW = 60;
+
+interface PerformanceMemoryShim {
+  usedJSHeapSize: number;
+  totalJSHeapSize: number;
+  jsHeapSizeLimit: number;
+}
+
+// Polls main-process system metrics over IPC. Mounted only on the
+// Observability page so the IPC traffic is confined to when the user is
+// actually looking at it.
+export function useSystemMetricsCollector(active: boolean): void {
+  const setSystemMetrics = useMetricsStore((s) => s.setSystemMetrics);
+  useEffect(() => {
+    if (!active) return undefined;
+    let cancelled = false;
+    async function poll() {
+      try {
+        const snapshot = await window.castApi.obsGetSystemMetrics();
+        if (!cancelled) setSystemMetrics(snapshot);
+      } catch (error) {
+        console.error('[obs] system metrics poll failed', error);
+      }
+    }
+    void poll();
+    const id = window.setInterval(poll, SYSTEM_METRICS_INTERVAL_MS);
+    return () => { cancelled = true; window.clearInterval(id); };
+  }, [active, setSystemMetrics]);
+}
+
+export function useRendererMemoryCollector(active: boolean): void {
+  const setRendererMemory = useMetricsStore((s) => s.setRendererMemory);
+  useEffect(() => {
+    if (!active) return undefined;
+    function sample() {
+      // performance.memory is a non-standard Chromium extension. It's
+      // present in Electron but not in lib.dom.d.ts, so the cast is local.
+      const mem = (performance as unknown as { memory?: PerformanceMemoryShim }).memory;
+      if (!mem) {
+        setRendererMemory(null);
+        return;
+      }
+      const snapshot: RendererMemorySnapshot = {
+        capturedAtMs: Date.now(),
+        jsHeapSizeBytes: mem.usedJSHeapSize,
+        totalJSHeapSizeBytes: mem.totalJSHeapSize,
+        jsHeapLimitBytes: mem.jsHeapSizeLimit,
+      };
+      setRendererMemory(snapshot);
+    }
+    sample();
+    const id = window.setInterval(sample, RENDERER_MEMORY_INTERVAL_MS);
+    return () => { window.clearInterval(id); };
+  }, [active, setRendererMemory]);
+}
+
+interface VideoSampleCarry {
+  lastTotalDecoded: number;
+  lastSampledAt: number;
+}
+
+// Walks the document for HTMLVideoElements and reports their playback
+// quality (drops, decoded fps). Cheap — just `document.querySelectorAll` +
+// a couple of property reads per element per second.
+export function useVideoQualityCollector(active: boolean): void {
+  const setVideoQualities = useMetricsStore((s) => s.setVideoQualities);
+  const carryRef = useRef<Map<string, VideoSampleCarry>>(new Map());
+  useEffect(() => {
+    if (!active) return undefined;
+    const carry = carryRef.current;
+    function sample() {
+      const elements = Array.from(document.querySelectorAll('video')) as HTMLVideoElement[];
+      const now = Date.now();
+      const samples: VideoQualitySample[] = [];
+      const liveKeys = new Set<string>();
+      for (const el of elements) {
+        const src = el.currentSrc || el.src;
+        if (!src) continue;
+        liveKeys.add(src);
+        const quality = typeof el.getVideoPlaybackQuality === 'function'
+          ? el.getVideoPlaybackQuality()
+          : null;
+        const totalDecoded = quality?.totalVideoFrames ?? 0;
+        const dropped = quality?.droppedVideoFrames ?? 0;
+        const previous = carry.get(src);
+        let decodedFps = 0;
+        if (previous) {
+          const elapsedSec = Math.max(0.001, (now - previous.lastSampledAt) / 1000);
+          decodedFps = Math.max(0, (totalDecoded - previous.lastTotalDecoded) / elapsedSec);
+        }
+        carry.set(src, { lastTotalDecoded: totalDecoded, lastSampledAt: now });
+
+        const label = labelForVideoSrc(src);
+        samples.push({
+          capturedAtMs: now,
+          src,
+          label,
+          droppedVideoFrames: dropped,
+          totalVideoFrames: totalDecoded,
+          decodedFps,
+          isPlaying: !el.paused && !el.ended && el.readyState >= 2,
+          hasAudio: 'mozHasAudio' in el ? Boolean((el as unknown as { mozHasAudio: boolean }).mozHasAudio) : true,
+          currentTimeSeconds: el.currentTime,
+          durationSeconds: Number.isFinite(el.duration) ? el.duration : 0,
+        });
+      }
+      // Drop carry entries for elements that have left the DOM.
+      for (const key of carry.keys()) {
+        if (!liveKeys.has(key)) carry.delete(key);
+      }
+      setVideoQualities(samples);
+    }
+    sample();
+    const id = window.setInterval(sample, VIDEO_QUALITY_INTERVAL_MS);
+    return () => { window.clearInterval(id); };
+  }, [active, setVideoQualities]);
+}
+
+function labelForVideoSrc(src: string): string {
+  try {
+    const url = new URL(src, window.location.href);
+    const parts = url.pathname.split('/').filter(Boolean);
+    return parts[parts.length - 1] ?? src;
+  } catch {
+    return src;
+  }
+}
+
+export function useAudioHealthCollector(active: boolean): void {
+  const setAudioHealth = useMetricsStore((s) => s.setAudioHealth);
+  const lastClipAtRef = useRef(0);
+  useEffect(() => {
+    if (!active) return undefined;
+    const buffer = new Float32Array(1024);
+    let underrunCount = 0;
+    function sample() {
+      const handle = getActiveNdiAudioContext();
+      if (!handle) {
+        setAudioHealth(null);
+        return;
+      }
+      const { ctx, analyser } = handle;
+      analyser.getFloatTimeDomainData(buffer);
+      let peak = 0;
+      let sumSquares = 0;
+      let allZero = true;
+      for (let i = 0; i < buffer.length; i++) {
+        const v = buffer[i];
+        if (v !== 0) allZero = false;
+        const abs = Math.abs(v);
+        if (abs > peak) peak = abs;
+        sumSquares += v * v;
+      }
+      // All-zero frames while the AudioContext is running often indicate
+      // an underrun (no upstream samples reached the analyser).
+      if (allZero && ctx.state === 'running') {
+        underrunCount += 1;
+      }
+      const rms = Math.sqrt(sumSquares / buffer.length);
+      const clipping = peak >= 0.999;
+      if (clipping) lastClipAtRef.current = Date.now();
+      const snapshot: AudioHealthSnapshot = {
+        contextState: ctx.state,
+        baseLatencyMs: (ctx.baseLatency ?? 0) * 1000,
+        outputLatencyMs: (ctx.outputLatency ?? 0) * 1000,
+        sampleRate: ctx.sampleRate,
+        peakLevel: peak,
+        rmsLevel: rms,
+        clippingDetected: Date.now() - lastClipAtRef.current < 2000,
+        underrunCount,
+      };
+      setAudioHealth(snapshot);
+    }
+    sample();
+    const id = window.setInterval(sample, AUDIO_HEALTH_INTERVAL_MS);
+    return () => { window.clearInterval(id); };
+  }, [active, setAudioHealth]);
+}
+
+// Measures the renderer's rAF cadence — proxy for "is the UI smooth".
+// Not a perfect substitute for compositor-level frame stats but cheap and
+// good enough to spot stalls.
+export function useCanvasRenderCollector(active: boolean): void {
+  const setCanvasRender = useMetricsStore((s) => s.setCanvasRender);
+  useEffect(() => {
+    if (!active) return undefined;
+    let rafId: number | null = null;
+    let lastTimestamp = 0;
+    const samples: number[] = [];
+    let lastEmitAt = 0;
+
+    function tick(timestamp: number) {
+      if (lastTimestamp > 0) {
+        const interval = timestamp - lastTimestamp;
+        if (samples.length >= CANVAS_RENDER_SAMPLE_WINDOW) samples.shift();
+        samples.push(interval);
+        const now = Date.now();
+        if (now - lastEmitAt >= 500 && samples.length >= 2) {
+          lastEmitAt = now;
+          const sorted = samples.slice().sort((a, b) => a - b);
+          const p50 = sorted[Math.floor(sorted.length * 0.5)];
+          const p95 = sorted[Math.min(sorted.length - 1, Math.floor(sorted.length * 0.95))];
+          setCanvasRender({
+            capturedAtMs: now,
+            p50FrameIntervalMs: p50,
+            p95FrameIntervalMs: p95,
+            lastFrameIntervalMs: interval,
+            layerCount: document.querySelectorAll('canvas').length,
+          });
+        }
+      }
+      lastTimestamp = timestamp;
+      rafId = requestAnimationFrame(tick);
+    }
+    rafId = requestAnimationFrame(tick);
+    return () => {
+      if (rafId !== null) cancelAnimationFrame(rafId);
+    };
+  }, [active, setCanvasRender]);
+}

--- a/app/renderer/features/observability/observability-panel.tsx
+++ b/app/renderer/features/observability/observability-panel.tsx
@@ -1,0 +1,613 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { LogReadResult, LogSessionSummary, NdiActiveSenderDiagnostics, NdiOutputName } from '@core/types';
+import { useNdi } from '../../contexts/app-context';
+import { useImageCacheStats } from '../canvas/use-image-cache-stats';
+import {
+  useAudioHealthCollector,
+  useCanvasRenderCollector,
+  useRendererMemoryCollector,
+  useSystemMetricsCollector,
+  useVideoQualityCollector,
+} from './observability-collectors';
+import {
+  useMetricsStore,
+  useShallow,
+  type ObsEvent,
+  type ObsEventCategory,
+  type ObsEventLevel,
+} from './metrics-store';
+
+const OUTPUT_TITLES: Record<NdiOutputName, string> = {
+  audience: 'Audience',
+  stage: 'Stage',
+};
+
+export function ObservabilityPanel() {
+  // Mount the live collectors only while this panel is open. They're
+  // cheap, but no point sampling memory/audio when the user isn't looking.
+  useSystemMetricsCollector(true);
+  useRendererMemoryCollector(true);
+  useVideoQualityCollector(true);
+  useAudioHealthCollector(true);
+  useCanvasRenderCollector(true);
+
+  return (
+    <div className="flex flex-col gap-8">
+      <NdiOutputsSection />
+      <SourcePlaybackSection />
+      <AudioHealthSection />
+      <CanvasRenderSection />
+      <MemorySection />
+      <ImageCacheSection />
+      <EventTimelineSection />
+      <LogViewerSection />
+    </div>
+  );
+}
+
+// ─── NDI outputs ────────────────────────────────────────────────────
+
+function NdiOutputsSection() {
+  const { state: { diagnostics } } = useNdi();
+  if (!diagnostics) {
+    return <SectionShell title="NDI outputs"><p className="text-sm text-tertiary">Waiting for NDI diagnostics.</p></SectionShell>;
+  }
+  return (
+    <SectionShell title="NDI outputs" subtitle={`Runtime: ${diagnostics.runtimeLoaded ? (diagnostics.runtimePath ?? 'Loaded') : 'Not loaded'} · Source: ${diagnostics.sourceStatus}`}>
+      <div className="flex flex-col gap-4">
+        <SenderCard name="audience" sender={diagnostics.senders.audience} />
+        <SenderCard name="stage" sender={diagnostics.senders.stage} />
+        {diagnostics.lastError ? (
+          <div className="rounded border border-red-500/50 bg-red-500/10 px-3 py-2 text-sm text-red-300">{diagnostics.lastError}</div>
+        ) : null}
+      </div>
+    </SectionShell>
+  );
+}
+
+function SenderCard({ name, sender }: { name: NdiOutputName; sender: NdiActiveSenderDiagnostics | null }) {
+  if (!sender) {
+    return (
+      <div className="rounded border border-secondary px-3 py-2 text-sm text-tertiary">
+        {OUTPUT_TITLES[name]} sender: inactive
+      </div>
+    );
+  }
+  const performance = sender.performance;
+  const audio = sender.audio;
+  const uptimeMs = Date.now() - sender.startedAtMs;
+  const dropRate = performance.framesCaptured > 0
+    ? ((performance.framesDroppedBackpressure / performance.framesCaptured) * 100)
+    : 0;
+  return (
+    <div className="rounded border border-secondary px-3 py-3">
+      <div className="flex items-center justify-between gap-3 pb-2">
+        <h3 className="text-sm font-semibold text-primary">{OUTPUT_TITLES[name]} · {sender.senderName}</h3>
+        <span className="text-xs text-tertiary">
+          {sender.width}×{sender.height} · {sender.withAlpha ? 'BGRA' : 'BGRX'} · {sender.asyncVideoSend ? 'async' : 'sync'} · up {formatDuration(uptimeMs)}
+        </span>
+      </div>
+      <div className="grid grid-cols-2 gap-x-6 gap-y-1 text-sm text-secondary md:grid-cols-3">
+        <Stat label="Connections" value={sender.connectionCount ?? 'unknown'} />
+        <Stat label="Frames sent" value={formatNumber(performance.framesSent)} />
+        <Stat label="Captured" value={formatNumber(performance.framesCaptured)} />
+        <Stat label="Replayed" value={formatNumber(performance.framesReplayed)} />
+        <Stat label="Backpressure drops" value={`${formatNumber(performance.framesDroppedBackpressure)} (${dropRate.toFixed(1)}%)`} highlight={dropRate > 1} />
+        <Stat label="Skipped captures" value={formatNumber(performance.skippedCaptures)} />
+        <Stat label="Rejected" value={formatNumber(performance.framesRejected)} highlight={performance.framesRejected > 0} />
+        <Stat label="Blackout sent" value={formatNumber(performance.blackoutFramesSent)} />
+        <Stat label="Bytes received" value={formatBytes(performance.bytesReceived)} />
+      </div>
+      <div className="mt-2 grid grid-cols-2 gap-x-6 gap-y-1 text-sm text-secondary md:grid-cols-3">
+        <Stat label="Capture avg" value={`${performance.avgCaptureDurationMs.toFixed(2)} ms`} />
+        <Stat label="Readback avg" value={`${performance.avgReadbackDurationMs.toFixed(2)} ms`} />
+        <Stat label="Send avg" value={`${performance.avgSendDurationMs.toFixed(2)} ms`} />
+        <Stat label="Send p50" value={`${performance.p50SendDurationMs.toFixed(2)} ms`} />
+        <Stat label="Send p95" value={`${performance.p95SendDurationMs.toFixed(2)} ms`} highlight={performance.p95SendDurationMs > 16} />
+        <Stat label="Send p99" value={`${performance.p99SendDurationMs.toFixed(2)} ms`} highlight={performance.p99SendDurationMs > 33} />
+        <Stat label="Send jitter (σ)" value={`${performance.sendIntervalJitterMs.toFixed(2)} ms`} highlight={performance.sendIntervalJitterMs > 5} />
+        <Stat label="Frame size last" value={formatBytes(performance.lastFrameBytes)} />
+        <Stat
+          label="Frame size range"
+          value={performance.minFrameBytes > 0
+            ? `${formatBytes(performance.minFrameBytes)} – ${formatBytes(performance.maxFrameBytes)}`
+            : '—'}
+        />
+      </div>
+      <div className="mt-2 grid grid-cols-2 gap-x-6 gap-y-1 text-sm text-secondary md:grid-cols-3">
+        <Stat label="Audio frames in" value={formatNumber(audio.audioFramesReceived)} />
+        <Stat label="Audio frames sent" value={formatNumber(audio.audioFramesSent)} />
+        <Stat label="Audio samples sent" value={formatNumber(audio.audioSamplesSent)} />
+        <Stat label="Silence frames" value={formatNumber(audio.audioSilenceFramesSent)} />
+        <Stat label="Audio rejected" value={formatNumber(audio.audioFramesRejected)} highlight={audio.audioFramesRejected > 0} />
+        <Stat label="Audio format" value={audio.lastSampleRate > 0 ? `${audio.lastSampleRate} Hz × ${audio.lastChannels}ch` : 'inactive'} />
+      </div>
+    </div>
+  );
+}
+
+// ─── Source playback (HTMLVideoElement quality) ────────────────────
+
+function SourcePlaybackSection() {
+  const samples = useMetricsStore((s) => s.videoQualities);
+  const list = useMemo(() => Object.values(samples), [samples]);
+  return (
+    <SectionShell title="Source playback" subtitle="Per-video drop counts and decoded fps from HTMLVideoElement.getVideoPlaybackQuality().">
+      {list.length === 0 ? (
+        <p className="text-sm text-tertiary">No video elements in the DOM.</p>
+      ) : (
+        <div className="flex flex-col gap-2">
+          {list.map((video) => {
+            const dropRate = video.totalVideoFrames > 0
+              ? (video.droppedVideoFrames / video.totalVideoFrames) * 100
+              : 0;
+            return (
+              <div key={video.src} className="rounded border border-secondary px-3 py-2">
+                <div className="flex items-center justify-between gap-3 pb-1">
+                  <span className="truncate text-sm font-medium text-primary">{video.label}</span>
+                  <span className="text-xs text-tertiary">{video.isPlaying ? 'playing' : 'paused'}</span>
+                </div>
+                <div className="grid grid-cols-2 gap-x-6 gap-y-1 text-sm text-secondary md:grid-cols-4">
+                  <Stat label="Decoded fps" value={video.decodedFps.toFixed(1)} highlight={video.isPlaying && video.decodedFps < 24} />
+                  <Stat label="Total frames" value={formatNumber(video.totalVideoFrames)} />
+                  <Stat label="Dropped" value={`${formatNumber(video.droppedVideoFrames)} (${dropRate.toFixed(2)}%)`} highlight={dropRate > 1} />
+                  <Stat label="Position" value={`${video.currentTimeSeconds.toFixed(1)} / ${video.durationSeconds.toFixed(1)} s`} />
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </SectionShell>
+  );
+}
+
+// ─── Audio health ──────────────────────────────────────────────────
+
+function AudioHealthSection() {
+  const audio = useMetricsStore((s) => s.audioHealth);
+  return (
+    <SectionShell title="Audio health" subtitle="Sampled from the same AudioContext that feeds NDI audio.">
+      {!audio ? (
+        <p className="text-sm text-tertiary">Audio capture not initialized — start playing audio or video to wake it up.</p>
+      ) : (
+        <div className="grid grid-cols-2 gap-x-6 gap-y-1 text-sm text-secondary md:grid-cols-4">
+          <Stat label="Context" value={audio.contextState ?? 'n/a'} highlight={audio.contextState !== 'running'} />
+          <Stat label="Sample rate" value={`${audio.sampleRate} Hz`} />
+          <Stat label="Base latency" value={`${audio.baseLatencyMs.toFixed(1)} ms`} />
+          <Stat label="Output latency" value={`${audio.outputLatencyMs.toFixed(1)} ms`} />
+          <Stat label="Peak" value={audio.peakLevel.toFixed(3)} highlight={audio.peakLevel >= 0.99} />
+          <Stat label="RMS" value={audio.rmsLevel.toFixed(3)} />
+          <Stat label="Clipping" value={audio.clippingDetected ? 'yes' : 'no'} highlight={audio.clippingDetected} />
+          <Stat label="Underruns" value={formatNumber(audio.underrunCount)} highlight={audio.underrunCount > 0} />
+        </div>
+      )}
+    </SectionShell>
+  );
+}
+
+// ─── Canvas render ─────────────────────────────────────────────────
+
+function CanvasRenderSection() {
+  const render = useMetricsStore((s) => s.canvasRender);
+  return (
+    <SectionShell title="Canvas / render" subtitle="rAF cadence in the renderer — proxy for UI smoothness.">
+      {!render ? (
+        <p className="text-sm text-tertiary">Sampling…</p>
+      ) : (
+        <div className="grid grid-cols-2 gap-x-6 gap-y-1 text-sm text-secondary md:grid-cols-4">
+          <Stat label="Frame interval p50" value={`${render.p50FrameIntervalMs.toFixed(2)} ms`} />
+          <Stat label="Frame interval p95" value={`${render.p95FrameIntervalMs.toFixed(2)} ms`} highlight={render.p95FrameIntervalMs > 25} />
+          <Stat label="Last interval" value={`${render.lastFrameIntervalMs.toFixed(2)} ms`} />
+          <Stat label="Canvases mounted" value={formatNumber(render.layerCount)} />
+        </div>
+      )}
+    </SectionShell>
+  );
+}
+
+// ─── Memory & process ──────────────────────────────────────────────
+
+function MemorySection() {
+  const renderer = useMetricsStore((s) => s.rendererMemory);
+  const system = useMetricsStore((s) => s.systemMetrics);
+  return (
+    <SectionShell title="Memory & CPU" subtitle="Renderer JS heap and main-process metrics, sampled while this page is open.">
+      <div className="flex flex-col gap-3">
+        <div>
+          <div className="pb-1 text-xs font-semibold uppercase tracking-wide text-tertiary">Renderer</div>
+          {!renderer ? (
+            <p className="text-sm text-tertiary">performance.memory unavailable in this context.</p>
+          ) : (
+            <div className="grid grid-cols-2 gap-x-6 gap-y-1 text-sm text-secondary md:grid-cols-3">
+              <Stat label="JS heap used" value={formatBytes(renderer.jsHeapSizeBytes)} />
+              <Stat label="JS heap total" value={formatBytes(renderer.totalJSHeapSizeBytes)} />
+              <Stat label="JS heap limit" value={formatBytes(renderer.jsHeapLimitBytes)} />
+            </div>
+          )}
+        </div>
+        <div>
+          <div className="pb-1 text-xs font-semibold uppercase tracking-wide text-tertiary">Main process</div>
+          {!system ? (
+            <p className="text-sm text-tertiary">Sampling…</p>
+          ) : (
+            <div className="grid grid-cols-2 gap-x-6 gap-y-1 text-sm text-secondary md:grid-cols-3">
+              <Stat label="RSS" value={formatBytes(system.main.rssBytes)} />
+              <Stat label="Heap used" value={formatBytes(system.main.heapUsedBytes)} />
+              <Stat label="Heap total" value={formatBytes(system.main.heapTotalBytes)} />
+              <Stat label="External" value={formatBytes(system.main.externalBytes)} />
+              <Stat label="CPU" value={`${system.main.cpuPercent.toFixed(1)}%`} highlight={system.main.cpuPercent > 60} />
+              <Stat label="Uptime" value={formatDuration(system.uptimeSeconds * 1000)} />
+            </div>
+          )}
+        </div>
+      </div>
+    </SectionShell>
+  );
+}
+
+// ─── Image cache (kept from old Output panel) ──────────────────────
+
+function ImageCacheSection() {
+  const stats = useImageCacheStats();
+  return (
+    <SectionShell title="Image cache" subtitle="In-memory image entries kept hot for the canvas.">
+      <div className="grid grid-cols-2 gap-x-6 gap-y-1 text-sm text-secondary md:grid-cols-3">
+        <Stat label="Entries" value={formatNumber(stats.entryCount)} />
+        <Stat label="Estimated memory" value={formatBytes(stats.totalEstimatedBytes)} />
+        <Stat label="Loaded" value={formatNumber(stats.loadedCount)} />
+        <Stat label="Loading" value={formatNumber(stats.loadingCount)} />
+        <Stat label="Errors" value={formatNumber(stats.errorCount)} highlight={stats.errorCount > 0} />
+      </div>
+    </SectionShell>
+  );
+}
+
+// ─── Event timeline ────────────────────────────────────────────────
+
+const CATEGORY_FILTERS: Array<{ id: 'all' | ObsEventCategory; label: string }> = [
+  { id: 'all', label: 'All' },
+  { id: 'ndi', label: 'NDI' },
+  { id: 'layer', label: 'Layers' },
+  { id: 'overlay', label: 'Overlays' },
+  { id: 'slide', label: 'Slides' },
+  { id: 'playback', label: 'Playback' },
+  { id: 'system', label: 'System' },
+  { id: 'error', label: 'Errors' },
+];
+
+function EventTimelineSection() {
+  const { events, clearEvents } = useMetricsStore(
+    useShallow((s) => ({ events: s.events, clearEvents: s.clearEvents })),
+  );
+  const [filter, setFilter] = useState<'all' | ObsEventCategory>('all');
+  const visible = useMemo(() => {
+    const base = filter === 'all' ? events : events.filter((event) => event.category === filter);
+    return base.slice().reverse();
+  }, [events, filter]);
+  return (
+    <SectionShell
+      title="Event timeline"
+      subtitle="Recent in-app events, newest first. Cleared on app restart — for permanent history use the log viewer below."
+      headerExtra={(
+        <div className="flex items-center gap-2">
+          <FilterChips
+            value={filter}
+            options={CATEGORY_FILTERS}
+            onChange={(next) => setFilter(next)}
+          />
+          <button
+            type="button"
+            className="rounded border border-secondary px-2 py-0.5 text-xs text-secondary hover:bg-tertiary/40"
+            onClick={clearEvents}
+          >
+            Clear
+          </button>
+        </div>
+      )}
+    >
+      {visible.length === 0 ? (
+        <p className="text-sm text-tertiary">No events yet.</p>
+      ) : (
+        <div className="max-h-72 overflow-y-auto rounded border border-secondary">
+          <table className="w-full text-left text-xs">
+            <tbody>
+              {visible.map((event) => (
+                <EventRow key={event.id} event={event} />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </SectionShell>
+  );
+}
+
+function EventRow({ event }: { event: ObsEvent }) {
+  const time = new Date(event.capturedAtMs).toLocaleTimeString();
+  const color = colorForLevel(event.level);
+  return (
+    <tr className="border-b border-secondary/40 last:border-b-0">
+      <td className="w-24 px-2 py-1 align-top font-mono text-tertiary">{time}</td>
+      <td className="w-20 px-2 py-1 align-top text-tertiary">{event.category}</td>
+      <td className={`px-2 py-1 align-top ${color}`}>
+        <div>{event.message}</div>
+        {event.details ? (
+          <div className="font-mono text-[10px] text-tertiary">{JSON.stringify(event.details)}</div>
+        ) : null}
+      </td>
+    </tr>
+  );
+}
+
+function colorForLevel(level: ObsEventLevel): string {
+  switch (level) {
+    case 'error': return 'text-red-400';
+    case 'warn': return 'text-amber-400';
+    default: return 'text-secondary';
+  }
+}
+
+// ─── Log viewer ────────────────────────────────────────────────────
+
+const LEVEL_FILTERS: Array<{ id: 'all' | 'INFO' | 'WARN' | 'ERROR'; label: string }> = [
+  { id: 'all', label: 'All' },
+  { id: 'INFO', label: 'Info' },
+  { id: 'WARN', label: 'Warn' },
+  { id: 'ERROR', label: 'Error' },
+];
+
+function LogViewerSection() {
+  const [sessions, setSessions] = useState<LogSessionSummary[]>([]);
+  const [selected, setSelected] = useState<string | null>(null);
+  const [lines, setLines] = useState<string[]>([]);
+  const [tailOffset, setTailOffset] = useState(0);
+  const [levelFilter, setLevelFilter] = useState<'all' | 'INFO' | 'WARN' | 'ERROR'>('all');
+  const [loading, setLoading] = useState(false);
+  const lineContainerRef = useRef<HTMLDivElement>(null);
+  const userScrolledRef = useRef(false);
+
+  const refreshSessions = useCallback(async () => {
+    try {
+      const next = await window.castApi.obsListLogSessions();
+      setSessions(next);
+      if (!selected && next.length > 0) {
+        const current = next.find((session) => session.isCurrent) ?? next[0];
+        setSelected(current.path);
+      }
+    } catch (error) {
+      console.error('[obs] failed to list log sessions', error);
+    }
+  }, [selected]);
+
+  useEffect(() => {
+    void refreshSessions();
+  }, [refreshSessions]);
+
+  // Initial load + tail of selected session.
+  useEffect(() => {
+    if (!selected) return undefined;
+    let cancelled = false;
+    let intervalId: number | undefined;
+
+    async function loadInitial() {
+      setLoading(true);
+      try {
+        const result: LogReadResult = await window.castApi.obsReadLogSession(selected!, -1, 2000);
+        if (cancelled) return;
+        setLines(result.lines);
+        setTailOffset(result.nextOffset);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    void loadInitial();
+
+    const session = sessions.find((entry) => entry.path === selected);
+    if (session?.isCurrent) {
+      intervalId = window.setInterval(async () => {
+        try {
+          const result = await window.castApi.obsReadLogSession(selected!, tailOffset, 1000);
+          if (cancelled) return;
+          if (result.lines.length > 0) {
+            setLines((prev) => prev.concat(result.lines).slice(-5000));
+          }
+          setTailOffset(result.nextOffset);
+        } catch (error) {
+          console.error('[obs] log tail failed', error);
+        }
+      }, 1500);
+    }
+
+    return () => {
+      cancelled = true;
+      if (intervalId !== undefined) window.clearInterval(intervalId);
+    };
+    // tailOffset intentionally excluded — we update it inside the polled
+    // closure and re-running the effect on every offset change would break
+    // the live tail.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selected, sessions]);
+
+  // Auto-scroll to bottom on new lines unless the user has scrolled away.
+  useEffect(() => {
+    const container = lineContainerRef.current;
+    if (!container) return;
+    if (userScrolledRef.current) return;
+    container.scrollTop = container.scrollHeight;
+  }, [lines]);
+
+  const filteredLines = useMemo(() => {
+    if (levelFilter === 'all') return lines;
+    return lines.filter((line) => line.includes(` ${levelFilter} `));
+  }, [lines, levelFilter]);
+
+  function handleScroll() {
+    const container = lineContainerRef.current;
+    if (!container) return;
+    const atBottom = container.scrollHeight - container.scrollTop - container.clientHeight < 24;
+    userScrolledRef.current = !atBottom;
+  }
+
+  function handleCopyPath() {
+    if (selected) void window.castApi.writeClipboardText(selected);
+  }
+
+  function handleOpenFolder() {
+    void window.castApi.obsOpenLogFolder();
+  }
+
+  return (
+    <SectionShell
+      title="Logs"
+      subtitle="Session log files written by the main process. The current session live-tails."
+      headerExtra={(
+        <div className="flex items-center gap-2">
+          <button type="button" className="rounded border border-secondary px-2 py-0.5 text-xs text-secondary hover:bg-tertiary/40" onClick={() => void refreshSessions()}>
+            Refresh
+          </button>
+          <button type="button" className="rounded border border-secondary px-2 py-0.5 text-xs text-secondary hover:bg-tertiary/40" onClick={handleOpenFolder}>
+            Open folder
+          </button>
+          <button type="button" className="rounded border border-secondary px-2 py-0.5 text-xs text-secondary hover:bg-tertiary/40 disabled:opacity-40" onClick={handleCopyPath} disabled={!selected}>
+            Copy path
+          </button>
+        </div>
+      )}
+    >
+      <div className="grid grid-cols-1 gap-3 lg:grid-cols-[260px_minmax(0,1fr)]">
+        <div className="flex max-h-72 flex-col overflow-y-auto rounded border border-secondary">
+          {sessions.length === 0 ? (
+            <p className="p-3 text-sm text-tertiary">No log sessions found.</p>
+          ) : (
+            sessions.map((session) => {
+              const active = session.path === selected;
+              return (
+                <button
+                  key={session.path}
+                  type="button"
+                  onClick={() => { setSelected(session.path); userScrolledRef.current = false; }}
+                  className={`flex flex-col gap-0.5 border-b border-secondary/40 px-3 py-2 text-left text-xs last:border-b-0 ${active ? 'bg-active text-primary' : 'text-secondary hover:bg-tertiary/40'}`}
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="truncate font-medium">{session.fileName}</span>
+                    {session.isCurrent ? (
+                      <span className="rounded bg-emerald-500/20 px-1 text-[10px] uppercase tracking-wide text-emerald-300">live</span>
+                    ) : null}
+                  </div>
+                  <div className="text-tertiary">{formatBytes(session.sizeBytes)} · {new Date(session.modifiedAtMs).toLocaleString()}</div>
+                </button>
+              );
+            })
+          )}
+        </div>
+        <div className="flex min-h-72 flex-col gap-2">
+          <FilterChips
+            value={levelFilter}
+            options={LEVEL_FILTERS}
+            onChange={(next) => setLevelFilter(next)}
+          />
+          <div
+            ref={lineContainerRef}
+            onScroll={handleScroll}
+            className="h-72 overflow-y-auto rounded border border-secondary bg-primary/40 p-2 font-mono text-[11px] leading-snug text-secondary"
+          >
+            {loading && filteredLines.length === 0 ? (
+              <div className="text-tertiary">Loading…</div>
+            ) : filteredLines.length === 0 ? (
+              <div className="text-tertiary">No log lines.</div>
+            ) : (
+              filteredLines.map((line, index) => (
+                <div key={`${index}-${line.length}`} className={lineColor(line)}>{line}</div>
+              ))
+            )}
+          </div>
+        </div>
+      </div>
+    </SectionShell>
+  );
+}
+
+function lineColor(line: string): string {
+  if (line.includes(' ERROR ')) return 'text-red-400';
+  if (line.includes(' WARN ')) return 'text-amber-400';
+  return '';
+}
+
+// ─── Shared bits ────────────────────────────────────────────────────
+
+function SectionShell({ title, subtitle, headerExtra, children }: {
+  title: string;
+  subtitle?: string;
+  headerExtra?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="flex flex-col gap-3 border-b border-primary pb-6 last:border-b-0">
+      <header className="flex items-start justify-between gap-3">
+        <div className="flex flex-col gap-0.5">
+          <h2 className="text-sm font-semibold text-primary">{title}</h2>
+          {subtitle ? <p className="text-xs text-tertiary">{subtitle}</p> : null}
+        </div>
+        {headerExtra}
+      </header>
+      {children}
+    </section>
+  );
+}
+
+function Stat({ label, value, highlight }: { label: string; value: React.ReactNode; highlight?: boolean }) {
+  return (
+    <div className="flex items-center justify-between gap-2">
+      <span className="text-tertiary">{label}</span>
+      <span className={`font-mono text-xs ${highlight ? 'text-amber-300' : 'text-secondary'}`}>{value}</span>
+    </div>
+  );
+}
+
+function FilterChips<T extends string>({
+  value,
+  options,
+  onChange,
+}: {
+  value: T;
+  options: Array<{ id: T; label: string }>;
+  onChange: (next: T) => void;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-1">
+      {options.map((option) => (
+        <button
+          key={option.id}
+          type="button"
+          onClick={() => onChange(option.id)}
+          className={`rounded px-2 py-0.5 text-xs ${value === option.id ? 'bg-active text-primary' : 'text-secondary hover:bg-tertiary/40'}`}
+        >
+          {option.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function formatNumber(value: number): string {
+  return value.toLocaleString();
+}
+
+function formatBytes(value: number): string {
+  if (value < 1024) return `${value} B`;
+  if (value < 1024 * 1024) return `${(value / 1024).toFixed(1)} KB`;
+  if (value < 1024 * 1024 * 1024) return `${(value / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(value / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
+function formatDuration(ms: number): string {
+  const sec = Math.floor(ms / 1000);
+  const minutes = Math.floor(sec / 60);
+  const remainingSec = sec % 60;
+  if (minutes < 60) return `${minutes}m ${remainingSec.toString().padStart(2, '0')}s`;
+  const hours = Math.floor(minutes / 60);
+  const remainingMin = minutes % 60;
+  return `${hours}h ${remainingMin.toString().padStart(2, '0')}m`;
+}

--- a/app/renderer/features/playback/ndi-audio-capture.ts
+++ b/app/renderer/features/playback/ndi-audio-capture.ts
@@ -78,10 +78,22 @@ interface AudioCaptureContext {
   ctx: AudioContext;
   mixGain: GainNode;
   worklet: AudioWorkletNode;
+  analyser: AnalyserNode;
 }
 
 let initPromise: Promise<AudioCaptureContext | null> | null = null;
+let activeContext: AudioCaptureContext | null = null;
 const sources = new WeakMap<HTMLMediaElement, MediaElementAudioSourceNode>();
+
+// Read-only handle for the observability page so it can sample the same
+// AudioContext we're using for capture. Returns null when capture hasn't
+// initialized yet (no media has been hooked up).
+export function getActiveNdiAudioContext():
+  | { ctx: AudioContext; analyser: AnalyserNode }
+  | null {
+  if (!activeContext) return null;
+  return { ctx: activeContext.ctx, analyser: activeContext.analyser };
+}
 
 // Outputs that should receive audio. Updated externally when the user toggles
 // NDI outputs on/off. We always run capture (so the speaker output stays
@@ -152,7 +164,15 @@ async function ensureContext(): Promise<AudioCaptureContext | null> {
     // elements routed through the source nodes would be silent locally.
     mixGain.connect(ctx.destination);
 
-    return { ctx, mixGain, worklet };
+    // Side-tap: the observability page sniffs peak/RMS levels off this
+    // analyser. Connecting the mix into it (no further routing) doesn't
+    // contribute to playback but keeps the analyser fed.
+    const analyser = new AnalyserNode(ctx, { fftSize: 1024 });
+    mixGain.connect(analyser);
+
+    const capture: AudioCaptureContext = { ctx, mixGain, worklet, analyser };
+    activeContext = capture;
+    return capture;
   })();
   return initPromise;
 }

--- a/app/renderer/features/playback/output-settings-panel.tsx
+++ b/app/renderer/features/playback/output-settings-panel.tsx
@@ -1,8 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
-import type { NdiActiveSenderDiagnostics, NdiOutputName } from '@core/types';
+import type { NdiOutputName } from '@core/types';
 import { FieldCheckbox as CheckboxField, FieldInput } from '../../components/form/field';
 import { useNdi } from '../../contexts/app-context';
-import { useImageCacheStats } from '../canvas/use-image-cache-stats';
 
 const OUTPUT_TITLES: Record<NdiOutputName, string> = {
   audience: 'Audience NDI',
@@ -15,9 +14,6 @@ const OUTPUT_DESCRIPTIONS: Record<NdiOutputName, string | null> = {
 };
 
 export function OutputSettingsPanel() {
-  const { state: { diagnostics } } = useNdi();
-  const imageCacheStats = useImageCacheStats();
-
   return (
     <div className="flex flex-col gap-6">
       <section className="flex flex-col gap-3 border-b border-primary pb-5">
@@ -30,87 +26,11 @@ export function OutputSettingsPanel() {
       <OutputControls name="audience" />
       <OutputControls name="stage" />
 
-      <section className="flex flex-col gap-3">
-        <header className="flex items-center justify-between gap-3">
-          <h2 className="text-sm font-semibold text-primary">NDI diagnostics</h2>
-        </header>
-        {diagnostics ? (
-          <div className="flex flex-col gap-1 text-sm text-secondary">
-            <div>Runtime: {diagnostics.runtimeLoaded ? (diagnostics.runtimePath ?? 'Loaded') : 'Not loaded'}</div>
-            <div>Status: {diagnostics.sourceStatus}</div>
-            <div>Audience config: {diagnostics.outputConfigs.audience.senderName}</div>
-            <div>Stage config: {diagnostics.outputConfigs.stage.senderName}</div>
-            <SenderDiagnosticsBlock name="audience" diagnostics={diagnostics.senders.audience} />
-            <SenderDiagnosticsBlock name="stage" diagnostics={diagnostics.senders.stage} />
-            {diagnostics.lastError ? (
-              <div className="text-red-400">Error: {diagnostics.lastError}</div>
-            ) : null}
-          </div>
-        ) : (
-          <p className="text-sm text-tertiary">Waiting for NDI diagnostics.</p>
-        )}
-      </section>
-
-      <section className="flex flex-col gap-3">
-        <header className="flex items-center justify-between gap-3">
-          <h2 className="text-sm font-semibold text-primary">Image cache</h2>
-        </header>
-        <div className="flex flex-col gap-1 text-sm text-secondary">
-          <div>Entries: {imageCacheStats.entryCount}</div>
-          <div>Estimated memory: {formatBytes(imageCacheStats.totalEstimatedBytes)}</div>
-          <div>Loaded: {imageCacheStats.loadedCount}</div>
-          <div>Loading: {imageCacheStats.loadingCount}</div>
-          <div>Errors: {imageCacheStats.errorCount}</div>
-        </div>
-      </section>
+      <p className="text-sm text-tertiary">
+        Live diagnostics, frame stats, log viewer, and process metrics moved to the Observability tab.
+      </p>
     </div>
   );
-}
-
-function SenderDiagnosticsBlock({ name, diagnostics }: { name: NdiOutputName; diagnostics: NdiActiveSenderDiagnostics | null }) {
-  if (!diagnostics) {
-    return <div>{OUTPUT_TITLES[name]} sender: inactive</div>;
-  }
-
-  const performance = diagnostics.performance;
-  return (
-    <>
-      <div>
-        {OUTPUT_TITLES[name]} sender: {diagnostics.senderName} ({diagnostics.width}x{diagnostics.height})
-        {' '}· Async send: {diagnostics.asyncVideoSend ? 'on' : 'off'}
-        {' '}· Connections: {diagnostics.connectionCount ?? 'unknown'}
-      </div>
-      <div>{OUTPUT_TITLES[name]} frames captured: {performance.framesCaptured}</div>
-      <div>{OUTPUT_TITLES[name]} frames sent: {performance.framesSent}</div>
-      <div>{OUTPUT_TITLES[name]} frames replayed: {performance.framesReplayed}</div>
-      <div>{OUTPUT_TITLES[name]} frames skipped with no connections: {performance.framesSkippedNoConnections}</div>
-      <div>{OUTPUT_TITLES[name]} skipped captures: {performance.skippedCaptures}</div>
-      <div>{OUTPUT_TITLES[name]} frames dropped (backpressure): {performance.framesDroppedBackpressure}</div>
-      <div>{OUTPUT_TITLES[name]} bytes received: {formatBytes(performance.bytesReceived)}</div>
-      <div>{OUTPUT_TITLES[name]} cache copy bytes: {formatBytes(performance.cacheCopyBytes)}</div>
-      <div>{OUTPUT_TITLES[name]} average capture time: {performance.avgCaptureDurationMs.toFixed(2)} ms</div>
-      <div>{OUTPUT_TITLES[name]} average readback time: {performance.avgReadbackDurationMs.toFixed(2)} ms</div>
-      <div>{OUTPUT_TITLES[name]} average send time: {performance.avgSendDurationMs.toFixed(2)} ms</div>
-      <div>{OUTPUT_TITLES[name]} rejected frames: {performance.framesRejected}</div>
-      <div>
-        {OUTPUT_TITLES[name]} audio: received {diagnostics.audio.audioFramesReceived} ·
-        sent {diagnostics.audio.audioFramesSent} ·
-        samples {diagnostics.audio.audioSamplesSent} ·
-        {diagnostics.audio.lastSampleRate > 0
-          ? ` ${diagnostics.audio.lastSampleRate} Hz × ${diagnostics.audio.lastChannels}ch`
-          : ' inactive'}
-        {diagnostics.audio.audioFramesRejected > 0
-          ? ` · rejected ${diagnostics.audio.audioFramesRejected}`
-          : ''}
-      </div>
-    </>
-  );
-}
-
-function formatBytes(value: number): string {
-  if (value < 1024) return `${value} B`;
-  if (value < 1024 * 1024) return `${(value / 1024).toFixed(1)} KB`;
-  return `${(value / (1024 * 1024)).toFixed(1)} MB`;
 }
 
 // Per-output controls block. Rendered once per `NdiOutputName` so audience and

--- a/app/renderer/screens/settings/page.tsx
+++ b/app/renderer/screens/settings/page.tsx
@@ -2,12 +2,13 @@ import { useState } from 'react';
 import { LumaCastPanel } from '@renderer/components/layout/panel';
 import { SelectableRow } from '../../components/display/selectable-row';
 import { AppearanceSettingsPanel } from './appearance-settings-panel';
+import { ObservabilityPanel } from '../../features/observability/observability-panel';
 import { OutputSettingsPanel } from '../../features/playback/output-settings-panel';
 import { OverlaySettingsPanel } from '../../features/assets/overlays/overlay-settings-panel';
 import { ImportExportPanel } from '../../features/deck/import-export-panel';
 import { SplitPanel } from '@renderer/components/layout/panel-split/split-panel';
 
-type SettingsTabId = 'appearance' | 'output' | 'overlays' | 'transfer';
+type SettingsTabId = 'appearance' | 'output' | 'overlays' | 'observability' | 'transfer';
 
 export function SettingsScreen() {
   const [activeTab, setActiveTab] = useState<SettingsTabId>('appearance');
@@ -28,6 +29,9 @@ export function SettingsScreen() {
                 <SelectableRow.Root selected={activeTab === 'overlays'} onClick={() => setActiveTab('overlays')}>
                   <SelectableRow.Label>Overlays</SelectableRow.Label>
                 </SelectableRow.Root>
+                <SelectableRow.Root selected={activeTab === 'observability'} onClick={() => setActiveTab('observability')}>
+                  <SelectableRow.Label>Observability</SelectableRow.Label>
+                </SelectableRow.Root>
                 <SelectableRow.Root selected={activeTab === 'transfer'} onClick={() => setActiveTab('transfer')}>
                   <SelectableRow.Label>Import &amp; Export</SelectableRow.Label>
                 </SelectableRow.Root>
@@ -45,6 +49,7 @@ export function SettingsScreen() {
               {activeTab === 'appearance' && <AppearanceSettingsPanel />}
               {activeTab === 'output' && <OutputSettingsPanel />}
               {activeTab === 'overlays' && <OverlaySettingsPanel />}
+              {activeTab === 'observability' && <ObservabilityPanel />}
               {activeTab === 'transfer' && <ImportExportPanel />}
             </div>
           </main>

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "pretest:watch": "npm run ensure:native-deps",
     "test:watch": "vitest --watch",
     "pretest:e2e": "npm run build && npm run e2e:install",
-    "test:e2e": "playwright test",
+    "test:e2e": "playwright test --pass-with-no-tests",
     "e2e:install": "playwright install chromium",
     "capture:ui-screenshots": "npm run build && node app/e2e/capture-ui-screenshots.mjs",
     "pack": "electron-vite build && electron-builder --dir",


### PR DESCRIPTION
## Summary
- Send NDI audio alongside video for the audience output, with worklet/CSP/CORS fixes for the audio capture path
- Add a settings Observability panel backed by a metrics store, expanded NDI service stats, system metrics collection, and log tailing
- Bump to 0.1.9 plus assorted fixes (NDI frame IPC, startup logging, Windows launch path, release workflow gating)

## Test plan
- [ ] Launch app and verify NDI audio + video output to a receiver
- [ ] Open Settings → Observability and confirm metrics/log views populate
- [ ] Confirm NDI subprocess starts cleanly on macOS and Windows
- [ ] Smoke-test playback, deck import/export, and group browsing

🤖 Generated with [Claude Code](https://claude.com/claude-code)