### PR TITLE
Release 0.1.11: lyric layout engine, deck/inspector polish, actions plan

### DIFF
--- a/app/renderer/contexts/slide-context.tsx
+++ b/app/renderer/contexts/slide-context.tsx
@@ -127,13 +127,12 @@ export function SlideProvider({ children }: { children: ReactNode }) {
     armOutputPlaylistEntry(entryId);
   }, [armOutputPlaylistEntry, selectPlaylistEntryInNavigation, liveSelection.update]);
 
-  // Clicking an entry inside a segment should arm it on the program output
-  // (program + monitor surfaces). Free-floating selections that don't belong
-  // to a segment go through other code paths and are not armed here.
+  // Focus only — Program state is independent of which entry the operator is
+  // currently inspecting. Arming happens through explicit actions (activate,
+  // take, activatePlaylistEntrySlide, armCurrentPlaylistSelection).
   const selectPlaylistEntry = useCallback((entryId: Id) => {
     selectPlaylistEntryInNavigation(entryId);
-    armOutputPlaylistEntry(entryId);
-  }, [armOutputPlaylistEntry, selectPlaylistEntryInNavigation]);
+  }, [selectPlaylistEntryInNavigation]);
 
   const selectPlaylistDeckItem = useCallback((itemId: Id) => {
     selectPlaylistDeckItemInNavigation(itemId);

--- a/app/renderer/features/deck/lyric-editor-modal.tsx
+++ b/app/renderer/features/deck/lyric-editor-modal.tsx
@@ -1,9 +1,15 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { Baseline, Layers, MoveHorizontal, MoveVertical, Settings, Type } from 'lucide-react';
 import { ReacstButton } from '@renderer/components/controls/button';
 import { Dialog } from '../../components/overlays/dialog';
 import DocEditor, { type Block } from '../../components/form/doc-editor';
 import { useNavigation } from '../../contexts/navigation-context';
 import { useLyricEditorSave } from './use-lyric-editor-document';
+import { useLyricLayoutConfig, DEFAULT_LYRIC_LAYOUT_CONFIG, type LyricLayoutConfig } from './lyric-layout-config';
+import { FieldIcon, FieldInput, FieldSelect } from '../../components/form/field';
+import { Section } from '../inspector/inspector-section';
+import { Label } from '../../components/display/text';
+import { useSystemFonts } from '../inspector/use-system-fonts';
 
 interface LyricEditorModalProps {
   isOpen: boolean;
@@ -12,8 +18,10 @@ interface LyricEditorModalProps {
 
 export function LyricEditorModal({ isOpen, onClose }: LyricEditorModalProps) {
   const { currentDeckItem } = useNavigation();
-  const { initialBlocks, saveBlocks, isSaving } = useLyricEditorSave({ isOpen, onClose });
+  const { config, updateConfig } = useLyricLayoutConfig();
+  const { initialBlocks, saveBlocks, isSaving } = useLyricEditorSave({ isOpen, onClose, config });
   const blocksRef = useRef<Block[]>(initialBlocks);
+  const [isConfigOpen, setIsConfigOpen] = useState(false);
 
   useEffect(() => {
     if (isOpen) blocksRef.current = initialBlocks;
@@ -30,26 +38,143 @@ export function LyricEditorModal({ isOpen, onClose }: LyricEditorModalProps) {
   if (!isOpen || !currentDeckItem || currentDeckItem.type !== 'lyric') return null;
 
   return (
-    <Dialog.Root open onOpenChange={(isOpen) => { if (!isOpen) onClose(); }}>
+    <>
+      <Dialog.Root open onOpenChange={(isOpen) => { if (!isOpen) onClose(); }}>
+        <Dialog.Portal>
+          <Dialog.Backdrop />
+          <Dialog.Positioner>
+            <Dialog.Content data-ui-region="lyric-editor-modal" className="h-[calc(100vh-2rem)] w-full max-w-4xl">
+              <Dialog.Header>
+                <Dialog.Title>Lyric editor</Dialog.Title>
+                <div className="flex items-center gap-1">
+                  <ReacstButton.Icon label="Layout settings" variant="ghost" onClick={() => setIsConfigOpen(true)}>
+                    <Settings />
+                  </ReacstButton.Icon>
+                  <Dialog.CloseButton />
+                </div>
+              </Dialog.Header>
+              <Dialog.Body className="h-full overflow-auto bg-primary/95 px-0 py-0">
+                <div className="min-h-80 px-6 py-5">
+                  <div className="mx-auto flex max-w-3xl justify-center">
+                    <DocEditor initialBlocks={initialBlocks} onChange={handleChange} />
+                  </div>
+                </div>
+              </Dialog.Body>
+              <Dialog.Footer>
+                <div className="ml-auto flex items-center gap-2">
+                  <ReacstButton variant="ghost" onClick={onClose} disabled={isSaving}>Cancel</ReacstButton>
+                  <ReacstButton variant="take" onClick={handleSave} disabled={isSaving}>Save</ReacstButton>
+                </div>
+              </Dialog.Footer>
+            </Dialog.Content>
+          </Dialog.Positioner>
+        </Dialog.Portal>
+      </Dialog.Root>
+
+      <LyricLayoutConfigDialog
+        isOpen={isConfigOpen}
+        onClose={() => setIsConfigOpen(false)}
+        config={config}
+        onSave={updateConfig}
+      />
+    </>
+  );
+}
+
+interface LyricLayoutConfigDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  config: LyricLayoutConfig;
+  onSave: (next: LyricLayoutConfig) => void;
+}
+
+function LyricLayoutConfigDialog({ isOpen, onClose, config, onSave }: LyricLayoutConfigDialogProps) {
+  const [draft, setDraft] = useState<LyricLayoutConfig>(config);
+  const fontOptions = useSystemFonts(draft.fontFamily);
+
+  useEffect(() => {
+    if (isOpen) setDraft(config);
+  }, [isOpen, config]);
+
+  if (!isOpen) return null;
+
+  function patch<K extends keyof LyricLayoutConfig>(key: K, value: LyricLayoutConfig[K]) {
+    setDraft((prev) => ({ ...prev, [key]: value }));
+  }
+
+  function numericPatch<K extends keyof LyricLayoutConfig>(key: K, raw: string, fallback: number) {
+    const parsed = Number(raw);
+    patch(key, (Number.isFinite(parsed) ? parsed : fallback) as LyricLayoutConfig[K]);
+  }
+
+  function handleSubmit() {
+    onSave(draft);
+    onClose();
+  }
+
+  function handleReset() {
+    setDraft(DEFAULT_LYRIC_LAYOUT_CONFIG);
+  }
+
+  return (
+    <Dialog.Root open onOpenChange={(open) => { if (!open) onClose(); }}>
       <Dialog.Portal>
         <Dialog.Backdrop />
         <Dialog.Positioner>
-          <Dialog.Content data-ui-region="lyric-editor-modal" className="h-[calc(100vh-2rem)] max-w-[calc(100vw-2rem)]">
+          <Dialog.Content data-ui-region="lyric-layout-config" className="w-full max-w-md">
             <Dialog.Header>
-              <Dialog.Title>Lyric editor</Dialog.Title>
+              <Dialog.Title>Layout settings</Dialog.Title>
               <Dialog.CloseButton />
             </Dialog.Header>
-            <Dialog.Body className="h-full overflow-auto bg-primary/95 px-0 py-0">
-              <div className="min-h-80 px-6 py-5">
-                <div className="mx-auto flex max-w-3xl justify-center">
-                  <DocEditor initialBlocks={initialBlocks} onChange={handleChange} />
-                </div>
-              </div>
+            <Dialog.Body className="px-4 py-4">
+              <Section.Root>
+                <Section.Header><Label.xs>Text box</Label.xs></Section.Header>
+                <Section.Body>
+                  <Section.Row>
+                    <FieldInput type="number" value={draft.boxWidth} onChange={(v) => numericPatch('boxWidth', v, DEFAULT_LYRIC_LAYOUT_CONFIG.boxWidth)}>
+                      <FieldIcon><MoveHorizontal className="size-4" /></FieldIcon>
+                    </FieldInput>
+                    <FieldInput type="number" value={draft.boxHeight} onChange={(v) => numericPatch('boxHeight', v, DEFAULT_LYRIC_LAYOUT_CONFIG.boxHeight)}>
+                      <FieldIcon><MoveVertical className="size-4" /></FieldIcon>
+                    </FieldInput>
+                  </Section.Row>
+                </Section.Body>
+              </Section.Root>
+
+              <Section.Root>
+                <Section.Header><Label.xs>Typography</Label.xs></Section.Header>
+                <Section.Body>
+                  <Section.Row>
+                    <FieldSelect value={draft.fontFamily} onChange={(v) => patch('fontFamily', v)} options={fontOptions} />
+                    <FieldInput type="text" value={draft.fontWeight} onChange={(v) => patch('fontWeight', v)} />
+                  </Section.Row>
+                  <Section.Row>
+                    <FieldInput type="number" value={draft.fontSize} onChange={(v) => numericPatch('fontSize', v, DEFAULT_LYRIC_LAYOUT_CONFIG.fontSize)}>
+                      <FieldIcon><Type className="size-4" /></FieldIcon>
+                    </FieldInput>
+                    <FieldInput type="number" value={draft.lineHeight} onChange={(v) => numericPatch('lineHeight', v, DEFAULT_LYRIC_LAYOUT_CONFIG.lineHeight)}>
+                      <FieldIcon><Baseline className="size-4" /></FieldIcon>
+                    </FieldInput>
+                  </Section.Row>
+                </Section.Body>
+              </Section.Root>
+
+              <Section.Root>
+                <Section.Header><Label.xs>Slide composition</Label.xs></Section.Header>
+                <Section.Body>
+                  <Section.Row>
+                    <FieldInput type="number" value={draft.segmentsPerSlide} onChange={(v) => numericPatch('segmentsPerSlide', v, DEFAULT_LYRIC_LAYOUT_CONFIG.segmentsPerSlide)} min={1}>
+                      <FieldIcon><Layers className="size-4" /></FieldIcon>
+                    </FieldInput>
+                  </Section.Row>
+                </Section.Body>
+              </Section.Root>
             </Dialog.Body>
             <Dialog.Footer>
-              <div className="ml-auto flex items-center gap-2">
-                <ReacstButton variant="ghost" onClick={onClose} disabled={isSaving}>Cancel</ReacstButton>
-                <ReacstButton variant="take" onClick={handleSave} disabled={isSaving}>Save</ReacstButton>
+              <ReacstButton variant="ghost" onClick={handleReset}>Reset</ReacstButton>
+              <div className="flex items-center gap-2">
+                <ReacstButton variant="ghost" onClick={onClose}>Cancel</ReacstButton>
+                <ReacstButton variant="take" onClick={handleSubmit}>Apply</ReacstButton>
               </div>
             </Dialog.Footer>
           </Dialog.Content>

--- a/app/renderer/features/deck/lyric-editor-modal.tsx
+++ b/app/renderer/features/deck/lyric-editor-modal.tsx
@@ -6,6 +6,7 @@ import DocEditor, { type Block } from '../../components/form/doc-editor';
 import { useNavigation } from '../../contexts/navigation-context';
 import { useLyricEditorSave } from './use-lyric-editor-document';
 import { useLyricLayoutConfig, DEFAULT_LYRIC_LAYOUT_CONFIG, type LyricLayoutConfig } from './lyric-layout-config';
+import { groupSegmentsForSlides, joinSegments } from './lyric-slide-grouping';
 import { FieldIcon, FieldInput, FieldSelect } from '../../components/form/field';
 import { Section } from '../inspector/inspector-section';
 import { Label } from '../../components/display/text';
@@ -22,9 +23,16 @@ export function LyricEditorModal({ isOpen, onClose }: LyricEditorModalProps) {
   const { initialBlocks, saveBlocks, isSaving } = useLyricEditorSave({ isOpen, onClose, config });
   const blocksRef = useRef<Block[]>(initialBlocks);
   const [isConfigOpen, setIsConfigOpen] = useState(false);
+  const [editorBlocks, setEditorBlocks] = useState<Block[]>(initialBlocks);
+  const [editorEpoch, setEditorEpoch] = useState(0);
+  const [hasAppliedGrouping, setHasAppliedGrouping] = useState(false);
 
   useEffect(() => {
-    if (isOpen) blocksRef.current = initialBlocks;
+    if (!isOpen) return;
+    blocksRef.current = initialBlocks;
+    setEditorBlocks(initialBlocks);
+    setEditorEpoch((n) => n + 1);
+    setHasAppliedGrouping(false);
   }, [isOpen, initialBlocks]);
 
   function handleChange(blocks: Block[]) {
@@ -32,7 +40,22 @@ export function LyricEditorModal({ isOpen, onClose }: LyricEditorModalProps) {
   }
 
   function handleSave() {
-    void saveBlocks(blocksRef.current);
+    void saveBlocks(blocksRef.current, { skipGrouping: hasAppliedGrouping });
+  }
+
+  function handlePreview() {
+    const segments = blocksRef.current
+      .map((block) => block.content.replace(/^[ \t\n]+|[ \t\n]+$/g, ''))
+      .filter((content) => content.length > 0);
+    const groups = groupSegmentsForSlides(segments, config);
+    const groupedBlocks: Block[] = groups.map((group) => ({
+      id: Math.random().toString(36).slice(2, 9),
+      content: joinSegments(group),
+    }));
+    blocksRef.current = groupedBlocks;
+    setEditorBlocks(groupedBlocks);
+    setEditorEpoch((n) => n + 1);
+    setHasAppliedGrouping(true);
   }
 
   if (!isOpen || !currentDeckItem || currentDeckItem.type !== 'lyric') return null;
@@ -56,12 +79,13 @@ export function LyricEditorModal({ isOpen, onClose }: LyricEditorModalProps) {
               <Dialog.Body className="h-full overflow-auto bg-primary/95 px-0 py-0">
                 <div className="min-h-80 px-6 py-5">
                   <div className="mx-auto flex max-w-3xl justify-center">
-                    <DocEditor initialBlocks={initialBlocks} onChange={handleChange} />
+                    <DocEditor key={editorEpoch} initialBlocks={editorBlocks} onChange={handleChange} />
                   </div>
                 </div>
               </Dialog.Body>
               <Dialog.Footer>
-                <div className="ml-auto flex items-center gap-2">
+                <ReacstButton variant="default" onClick={handlePreview} disabled={isSaving}>Preview</ReacstButton>
+                <div className="flex items-center gap-2">
                   <ReacstButton variant="ghost" onClick={onClose} disabled={isSaving}>Cancel</ReacstButton>
                   <ReacstButton variant="take" onClick={handleSave} disabled={isSaving}>Save</ReacstButton>
                 </div>

--- a/app/renderer/features/deck/lyric-layout-config.ts
+++ b/app/renderer/features/deck/lyric-layout-config.ts
@@ -1,0 +1,59 @@
+import { useCallback, useEffect, useState } from 'react';
+
+export type LyricLayoutConfig = {
+  boxWidth: number;
+  boxHeight: number;
+  fontFamily: string;
+  fontWeight: string;
+  fontSize: number;
+  lineHeight: number;
+  segmentsPerSlide: number;
+};
+
+export const DEFAULT_LYRIC_LAYOUT_CONFIG: LyricLayoutConfig = {
+  boxWidth: 1767,
+  boxHeight: 210,
+  fontFamily: 'Arial',
+  fontWeight: '700',
+  fontSize: 81,
+  lineHeight: 1.2,
+  segmentsPerSlide: 1,
+};
+
+const STORAGE_KEY = 'lumacast.lyric-layout-config';
+
+function readStoredConfig(): LyricLayoutConfig {
+  if (typeof window === 'undefined') return DEFAULT_LYRIC_LAYOUT_CONFIG;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return DEFAULT_LYRIC_LAYOUT_CONFIG;
+    const parsed = JSON.parse(raw) as Partial<LyricLayoutConfig>;
+    return { ...DEFAULT_LYRIC_LAYOUT_CONFIG, ...parsed };
+  } catch {
+    return DEFAULT_LYRIC_LAYOUT_CONFIG;
+  }
+}
+
+export function useLyricLayoutConfig() {
+  const [config, setConfig] = useState<LyricLayoutConfig>(() => readStoredConfig());
+
+  useEffect(() => {
+    const onStorage = (event: StorageEvent) => {
+      if (event.key !== STORAGE_KEY) return;
+      setConfig(readStoredConfig());
+    };
+    window.addEventListener('storage', onStorage);
+    return () => window.removeEventListener('storage', onStorage);
+  }, []);
+
+  const updateConfig = useCallback((next: LyricLayoutConfig) => {
+    setConfig(next);
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+    } catch {
+      // ignore quota / serialization errors
+    }
+  }, []);
+
+  return { config, updateConfig };
+}

--- a/app/renderer/features/deck/lyric-slide-grouping.ts
+++ b/app/renderer/features/deck/lyric-slide-grouping.ts
@@ -1,0 +1,50 @@
+import { measureInlineTextHeight } from '../canvas/inline-text-editor-utils';
+import type { LyricLayoutConfig } from './lyric-layout-config';
+
+const SEGMENT_JOIN = '\n';
+
+export function joinSegments(segments: string[]): string {
+  return segments.join(SEGMENT_JOIN);
+}
+
+function fitsInBox(text: string, config: LyricLayoutConfig): boolean {
+  const measured = measureInlineTextHeight({
+    text,
+    width: config.boxWidth,
+    fontSize: config.fontSize,
+    lineHeight: config.lineHeight,
+    fontWeight: config.fontWeight,
+    fontStyle: 'normal',
+    fontFamily: config.fontFamily,
+  });
+  return measured <= config.boxHeight + 0.5;
+}
+
+function splitGroup(segments: string[], config: LyricLayoutConfig): string[][] {
+  if (segments.length <= 1) return [segments];
+  if (fitsInBox(joinSegments(segments), config)) return [segments];
+
+  const half = Math.ceil(segments.length / 2);
+  const left = segments.slice(0, half);
+  const right = segments.slice(half);
+  return [...splitGroup(left, config), ...splitGroup(right, config)];
+}
+
+export function groupSegmentsForSlides(segments: string[], config: LyricLayoutConfig): string[][] {
+  if (segments.length === 0) return [];
+  const target = Math.max(1, Math.floor(config.segmentsPerSlide));
+  const slides: string[][] = [];
+
+  for (let i = 0; i < segments.length; i += target) {
+    const chunk = segments.slice(i, i + target);
+    if (chunk.length === 1) {
+      slides.push(chunk);
+      continue;
+    }
+    for (const group of splitGroup(chunk, config)) {
+      slides.push(group);
+    }
+  }
+
+  return slides;
+}

--- a/app/renderer/features/deck/lyric-text-utils.ts
+++ b/app/renderer/features/deck/lyric-text-utils.ts
@@ -29,9 +29,15 @@ export function buildLyricTextElement(slideId: Id, text: string): ElementCreateI
 }
 
 export function parseLyricImportText(text: string): string[] {
-  return text
-    .replace(/\r\n/g, '\n')
-    .split(/\n\s*\n/g)
-    .map((block) => block.trim())
+  const normalized = text
+    .replace(/\r\n?/g, '\n')
+    .replace(/[\u2028\u2029]/g, '\n');
+
+  const hasBlankLineSeparator = /\n[ \t]*\n/.test(normalized);
+  const splitter = hasBlankLineSeparator ? /\n[ \t]*\n+/g : /\n+/g;
+
+  return normalized
+    .split(splitter)
+    .map((block) => block.replace(/^[ \t\n]+|[ \t\n]+$/g, ''))
     .filter((block) => block.length > 0);
 }

--- a/app/renderer/features/deck/slide-grid-tile.tsx
+++ b/app/renderer/features/deck/slide-grid-tile.tsx
@@ -54,7 +54,7 @@ function SlideGridTileBody({
   const isFirst = index === 0;
   const isLast = index === slides.length - 1;
   const activeRef = useScrollAreaActiveItem<HTMLDivElement>(selected);
-  const { ref: triggerRef, ...triggerHandlers } = useContextMenuTrigger();
+  const { ref: triggerRef, onContextMenu: triggerContextMenu, ...triggerHandlers } = useContextMenuTrigger();
 
   function handleClick() {
     onActivate(index);
@@ -62,6 +62,11 @@ function SlideGridTileBody({
 
   function handleDoubleClick() {
     onFocus(index);
+  }
+
+  function handleContextMenu(event: React.MouseEvent<HTMLElement>) {
+    if (!selected) onActivate(index);
+    triggerContextMenu(event);
   }
 
   async function handleDelete() {
@@ -87,6 +92,7 @@ function SlideGridTileBody({
         }}
         style={containerStyle}
         onClick={handleClick}
+        onContextMenu={handleContextMenu}
         onDoubleClick={handleDoubleClick}
         selected={selected}
         className={dragging ? 'cursor-grabbing opacity-70 shadow-lg' : 'cursor-grab'}

--- a/app/renderer/features/deck/slide-list-row.tsx
+++ b/app/renderer/features/deck/slide-list-row.tsx
@@ -68,7 +68,7 @@ function SlideOutlineRowBody({
   }
 
   const activeRef = useScrollAreaActiveItem<HTMLDivElement>(isFocused);
-  const { ref: triggerRef, ...triggerHandlers } = useContextMenuTrigger({ disabled: !slideOwned });
+  const { ref: triggerRef, onContextMenu: triggerContextMenu, ...triggerHandlers } = useContextMenuTrigger({ disabled: !slideOwned });
 
   const rowStateClass = isFocused
     ? 'border-brand-400/80 bg-brand-400/8'
@@ -76,6 +76,11 @@ function SlideOutlineRowBody({
 
   function handleSelect() {
     onSelect(row.index);
+  }
+
+  function handleContextMenu(event: React.MouseEvent<HTMLElement>) {
+    if (slideOwned && !isFocused) onSelect(row.index);
+    triggerContextMenu(event);
   }
 
   function handleOpen() {
@@ -116,6 +121,7 @@ function SlideOutlineRowBody({
         }}
         style={containerStyle}
         onClick={handleSelect}
+        onContextMenu={handleContextMenu}
         onDoubleClick={row.textEditable ? undefined : handleOpen}
         className={cn(rowStateClass, dragging ? 'cursor-grabbing opacity-70 shadow-lg' : 'cursor-grab')}
       >

--- a/app/renderer/features/deck/use-lyric-editor-document.tsx
+++ b/app/renderer/features/deck/use-lyric-editor-document.tsx
@@ -7,12 +7,20 @@ import { useProjectContent } from '../../contexts/use-project-content';
 import { useSlides } from '../../contexts/slide-context';
 import { slideTextDetails } from '../../utils/slides';
 import { buildLyricTextElement } from './lyric-text-utils';
+import { groupSegmentsForSlides, joinSegments } from './lyric-slide-grouping';
+import type { LyricLayoutConfig } from './lyric-layout-config';
 
 function findTextElement(elements: SlideElement[]): SlideElement | null {
   return elements.find((element) => element.type === 'text' && 'text' in element.payload) ?? null;
 }
 
-export function useLyricEditorSave({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) {
+interface UseLyricEditorSaveArgs {
+  isOpen: boolean;
+  onClose: () => void;
+  config: LyricLayoutConfig;
+}
+
+export function useLyricEditorSave({ isOpen, onClose, config }: UseLyricEditorSaveArgs) {
   const { currentDeckItem } = useNavigation();
   const { slides } = useSlides();
   const { slideElementsBySlideId } = useProjectContent();
@@ -27,36 +35,31 @@ export function useLyricEditorSave({ isOpen, onClose }: { isOpen: boolean; onClo
     }));
   }, [isOpen, currentDeckItem, slideElementsBySlideId, slides]);
 
-  const slideIds = useMemo(() => new Set(slides.map((s) => s.id)), [slides]);
-
-  const saveRowText = useCallback(async (slideId: Id, text: string, currentElements: SlideElement[]) => {
+  const writeSlideText = useCallback(async (slideId: Id, text: string, currentElements: SlideElement[]) => {
     const textElement = findTextElement(currentElements);
     if (textElement && 'text' in textElement.payload) {
       const currentText = String(textElement.payload.text ?? '');
-      if (currentText !== text) {
-        await mutatePatch(() => window.castApi.updateElement({
-          id: textElement.id,
-          payload: { ...textElement.payload, text },
-        }));
-      }
+      if (currentText === text) return;
+      await mutatePatch(() => window.castApi.updateElement({
+        id: textElement.id,
+        payload: { ...textElement.payload, text },
+      }));
       return;
     }
     await mutatePatch(() => window.castApi.createElement(buildLyricTextElement(slideId, text)));
   }, [mutatePatch]);
 
-  const createSlideForRow = useCallback(async (lyricId: Id, text: string) => {
+  const createSlideWithText = useCallback(async (lyricId: Id, text: string): Promise<Id> => {
     const snapshot = await mutatePatch(() => window.castApi.createSlide({ lyricId }));
     const nextSlide = snapshot.slides
       .filter((slide) => slide.lyricId === lyricId)
       .sort((left, right) => right.order - left.order)
       .at(0);
-
     if (!nextSlide) throw new Error('Unable to create lyric slide.');
-
     const nextSlideElements = snapshot.slideElements.filter((element) => element.slideId === nextSlide.id);
-    await saveRowText(nextSlide.id, text, nextSlideElements);
+    await writeSlideText(nextSlide.id, text, nextSlideElements);
     return nextSlide.id;
-  }, [mutatePatch, saveRowText]);
+  }, [mutatePatch, writeSlideText]);
 
   const saveBlocks = useCallback(async (blocks: Block[]) => {
     if (!currentDeckItem || currentDeckItem.type !== 'lyric') return;
@@ -65,24 +68,32 @@ export function useLyricEditorSave({ isOpen, onClose }: { isOpen: boolean; onClo
 
     try {
       await runOperation('Saving lyrics...', async () => {
-        const removedSlideIds = slides
-          .filter((slide) => !blocks.some((block) => block.id === slide.id))
-          .map((slide) => slide.id);
+        const segments = blocks
+          .map((block) => block.content.replace(/^[ \t\n]+|[ \t\n]+$/g, ''))
+          .filter((content) => content.length > 0);
 
-        for (const slideId of removedSlideIds) {
-          await mutatePatch(() => window.castApi.deleteSlide(slideId));
-        }
+        const slideGroups = groupSegmentsForSlides(segments, config);
+        const slideTexts = slideGroups.map((group) => joinSegments(group));
 
         const orderedSlideIds: Id[] = [];
+        const reusableSlideIds = slides.map((slide) => slide.id);
 
-        for (const block of blocks) {
-          if (slideIds.has(block.id)) {
-            await saveRowText(block.id, block.content, slideElementsBySlideId.get(block.id) ?? []);
-            orderedSlideIds.push(block.id);
+        for (let i = 0; i < slideTexts.length; i += 1) {
+          const text = slideTexts[i];
+          const reuseId = reusableSlideIds[i];
+          if (reuseId) {
+            const elements = slideElementsBySlideId.get(reuseId) ?? [];
+            await writeSlideText(reuseId, text, elements);
+            orderedSlideIds.push(reuseId);
           } else {
-            const createdSlideId = await createSlideForRow(currentDeckItem.id, block.content);
-            orderedSlideIds.push(createdSlideId);
+            const created = await createSlideWithText(currentDeckItem.id, text);
+            orderedSlideIds.push(created);
           }
+        }
+
+        const removedSlideIds = reusableSlideIds.slice(slideTexts.length);
+        for (const slideId of removedSlideIds) {
+          await mutatePatch(() => window.castApi.deleteSlide(slideId));
         }
 
         for (const [index, slideId] of orderedSlideIds.entries()) {
@@ -98,7 +109,7 @@ export function useLyricEditorSave({ isOpen, onClose }: { isOpen: boolean; onClo
     } finally {
       setIsSaving(false);
     }
-  }, [createSlideForRow, currentDeckItem, mutatePatch, onClose, runOperation, saveRowText, setStatusText, slideElementsBySlideId, slideIds, slides]);
+  }, [config, createSlideWithText, currentDeckItem, mutatePatch, onClose, runOperation, setStatusText, slideElementsBySlideId, slides, writeSlideText]);
 
   return { initialBlocks, saveBlocks, isSaving };
 }

--- a/app/renderer/features/deck/use-lyric-editor-document.tsx
+++ b/app/renderer/features/deck/use-lyric-editor-document.tsx
@@ -61,7 +61,7 @@ export function useLyricEditorSave({ isOpen, onClose, config }: UseLyricEditorSa
     return nextSlide.id;
   }, [mutatePatch, writeSlideText]);
 
-  const saveBlocks = useCallback(async (blocks: Block[]) => {
+  const saveBlocks = useCallback(async (blocks: Block[], options?: { skipGrouping?: boolean }) => {
     if (!currentDeckItem || currentDeckItem.type !== 'lyric') return;
 
     setIsSaving(true);
@@ -72,8 +72,9 @@ export function useLyricEditorSave({ isOpen, onClose, config }: UseLyricEditorSa
           .map((block) => block.content.replace(/^[ \t\n]+|[ \t\n]+$/g, ''))
           .filter((content) => content.length > 0);
 
-        const slideGroups = groupSegmentsForSlides(segments, config);
-        const slideTexts = slideGroups.map((group) => joinSegments(group));
+        const slideTexts = options?.skipGrouping
+          ? segments
+          : groupSegmentsForSlides(segments, config).map((group) => joinSegments(group));
 
         const orderedSlideIds: Id[] = [];
         const reusableSlideIds = slides.map((slide) => slide.id);

--- a/app/renderer/screens/overlay-editor/inspector-panel.tsx
+++ b/app/renderer/screens/overlay-editor/inspector-panel.tsx
@@ -22,9 +22,7 @@ export function OverlayEditorInspectorPanel() {
 
   useEffect(() => {
     if (!hasSelection) {
-      if (inspectorTab === 'shape' || inspectorTab === 'text' || inspectorTab === 'presentation' || inspectorTab === 'video' || inspectorTab === 'binding') {
-        setInspectorTab('slide');
-      }
+      if (inspectorTab !== 'slide') setInspectorTab('slide');
       return;
     }
 

--- a/app/renderer/screens/overlay-editor/page.tsx
+++ b/app/renderer/screens/overlay-editor/page.tsx
@@ -1,3 +1,4 @@
+import { type MouseEvent as ReactMouseEvent } from 'react';
 import { overlayToLayerElements } from '@core/presentation-layers';
 import { Plus } from 'lucide-react';
 import { LumaCastPanel } from '@renderer/components/layout/panel';
@@ -11,6 +12,9 @@ import { SplitPanel } from '@renderer/components/layout/panel-split/split-panel'
 import { Label } from '@renderer/components/display/text';
 import { EmptyState } from '@renderer/components/display/empty-state';
 import { ScrollArea, useScrollAreaActiveItem } from '@renderer/components/layout/scroll-area';
+import { ContextMenu, useContextMenuTrigger } from '@renderer/components/overlays/context-menu';
+import { useConfirm } from '@renderer/components/overlays/confirm-dialog';
+import { useOverlayEditor } from '@renderer/contexts/asset-editor/asset-editor-context';
 import { OverlayEditorInspectorPanel } from './inspector-panel';
 import { OverlayEditorLayersPanel } from './layers-panel';
 import { OverlayEditorScreenProvider, useOverlayEditorScreen } from './screen-context';
@@ -95,7 +99,19 @@ function OverlayEditorScreenContent() {
   );
 }
 
-function OverlayListItem({
+function OverlayListItem(props: {
+  overlay: ReturnType<typeof useOverlayEditorScreen>['state']['overlays'][number];
+  index: number;
+  isActive: boolean;
+}) {
+  return (
+    <ContextMenu.Root>
+      <OverlayListItemBody {...props} />
+    </ContextMenu.Root>
+  );
+}
+
+function OverlayListItemBody({
   overlay,
   index,
   isActive,
@@ -105,30 +121,63 @@ function OverlayListItem({
   isActive: boolean;
 }) {
   const { actions } = useOverlayEditorScreen();
+  const { duplicateOverlay, deleteOverlay, requestNameFocus } = useOverlayEditor();
+  const confirm = useConfirm();
   const scene = buildRenderScene(null, overlayToLayerElements(overlay));
+  const activeRef = useScrollAreaActiveItem<HTMLDivElement>(isActive);
+  const { ref: triggerRef, onContextMenu: triggerContextMenu, ...triggerHandlers } = useContextMenuTrigger();
 
   function handleSelect() {
     actions.selectOverlay(overlay.id);
   }
 
-  return (
-    <ActiveOverlayTile isActive={isActive} onClick={handleSelect} selected={isActive}>
-      <Thumbnail.Body>
-        <SceneFrame width={scene.width} height={scene.height} className="bg-tertiary" stageClassName="absolute inset-0" checkerboard>
-          <SceneStage scene={scene} surface="list" className="absolute inset-0 pointer-events-none" />
-        </SceneFrame>
-      </Thumbnail.Body>
-      <Thumbnail.Caption>
-        <div className="flex items-center gap-2">
-          <span className="shrink-0 text-sm font-semibold tabular-nums text-secondary">{index + 1}</span>
-          <span className="min-w-0 truncate text-sm text-tertiary">{overlay.name}</span>
-        </div>
-      </Thumbnail.Caption>
-    </ActiveOverlayTile>
-  );
-}
+  function handleContextMenu(event: ReactMouseEvent<HTMLElement>) {
+    if (!isActive) actions.selectOverlay(overlay.id);
+    triggerContextMenu(event);
+  }
 
-function ActiveOverlayTile({ isActive, ...props }: React.ComponentProps<typeof Thumbnail.Tile> & { isActive: boolean }) {
-  const ref = useScrollAreaActiveItem(isActive);
-  return <Thumbnail.Tile ref={ref} {...props} />;
+  async function handleDelete() {
+    const ok = await confirm({
+      title: `Delete "${overlay.name}"?`,
+      description: 'This overlay will be permanently removed.',
+      confirmLabel: 'Delete',
+      destructive: true,
+    });
+    if (ok) await deleteOverlay(overlay.id);
+  }
+
+  return (
+    <>
+      <Thumbnail.Tile
+        {...triggerHandlers}
+        ref={(node) => {
+          activeRef.current = node;
+          triggerRef(node);
+        }}
+        onContextMenu={handleContextMenu}
+        onClick={handleSelect}
+        selected={isActive}
+      >
+        <Thumbnail.Body>
+          <SceneFrame width={scene.width} height={scene.height} className="bg-tertiary" stageClassName="absolute inset-0" checkerboard>
+            <SceneStage scene={scene} surface="list" className="absolute inset-0 pointer-events-none" />
+          </SceneFrame>
+        </Thumbnail.Body>
+        <Thumbnail.Caption>
+          <div className="flex items-center gap-2">
+            <span className="shrink-0 text-sm font-semibold tabular-nums text-secondary">{index + 1}</span>
+            <span className="min-w-0 truncate text-sm text-tertiary">{overlay.name}</span>
+          </div>
+        </Thumbnail.Caption>
+      </Thumbnail.Tile>
+      <ContextMenu.Portal>
+        <ContextMenu.Menu>
+          <ContextMenu.Item onSelect={() => requestNameFocus(overlay.id)}>Rename</ContextMenu.Item>
+          <ContextMenu.Item onSelect={() => duplicateOverlay(overlay.id)}>Duplicate</ContextMenu.Item>
+          <ContextMenu.Separator />
+          <ContextMenu.Item variant="destructive" onSelect={() => { void handleDelete(); }}>Delete</ContextMenu.Item>
+        </ContextMenu.Menu>
+      </ContextMenu.Portal>
+    </>
+  );
 }

--- a/app/renderer/screens/stage-editor/inspector-panel.tsx
+++ b/app/renderer/screens/stage-editor/inspector-panel.tsx
@@ -22,12 +22,7 @@ export function StageEditorInspectorPanel() {
 
   useEffect(() => {
     if (!hasSelection) {
-      // Mirror the theme-editor pattern: when nothing is selected, fall
-      // back to the stage-level tab (rename + meta) so the panel always has
-      // something useful instead of an empty state.
-      if (inspectorTab === 'shape' || inspectorTab === 'text' || inspectorTab === 'binding' || inspectorTab === 'slide' || inspectorTab === 'presentation' || inspectorTab === 'theme' || inspectorTab === 'video') {
-        setInspectorTab('stage');
-      }
+      if (inspectorTab !== 'stage') setInspectorTab('stage');
       return;
     }
     if (isTextSelected) {

--- a/app/renderer/screens/stage-editor/page.tsx
+++ b/app/renderer/screens/stage-editor/page.tsx
@@ -1,3 +1,4 @@
+import { type MouseEvent as ReactMouseEvent } from 'react';
 import { Plus } from 'lucide-react';
 import { LumaCastPanel } from '@renderer/components/layout/panel';
 import { Thumbnail } from '../../components/display/thumbnail';
@@ -10,6 +11,9 @@ import { SplitPanel } from '@renderer/components/layout/panel-split/split-panel'
 import { Label } from '@renderer/components/display/text';
 import { EmptyState } from '@renderer/components/display/empty-state';
 import { ScrollArea, useScrollAreaActiveItem } from '@renderer/components/layout/scroll-area';
+import { ContextMenu, useContextMenuTrigger } from '@renderer/components/overlays/context-menu';
+import { useConfirm } from '@renderer/components/overlays/confirm-dialog';
+import { useStageEditor } from '@renderer/contexts/asset-editor/asset-editor-context';
 import { StageEditorInspectorPanel } from './inspector-panel';
 import { StageEditorLayersPanel } from './layers-panel';
 import { StageEditorScreenProvider, useStageEditorScreen } from './screen-context';
@@ -94,7 +98,19 @@ function StageEditorScreenContent() {
   );
 }
 
-function StageListItem({
+function StageListItem(props: {
+  stage: ReturnType<typeof useStageEditorScreen>['state']['stages'][number];
+  index: number;
+  isActive: boolean;
+}) {
+  return (
+    <ContextMenu.Root>
+      <StageListItemBody {...props} />
+    </ContextMenu.Root>
+  );
+}
+
+function StageListItemBody({
   stage,
   index,
   isActive,
@@ -104,30 +120,63 @@ function StageListItem({
   isActive: boolean;
 }) {
   const { actions } = useStageEditorScreen();
+  const { duplicateStage, deleteStage, requestNameFocus } = useStageEditor();
+  const confirm = useConfirm();
   const scene = buildRenderScene(null, stage.elements);
+  const activeRef = useScrollAreaActiveItem<HTMLDivElement>(isActive);
+  const { ref: triggerRef, onContextMenu: triggerContextMenu, ...triggerHandlers } = useContextMenuTrigger();
 
   function handleSelect() {
     actions.selectStage(stage.id);
   }
 
-  return (
-    <ActiveStageTile isActive={isActive} onClick={handleSelect} selected={isActive}>
-      <Thumbnail.Body>
-        <SceneFrame width={scene.width} height={scene.height} className="bg-tertiary" stageClassName="absolute inset-0" checkerboard>
-          <SceneStage scene={scene} surface="list" className="absolute inset-0 pointer-events-none" />
-        </SceneFrame>
-      </Thumbnail.Body>
-      <Thumbnail.Caption>
-        <div className="flex items-center gap-2">
-          <span className="shrink-0 text-sm font-semibold tabular-nums text-secondary">{index + 1}</span>
-          <span className="min-w-0 truncate text-sm text-tertiary">{stage.name}</span>
-        </div>
-      </Thumbnail.Caption>
-    </ActiveStageTile>
-  );
-}
+  function handleContextMenu(event: ReactMouseEvent<HTMLElement>) {
+    if (!isActive) actions.selectStage(stage.id);
+    triggerContextMenu(event);
+  }
 
-function ActiveStageTile({ isActive, ...props }: React.ComponentProps<typeof Thumbnail.Tile> & { isActive: boolean }) {
-  const ref = useScrollAreaActiveItem(isActive);
-  return <Thumbnail.Tile ref={ref} {...props} />;
+  async function handleDelete() {
+    const ok = await confirm({
+      title: `Delete "${stage.name}"?`,
+      description: 'This stage will be permanently removed.',
+      confirmLabel: 'Delete',
+      destructive: true,
+    });
+    if (ok) await deleteStage(stage.id);
+  }
+
+  return (
+    <>
+      <Thumbnail.Tile
+        {...triggerHandlers}
+        ref={(node) => {
+          activeRef.current = node;
+          triggerRef(node);
+        }}
+        onContextMenu={handleContextMenu}
+        onClick={handleSelect}
+        selected={isActive}
+      >
+        <Thumbnail.Body>
+          <SceneFrame width={scene.width} height={scene.height} className="bg-tertiary" stageClassName="absolute inset-0" checkerboard>
+            <SceneStage scene={scene} surface="list" className="absolute inset-0 pointer-events-none" />
+          </SceneFrame>
+        </Thumbnail.Body>
+        <Thumbnail.Caption>
+          <div className="flex items-center gap-2">
+            <span className="shrink-0 text-sm font-semibold tabular-nums text-secondary">{index + 1}</span>
+            <span className="min-w-0 truncate text-sm text-tertiary">{stage.name}</span>
+          </div>
+        </Thumbnail.Caption>
+      </Thumbnail.Tile>
+      <ContextMenu.Portal>
+        <ContextMenu.Menu>
+          <ContextMenu.Item onSelect={() => requestNameFocus(stage.id)}>Rename</ContextMenu.Item>
+          <ContextMenu.Item onSelect={() => duplicateStage(stage.id)}>Duplicate</ContextMenu.Item>
+          <ContextMenu.Separator />
+          <ContextMenu.Item variant="destructive" onSelect={() => { void handleDelete(); }}>Delete</ContextMenu.Item>
+        </ContextMenu.Menu>
+      </ContextMenu.Portal>
+    </>
+  );
 }

--- a/app/renderer/screens/theme-editor/inspector-panel.tsx
+++ b/app/renderer/screens/theme-editor/inspector-panel.tsx
@@ -21,9 +21,10 @@ export function ThemeEditorInspectorPanel() {
 
   useEffect(() => {
     if (!hasSelection) {
-      if (inspectorTab === 'shape' || inspectorTab === 'text' || inspectorTab === 'slide' || inspectorTab === 'presentation' || inspectorTab === 'video') {
-        setInspectorTab('theme');
-      }
+      // No selection → only the theme tab is rendered; force it so we don't
+      // strand on a foreign editor's tab (e.g. 'stage' or 'slide') leaving
+      // the panel blank when navigating between editors.
+      if (inspectorTab !== 'theme') setInspectorTab('theme');
       return;
     }
 

--- a/app/renderer/screens/theme-editor/page.tsx
+++ b/app/renderer/screens/theme-editor/page.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, type MouseEvent as ReactMouseEvent } from 'react';
 import type { Theme } from '@core/types';
 import { Layers, Music, Plus, Presentation } from 'lucide-react';
 import { LazySceneStage } from '@renderer/components/display/lazy-scene-stage';
@@ -12,6 +12,9 @@ import { SplitPanel } from '@renderer/components/layout/panel-split/split-panel'
 import { EmptyState } from '@renderer/components/display/empty-state';
 import { Label } from '@renderer/components/display/text';
 import { ScrollArea, useScrollAreaActiveItem } from '@renderer/components/layout/scroll-area';
+import { ContextMenu, useContextMenuTrigger } from '@renderer/components/overlays/context-menu';
+import { useConfirm } from '@renderer/components/overlays/confirm-dialog';
+import { useThemeEditor } from '@renderer/contexts/asset-editor/asset-editor-context';
 import { ThemeEditorInspectorPanel } from './inspector-panel';
 import { ThemeEditorLayersPanel } from './layers-panel';
 import { ThemeEditorScreenProvider, useThemeEditorScreen } from './screen-context';
@@ -99,7 +102,19 @@ function ThemeEditorScreenContent() {
   );
 }
 
-function ThemeListItem({
+function ThemeListItem(props: {
+  theme: ReturnType<typeof useThemeEditorScreen>['state']['themes'][number];
+  index: number;
+  isActive: boolean;
+}) {
+  return (
+    <ContextMenu.Root>
+      <ThemeListItemBody {...props} />
+    </ContextMenu.Root>
+  );
+}
+
+function ThemeListItemBody({
   theme,
   index,
   isActive,
@@ -109,7 +124,11 @@ function ThemeListItem({
   isActive: boolean;
 }) {
   const { actions } = useThemeEditorScreen();
+  const { duplicateTheme, deleteTheme, requestNameFocus } = useThemeEditor();
+  const confirm = useConfirm();
   const scene = useMemo(() => buildRenderScene(null, theme.elements), [theme.elements]);
+  const activeRef = useScrollAreaActiveItem<HTMLDivElement>(isActive);
+  const { ref: triggerRef, onContextMenu: triggerContextMenu, ...triggerHandlers } = useContextMenuTrigger();
 
   function handleSelect() {
     actions.selectTheme(theme.id);
@@ -120,27 +139,56 @@ function ThemeListItem({
     actions.requestThemeNameFocus(theme.id);
   }
 
-  return (
-    <ActiveThemeTile isActive={isActive} onClick={handleSelect} selected={isActive}>
-      <Thumbnail.Body>
-        <SceneFrame width={scene.width} height={scene.height} className="bg-tertiary" stageClassName="absolute inset-0" checkerboard>
-          <LazySceneStage scene={scene} surface="list" className="absolute inset-0" />
-        </SceneFrame>
-      </Thumbnail.Body>
-      <Thumbnail.Caption>
-        <div className="flex items-center gap-2" onDoubleClick={handleCaptionDoubleClick}>
-          <span className="shrink-0 text-sm font-semibold tabular-nums text-secondary">{index + 1}</span>
-          <ThemeKindIcon kind={theme.kind} />
-          <span className="min-w-0 truncate text-sm text-tertiary">{theme.name}</span>
-        </div>
-      </Thumbnail.Caption>
-    </ActiveThemeTile>
-  );
-}
+  function handleContextMenu(event: ReactMouseEvent<HTMLElement>) {
+    if (!isActive) actions.selectTheme(theme.id);
+    triggerContextMenu(event);
+  }
 
-function ActiveThemeTile({ isActive, ...props }: React.ComponentProps<typeof Thumbnail.Tile> & { isActive: boolean }) {
-  const ref = useScrollAreaActiveItem(isActive);
-  return <Thumbnail.Tile ref={ref} {...props} />;
+  async function handleDelete() {
+    const ok = await confirm({
+      title: `Delete "${theme.name}"?`,
+      description: 'This theme will be permanently removed.',
+      confirmLabel: 'Delete',
+      destructive: true,
+    });
+    if (ok) deleteTheme(theme.id);
+  }
+
+  return (
+    <>
+      <Thumbnail.Tile
+        {...triggerHandlers}
+        ref={(node) => {
+          activeRef.current = node;
+          triggerRef(node);
+        }}
+        onContextMenu={handleContextMenu}
+        onClick={handleSelect}
+        selected={isActive}
+      >
+        <Thumbnail.Body>
+          <SceneFrame width={scene.width} height={scene.height} className="bg-tertiary" stageClassName="absolute inset-0" checkerboard>
+            <LazySceneStage scene={scene} surface="list" className="absolute inset-0" />
+          </SceneFrame>
+        </Thumbnail.Body>
+        <Thumbnail.Caption>
+          <div className="flex items-center gap-2" onDoubleClick={handleCaptionDoubleClick}>
+            <span className="shrink-0 text-sm font-semibold tabular-nums text-secondary">{index + 1}</span>
+            <ThemeKindIcon kind={theme.kind} />
+            <span className="min-w-0 truncate text-sm text-tertiary">{theme.name}</span>
+          </div>
+        </Thumbnail.Caption>
+      </Thumbnail.Tile>
+      <ContextMenu.Portal>
+        <ContextMenu.Menu>
+          <ContextMenu.Item onSelect={() => requestNameFocus(theme.id)}>Rename</ContextMenu.Item>
+          <ContextMenu.Item onSelect={() => duplicateTheme(theme.id)}>Duplicate</ContextMenu.Item>
+          <ContextMenu.Separator />
+          <ContextMenu.Item variant="destructive" onSelect={() => { void handleDelete(); }}>Delete</ContextMenu.Item>
+        </ContextMenu.Menu>
+      </ContextMenu.Portal>
+    </>
+  );
 }
 
 function ThemeKindIcon({ kind }: { kind: Theme['kind'] }) {

--- a/docs/actions-system-for-multi-step-triggers.md
+++ b/docs/actions-system-for-multi-step-triggers.md
@@ -1,0 +1,299 @@
+# Actions System for Multi-Step Triggers (#48)
+
+Branch: `feat/actions`
+
+## Context
+
+Recast has separate, isolated action-like pathways: slide take, overlay activation, media/video layer controls, audio transport, stage selection, NDI output toggles, app menu commands, command palette, and keyboard shortcuts. Each is wired one-to-one — a hotkey runs one handler; a slide click takes one slide. There's no way for an operator to say "when I take this slide, also start a video and bring up an overlay 500ms later."
+
+ProPresenter solves this with **Actions** (per-slide side-effects) and **Macros** (reusable bundles). Notably, ProPresenter only fires actions in *parallel* — sequential timing is delegated to its Timeline, and operators routinely complain about it. Issue #48 explicitly asks for both parallel **and** sequential with delays, e.g. "show overlay, wait, start video, then clear overlay."
+
+Deliverables on this branch:
+1. A markdown design doc committed at [docs/actions-proposal.md](docs/actions-proposal.md) — a trimmed version of this plan, reviewable independently.
+2. A minimal MVP slice that proves the data + runtime model end-to-end: schema v13 tables, IPC, dispatcher, step adapters for the highest-leverage subset, an Actions Library panel, and one trigger source (`slide.take`).
+
+## High-Level Approach
+
+Three layers, mirroring the existing app:
+
+1. **Action definitions** — reusable, named, persisted in their own SQLite tables. Closer to ProPresenter Macros than to per-slide attached actions: the same action ("Worship Open") can be bound to many triggers without duplication.
+2. **Trigger bindings** — a separate table mapping `(sourceType, sourceId)` → `actionId`. Many bindings can fire the same action; one source can have multiple bindings.
+3. **Runtime dispatcher** — a renderer-side context (`ActionsProvider`) mounted under `PlaybackProvider` so it can consume `usePlayback`, `useSlides`, `useNavigation`, `useStagePlayback`, NDI controls. Wraps existing handles as **step adapters**. No new command bus, no IPC refactor.
+
+A step adapter is a typed `(payload, ctx) => Promise<void>`. Adding a new step kind = add an entry to `step-adapters.ts`. Pure dispatch.
+
+## ActionStepKind — Full Catalog
+
+The full catalog is the *design intent* — the full set of action kinds Recast aims to support, mapped 1:1 against the existing capability surface and against ProPresenter's catalog (so we don't quietly miss something an operator coming from PP would expect).
+
+`✓` = ships in MVP catalog (adapter implemented in this branch).
+`◐` = type-only in MVP (declared in `ActionStepKind`, payload schema defined, adapter throws "not yet implemented" — keeps schema stable so we don't have to bump it again to add the adapter).
+`○` = deferred entirely (out of catalog until the underlying Recast capability exists). Listed in proposal doc with rationale; **not** in the v13 type union.
+
+| Kind | Status | Payload | Recast handle (file:symbol) | ProPresenter analog |
+|---|---|---|---|---|
+| **Slides / deck navigation** |
+| `slide.take` | ✓ | `{ slideId: Id }` | [app/renderer/contexts/playback/playback-context.tsx](app/renderer/contexts/playback/playback-context.tsx) `takeSlide` (via `useSlides`) | #18 Slide Destination fire |
+| `slide.activate` | ✓ | `{ slideId: Id }` | `useSlides().activateSlide` | (precue / arm) |
+| `slide.next` | ✓ | `{}` | `useSlides().goNext` | #70 Trigger Next Slide |
+| `slide.previous` | ✓ | `{}` | `useSlides().goPrev` | #71 Trigger Previous Slide |
+| `deck.armDeckItem` | ◐ | `{ deckItemId: Id }` | [app/renderer/contexts/navigation-context.tsx](app/renderer/contexts/navigation-context.tsx) `armOutputDeckItem` | #75 Go To Specific Presentation |
+| `deck.armPlaylistEntry` | ◐ | `{ playlistEntryId: Id }` | navigation `armOutputPlaylistEntry` | #76 Go To Playlist Item |
+| `deck.selectLibrary` | ◐ | `{ libraryId: Id }` | navigation `selectLibrary` | #77 Go To Library Item |
+| `deck.clearOutput` | ✓ | `{}` | navigation `clearOutputDeckItem` | (clear current) |
+| **Overlays** (Recast-specific; closest to PP Messages/Props) |
+| `overlay.activate` | ✓ | `{ overlayId: Id }` | `usePresentationOverlayLayer().activateOverlay` | #29 Show Message / #32 Show Prop |
+| `overlay.clear` | ✓ | `{ overlayId: Id }` | `clearOverlay` | #30 Hide Message / #33 Hide Prop |
+| `overlay.clearAll` | ✓ | `{}` | `clearAllOverlays` | #5/#6 Clear Messages / Props |
+| `overlay.setMode` | ✓ | `{ mode: 'single' \| 'multiple' }` | `setOverlayMode` | (n/a — Recast feature) |
+| **Presentation layers** |
+| `mediaLayer.set` | ✓ | `{ assetId: Id }` | `usePresentationMediaLayer().setMediaLayerAsset` (auto-routes image/video) | #34 Trigger Media |
+| `layer.clear` | ✓ | `{ layer: 'media' \| 'video' \| 'content' \| 'overlay' }` | `usePresentationLayers().clearLayer` | #2/#3/#5–#11 Clear * |
+| `layer.clearAll` | ✓ | `{}` | `clearAllLayers` | #1 Clear All |
+| `layer.showContent` | ◐ | `{}` | `showContentLayer` | (re-show after clear) |
+| **Video transport** (layer video) |
+| `video.arm` | ✓ | `{ assetId: Id }` | `useVideo().armVideo` | #34 Trigger Media (video) |
+| `video.clear` | ✓ | `{}` | `clearVideo` | #10 Clear Video Input |
+| `video.play` | ◐ | `{}` | `play` | #43 Play |
+| `video.pause` | ◐ | `{}` | `pause` | #43 Pause |
+| `video.togglePlayback` | ◐ | `{}` | `togglePlayback` | (toggle) |
+| `video.next` | ◐ | `{}` | `playNext` | #35 Trigger Next Media |
+| `video.previous` | ◐ | `{}` | `playPrevious` | #36 Trigger Previous Media |
+| `video.seekTo` | ◐ | `{ seconds: number }` | `seekTo` | (seek) |
+| `video.toggleLoop` | ◐ | `{}` | `toggleLoop` | (loop toggle) |
+| `video.toggleMuted` | ◐ | `{}` | `toggleMuted` | (mute toggle) |
+| **Audio** |
+| `audio.arm` | ✓ | `{ assetId: Id }` | `useAudio().armAudio` | #39 Trigger Audio |
+| `audio.select` | ◐ | `{ assetId: Id }` | `selectAudio` | #38/#44 Select Playlist |
+| `audio.clear` | ✓ | `{}` | `clearAudio` | #7 Clear Audio |
+| `audio.play` | ◐ | `{}` | `play` | #43 Audio Play |
+| `audio.pause` | ◐ | `{}` | `pause` | #43 Audio Pause |
+| `audio.togglePlayback` | ✓ | `{}` | `togglePlayback` | #43 Audio Play/Pause |
+| `audio.next` | ◐ | `{}` | `playNext` | #40 Next Audio |
+| `audio.previous` | ◐ | `{}` | `playPrevious` | #41 Previous Audio |
+| `audio.seekTo` | ◐ | `{ seconds: number }` | `seekTo` | (seek) |
+| `audio.toggleLoop` | ◐ | `{}` | `toggleLoop` | (loop toggle) |
+| `audio.toggleMuted` | ◐ | `{}` | `toggleMuted` | (mute toggle) |
+| **Stage** |
+| `stage.set` | ✓ | `{ stageId: Id }` | `useStagePlayback().setCurrentStageId` | #15 Select Stage Layout |
+| `stage.clear` | ✓ | `{}` | `setCurrentStageId(null)` | (clear stage) |
+| **Output / NDI** |
+| `output.setEnabled` | ◐ | `{ name: 'audience' \| 'stage', enabled: boolean }` | [app/main/ndi/ndi-service.ts](app/main/ndi/ndi-service.ts) `setNdiOutputEnabled` (via IPC) | #84/#85 Toggle Output |
+| `output.toggleAudience` | ◐ | `{}` | app-store `toggleAudienceOutput` | #84 Toggle Audience |
+| `output.toggleStage` | ◐ | `{}` | app-store `toggleStageOutput` | #85 Toggle Stage |
+| **Control flow** |
+| `flow.wait` | ✓ | `{ ms: number }` | (built-in: `setTimeout`) | (n/a — PP has no native delays) |
+| `flow.runAction` | ◐ | `{ actionId: Id }` | recursive into dispatcher (with cycle detection) | #69 Run Macro |
+
+### Deferred kinds (NOT in `ActionStepKind` union — require new Recast features)
+
+Documented in the proposal doc with rationale, so future contributors know why a PP user might expect these:
+
+- **Timer** (start/stop/reset/set/runTo/start-all/stop-all/reset-all) — Recast has no Timer feature. Tracked as a separate prerequisite.
+- **Message with editable tokens** (#29, #31) — Recast overlays don't yet support live token substitution.
+- **Prop (auto-clear semantics)** (#32, #33) — Recast overlays partially cover this; differentiate later.
+- **Audience Look** (#14) — no Look concept in Recast yet.
+- **Slide Destination** audience/stage/both (#18–#20) — Recast routes via NDI outputs, model differs; revisit.
+- **Capture / Recording** (#80, #81) — no recording feature.
+- **Bible verse / Announcement** (#88, #89) — no Bibles module.
+- **Apply Theme to slide at runtime** (#82, #83) — themes are edit-time only.
+- **Communication / Device actions**: MIDI Note On/Off/PC/CC, OSC, RossTalk (FTB/Key Cut/Trans/GPI/Custom Control), DMX, AMP, CITP, GlobalCache, GVG-100, Sony BVS/BVW, VDCP, PTZ presets, Network Link (#48–#68) — Recast has no outbound-device stack. Tracked as the `feat/devices` epic. The action runtime is designed so a `device.<protocol>` step kind plugs in by registering an adapter, with **no schema or runtime change** required when devices land.
+- **Freeze / Blackout per output** (#86, #87) — no per-output freeze. Cheap to add later as a black-fill source.
+- **Telestrator** (#11) — none.
+- **Custom Clear Group** (#13) — replaced by composing `layer.clear` / `overlay.clear` steps inside an Action. The Action *is* the user-defined clear group.
+
+### Out of scope (intentionally — never operator-fired)
+
+App-mode switches (`view.mode.show`, `view.mode.deckEditor`, etc.), slide/overlay/theme editing CRUD, element-level transforms.
+
+## Data Model
+
+New tables, schema v13 (current `LATEST_SCHEMA_VERSION` = 12 in [app/database/store.ts:86](app/database/store.ts#L86)):
+
+```sql
+CREATE TABLE actions (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  description TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+CREATE TABLE action_steps (
+  id TEXT PRIMARY KEY,
+  action_id TEXT NOT NULL REFERENCES actions(id) ON DELETE CASCADE,
+  kind TEXT NOT NULL,                  -- ActionStepKind
+  payload TEXT NOT NULL,               -- JSON, validated at runtime
+  group_id INTEGER NOT NULL,           -- steps with same group_id fire in parallel
+  order_index INTEGER NOT NULL,        -- group execution order ascending
+  failure_policy TEXT NOT NULL DEFAULT 'continue'  -- 'continue' | 'abort'
+);
+CREATE INDEX idx_action_steps_action ON action_steps(action_id, order_index);
+
+CREATE TABLE trigger_bindings (
+  id TEXT PRIMARY KEY,
+  action_id TEXT NOT NULL REFERENCES actions(id) ON DELETE CASCADE,
+  source_type TEXT NOT NULL,           -- TriggerSourceType
+  source_id TEXT,                      -- nullable (e.g. shortcut bindings)
+  accelerator TEXT,                    -- JSON ShortcutAccelerator | null
+  enabled INTEGER NOT NULL DEFAULT 1
+);
+CREATE INDEX idx_trigger_bindings_lookup ON trigger_bindings(source_type, source_id, enabled);
+```
+
+```ts
+// app/core/types.ts — additions
+
+export type ActionStepKind =
+  // (full union — see catalog table above; all ✓ and ◐ rows)
+  | 'slide.take' | 'slide.activate' | 'slide.next' | 'slide.previous'
+  | 'deck.armDeckItem' | 'deck.armPlaylistEntry' | 'deck.selectLibrary' | 'deck.clearOutput'
+  | 'overlay.activate' | 'overlay.clear' | 'overlay.clearAll' | 'overlay.setMode'
+  | 'mediaLayer.set' | 'layer.clear' | 'layer.clearAll' | 'layer.showContent'
+  | 'video.arm' | 'video.clear' | 'video.play' | 'video.pause' | 'video.togglePlayback'
+  | 'video.next' | 'video.previous' | 'video.seekTo' | 'video.toggleLoop' | 'video.toggleMuted'
+  | 'audio.arm' | 'audio.select' | 'audio.clear' | 'audio.play' | 'audio.pause' | 'audio.togglePlayback'
+  | 'audio.next' | 'audio.previous' | 'audio.seekTo' | 'audio.toggleLoop' | 'audio.toggleMuted'
+  | 'stage.set' | 'stage.clear'
+  | 'output.setEnabled' | 'output.toggleAudience' | 'output.toggleStage'
+  | 'flow.wait' | 'flow.runAction';
+
+// Per-kind payload typing via discriminated union — strict, no `Record<string, unknown>`.
+// Keeps adapters fully type-safe; saves the "JSON parsed but typed weakly" trap.
+export type ActionStep =
+  | { id: Id; kind: 'slide.take'; payload: { slideId: Id }; groupId: number; order: number; failurePolicy: 'continue' | 'abort' }
+  | { id: Id; kind: 'slide.next'; payload: Record<string, never>; groupId: number; order: number; failurePolicy: 'continue' | 'abort' }
+  | { id: Id; kind: 'flow.wait'; payload: { ms: number }; groupId: number; order: number; failurePolicy: 'continue' | 'abort' }
+  // …one variant per kind. Generated, not hand-written, via a `StepPayloadByKind` helper.
+  ;
+
+export interface Action {
+  id: Id;
+  name: string;
+  description?: string;
+  steps: ActionStep[];
+  createdAt: number;
+  updatedAt: number;
+}
+
+export type TriggerSourceType =
+  | 'slide.take'        // when the operator takes this slide
+  | 'slide.activate'    // when the operator selects/arms this slide
+  | 'media.play'        // when this media asset is played as a layer
+  | 'shortcut'          // bound hotkey
+  | 'commandPalette'    // surfaced as a palette command
+  | 'menu';             // app menu entry
+
+export interface TriggerBinding {
+  id: Id;
+  actionId: Id;
+  sourceType: TriggerSourceType;
+  sourceId: string | null;
+  accelerator?: ShortcutAccelerator;
+  enabled: boolean;
+}
+```
+
+## Runtime Semantics (precise)
+
+`ActionsProvider` exposes:
+
+```ts
+runAction(actionId: Id, ctx?: { source?: TriggerBinding; depth?: number }): Promise<void>
+fireTrigger(sourceType: TriggerSourceType, sourceId: string | null): void
+```
+
+Execution algorithm:
+
+1. Load `Action` (steps already sorted by `(groupId, order)` by the repo).
+2. Partition steps into **groups** keyed by `groupId`. Sort groups by min `order` of their members.
+3. For each group in order:
+   a. Dispatch every step in the group in parallel: `Promise.allSettled(group.map(step => adapters[step.kind](step.payload, runCtx)))`.
+   b. If any step rejected and its `failurePolicy === 'abort'`, abort the whole action; remaining groups don't run. Otherwise log and continue.
+4. `flow.wait` resolves after `setTimeout(payload.ms)`.
+5. `flow.runAction` recurses into `runAction(payload.actionId, { depth: depth + 1 })`. **Cycle detection**: maintain a per-dispatcher-tick `Set<Id>` of action ids currently on the stack. If the recursion would re-enter an id already in the set, log `recordObsEvent('action', 'Cycle detected', …)` and abort that branch only (return resolved). Hard cap `depth ≤ 8`.
+6. Re-firing the same top-level action while a previous instance is still running starts a new instance (no queueing). Documented; revisit if it bites in practice.
+7. Renderer reload kills in-flight `wait` steps. Acceptable; documented.
+8. Every step start/finish/failure logs to `recordObsEvent('action', …)` from [app/renderer/features/observability/metrics-store.ts](app/renderer/features/observability/metrics-store.ts) — no new observability surface needed.
+
+Step adapters live in **one file**: `app/renderer/features/actions/step-adapters.ts`. Each adapter is a closure built from the relevant context handles, returning `Promise<void>`. The provider builds the adapter map once via `useMemo` keyed on the underlying handles.
+
+## Trigger Wiring
+
+- **`slide.take`**: Wherever `takeSlide` is dispatched (start with the single canonical handler — find via `useSlides` definition), append `actionsCtx.fireTrigger('slide.take', slideId)` after the existing logic. One line; no-op when no bindings exist.
+- **`shortcut`**: In [app/renderer/hooks/use-keyboard-shortcuts.ts](app/renderer/hooks/use-keyboard-shortcuts.ts), after the existing `matchesShortcut()` match-and-dispatch, also iterate `trigger_bindings` where `sourceType='shortcut'` and matching accelerator. (MVP: stub — full wiring lands in slice 2.)
+- **`commandPalette`**: Extend the command source list in [app/renderer/features/command-palette/command-palette.tsx](app/renderer/features/command-palette/command-palette.tsx) with one entry per action whose has-or-could-have palette binding. (MVP: stub.)
+- **`media.play` / `menu`**: Stubbed in v1.
+
+## UI (MVP)
+
+One new panel: **Actions Library**, reachable from the app toolbar like the observability panel. Inspector pattern from [app/renderer/features/inspector/](app/renderer/features/inspector/) — `FieldInput`/`FieldSelect`, draft-state + blur-commit.
+
+- Left list: actions with name + step count.
+- Right pane:
+  - Name + description (draft + blur-commit).
+  - **Step list grouped visually**: each `groupId` is a horizontal "rail" (steps stacked vertically inside the rail = parallel; rails stack top-to-bottom = sequential). Up/down chevrons move a step to a different rail or reorder rails. No drag-and-drop in MVP.
+  - Per-step: kind picker (one `<select>` listing all ✓ kinds; ◐ kinds appear disabled with "(coming soon)") + payload form rendered per kind via a small `<StepPayloadEditor>` switch component.
+  - Failure-policy toggle per step (default `continue`).
+  - Add/remove/duplicate step buttons.
+- **Bindings tab** on each action: table of `trigger_bindings`. Add binding picks `sourceType` (MVP: `slide.take` only; others disabled with tooltip), then a slide picker (reuses existing slide-picker affordance from inspector). Remove binding via row delete.
+
+No per-slide inspector affordance in v1 — operators bind by editing the action.
+
+## MVP Slice (ships in this branch)
+
+1. Schema v13 migration + repo CRUD on `CastRepository` in [app/database/store.ts](app/database/store.ts): `listActions`, `getAction`, `createAction`, `updateAction`, `deleteAction`, `listTriggerBindings(forSourceType?, forSourceId?)`, `createTriggerBinding`, `deleteTriggerBinding`. Mirror existing slide/overlay repo shape.
+2. IPC: extend `MainApi` in [app/core/ipc.ts](app/core/ipc.ts) and handlers in [app/main/ipc.ts](app/main/ipc.ts) — one method per repo method above.
+3. Renderer types in [app/core/types.ts](app/core/types.ts): full `ActionStepKind` union (all ✓ and ◐), discriminated `ActionStep`, `Action`, `TriggerSourceType`, `TriggerBinding`.
+4. New: `app/renderer/features/actions/`:
+   - `actions-context.tsx` — provider with `runAction`, `fireTrigger`, `useActions()`.
+   - `step-adapters.ts` — adapters for all ✓ kinds; ◐ kinds throw `new Error('Step kind not yet implemented')` so they're declared but not silently no-op.
+   - `step-payload-editor.tsx` — switch component rendering payload form per kind.
+   - `actions-library.tsx` — the panel.
+   - `actions-store.ts` — action-list snapshot, integrated into the existing app-store mutation queue ([app/renderer/contexts/app-store.ts](app/renderer/contexts/app-store.ts)) so edits get undo/redo for free.
+5. Mount `ActionsProvider` in [app/renderer/App.tsx](app/renderer/App.tsx) under `PlaybackProvider`.
+6. Wire `slide.take` trigger emission at the canonical `takeSlide` callsite.
+7. Toolbar entry in [app/renderer/features/workbench/app-toolbar.tsx](app/renderer/features/workbench/app-toolbar.tsx) opening the panel.
+8. One demo action committed as a fixture: "Worship Open" — group 1: `overlay.activate(<some lower-third>)`; group 2: `flow.wait(500)`; group 3: `video.arm(<intro>)`. Bound to a sample slide via `slide.take`. Proves parallel-within-group, sequential-across-groups, and delay.
+9. Companion design doc at [docs/actions-proposal.md](docs/actions-proposal.md) — trimmed version of this plan including the full catalog table, deferred kinds, and rationale.
+
+**Out of scope for the MVP slice** (declared types only, adapters not implemented — i.e. the ◐ rows): all `deck.*`, `slide.activate`, `layer.showContent`, full video transport beyond `arm`/`clear`, full audio transport beyond `arm`/`clear`/`togglePlayback`, all `output.*`, `flow.runAction`, audio.select. Triggers other than `slide.take`. Per-slide inspector affordance. Drag-reorder. Conditional logic.
+
+## Critical Files
+
+- New: [app/renderer/features/actions/](app/renderer/features/actions/) — provider, adapters, library UI, payload editor, store.
+- New: [docs/actions-proposal.md](docs/actions-proposal.md) — proposal doc.
+- Modify: [app/database/store.ts](app/database/store.ts) — schema v13 migration + repo CRUD.
+- Modify: [app/core/types.ts](app/core/types.ts) — full `ActionStepKind` union, `ActionStep`, `Action`, `TriggerSourceType`, `TriggerBinding`.
+- Modify: [app/core/ipc.ts](app/core/ipc.ts) and [app/main/ipc.ts](app/main/ipc.ts) — CRUD endpoints.
+- Modify: [app/renderer/App.tsx](app/renderer/App.tsx) — mount provider.
+- Modify: the canonical `takeSlide` site (find via `useSlides` definition) — emit trigger.
+- Modify: [app/renderer/features/workbench/app-toolbar.tsx](app/renderer/features/workbench/app-toolbar.tsx) — toolbar entry.
+- Modify: [app/renderer/contexts/app-store.ts](app/renderer/contexts/app-store.ts) — register actions snapshot in the mutation queue.
+
+## Risks / Open Questions
+
+- **Snapshot/undo integration**: actions are content edits and need to flow through the existing `mutateQueue` / snapshot model in [app/renderer/contexts/app-store.ts](app/renderer/contexts/app-store.ts). Need a quick read pass over how non-Slide entities (overlays, stages) are persisted to follow the same pattern. Confirmed before implementation begins.
+- **Re-entrancy via `flow.runAction`**: handled by the cycle-detection set + `depth ≤ 8` cap above.
+- **Renderer reload kills in-flight `wait` steps**: acceptable for v1; documented in proposal doc.
+- **Visual grouping UX** ("rails" for parallel groups) is non-obvious. Validate with the user when MVP UI is in front of them; cheap to swap if it doesn't land.
+- **`mediaLayer.set` semantics**: existing `setMediaLayerAsset` auto-routes image vs. video. Documented in adapter so users don't expect a video-only or image-only kind.
+- **Device adapters (MIDI/OSC/etc.)**: declared deferred but the schema accommodates them — when the `feat/devices` epic lands, new step kinds are appended to `ActionStepKind` and adapters added. No schema change required.
+
+## Verification
+
+End-to-end test of the MVP slice:
+
+1. `npm run dev`. Confirm DB migrates to v13 and `actions`, `action_steps`, `trigger_bindings` tables exist (sqlite browser or `pragma user_version` + `.tables`).
+2. Open Actions Library panel. Create "Worship Open" with three steps in three rails: rail 1 `overlay.activate(lower-third)`, rail 2 `flow.wait(500)`, rail 3 `video.arm(intro)`. Save.
+3. Open Bindings tab → Bind to a specific slide via `slide.take`.
+4. From the deck browser, take that slide. Expected: lower-third appears immediately; ~500ms later, intro video arms and starts on the video layer.
+5. Take a *different* slide → no overlay, no video. Confirms binding scope.
+6. Edit the action (swap rail order), save, take the slide again → new behavior reflected without restart.
+7. Add a fourth step in rail 3 alongside `video.arm` (e.g. `audio.arm(<sting>)`) → both fire in parallel. Confirms parallel-within-group.
+8. Delete the binding, take the slide → slide takes normally with no side effects.
+9. Restart the app → action and binding persist; replay works.
+10. Try selecting a ◐ step kind in the picker → it's visibly disabled with "(coming soon)". Pick a ✓ kind. Confirms the catalog gate.
+11. Type-check + existing test suite pass; no regressions in slide/overlay/playback paths.
+
+The proposal doc itself ships in the same PR so it's reviewable independently of the runtime code.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lumacast",
   "productName": "LumaCast",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "private": true,
   "description": "Cross-platform presentation tool with reusable content hierarchy, slide rendering, and NDI output",
   "author": "IT-PSAPE",


### PR DESCRIPTION
## Summary
- **Lyric editor (#57)** — paste regression fix, layout-settings sub-modal (text box, typography, segments-per-slide), overflow-aware divide-and-conquer slide grouping, and a Preview button that injects the grouped result back into the editor as blocks.
- **Deck / inspector polish** — slide context menus across editors and inspector tab fallback (#58); deck item focus decoupled from Program arming (#56).
- **Plan** — actions system for multi-step triggers (#48) added under `docs/`.
- **Version** bumped to 0.1.11.

## Test plan
- [ ] Paste lyrics with blank-line section breaks → multi-line blocks preserved.
- [ ] Paste flat lyrics with no blank-line separators → one block per line.
- [ ] Open lyric editor → gear icon opens layout settings; values persist across reopens.
- [ ] With `segmentsPerSlide=2`, click Preview → numbered blocks collapse into pairs (with overflow falling back to 1+1 when a pair doesn't fit).
- [ ] Save after Preview → slides match what was previewed (no double-grouping).
- [ ] Save without Preview → grouping still happens automatically.
- [ ] Confirm theme attached to lyric deck item still drives the rendered slide styling (config values are measurement-only).
- [ ] Right-click slide context menus appear in deck/lyric/theme/overlay editors.
- [ ] Selecting a deck item without arming Program no longer takes it live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)