### PR TITLE
Release 0.1.12 — Talks, NDI capture fixes, latency instrumentation

### DIFF
--- a/app/core/deck-items.ts
+++ b/app/core/deck-items.ts
@@ -1,4 +1,4 @@
-import type { DeckItem, DeckItemType, Presentation, Lyric, PlaylistEntry, Slide } from './types';
+import type { DeckItem, DeckItemType, Presentation, Lyric, Talk, PlaylistEntry, Slide } from './types';
 
 interface DeckItemInput {
   id: string;
@@ -45,27 +45,38 @@ export function isPresentationDeckItem(item: DeckItem | null | undefined): item 
   return item?.type === 'presentation';
 }
 
-export function getDeckItemLabel(item: Pick<DeckItem, 'type'> | DeckItemType): 'Presentation' | 'Lyric' {
+export function isTalkDeckItem(item: DeckItem | null | undefined): item is Talk {
+  return item?.type === 'talk';
+}
+
+export function isPresentationLikeDeckItem(item: DeckItem | null | undefined): item is Presentation | Talk {
+  return item?.type === 'presentation' || item?.type === 'talk';
+}
+
+export function getDeckItemLabel(item: Pick<DeckItem, 'type'> | DeckItemType): 'Presentation' | 'Lyric' | 'Talk' {
   const type = typeof item === 'string' ? item : item.type;
+  if (type === 'talk') return 'Talk';
   return type === 'lyric' ? 'Lyric' : 'Presentation';
 }
 
-export function getSlideDeckItemId(slide: Pick<Slide, 'presentationId' | 'lyricId'>): string | null {
-  return slide.presentationId ?? slide.lyricId ?? null;
+export function getSlideDeckItemId(slide: Pick<Slide, 'presentationId' | 'lyricId' | 'talkId'>): string | null {
+  return slide.presentationId ?? slide.lyricId ?? slide.talkId ?? null;
 }
 
-export function getSlideDeckItemType(slide: Pick<Slide, 'presentationId' | 'lyricId'>): DeckItemType | null {
+export function getSlideDeckItemType(slide: Pick<Slide, 'presentationId' | 'lyricId' | 'talkId'>): DeckItemType | null {
   if (slide.presentationId) return 'presentation';
   if (slide.lyricId) return 'lyric';
+  if (slide.talkId) return 'talk';
   return null;
 }
 
-export function getPlaylistEntryDeckItemId(entry: Pick<PlaylistEntry, 'presentationId' | 'lyricId'>): string | null {
-  return entry.presentationId ?? entry.lyricId ?? null;
+export function getPlaylistEntryDeckItemId(entry: Pick<PlaylistEntry, 'presentationId' | 'lyricId' | 'talkId'>): string | null {
+  return entry.presentationId ?? entry.lyricId ?? entry.talkId ?? null;
 }
 
-export function getPlaylistEntryDeckItemType(entry: Pick<PlaylistEntry, 'presentationId' | 'lyricId'>): DeckItemType | null {
+export function getPlaylistEntryDeckItemType(entry: Pick<PlaylistEntry, 'presentationId' | 'lyricId' | 'talkId'>): DeckItemType | null {
   if (entry.presentationId) return 'presentation';
   if (entry.lyricId) return 'lyric';
+  if (entry.talkId) return 'talk';
   return null;
 }

--- a/app/core/ipc.ts
+++ b/app/core/ipc.ts
@@ -29,7 +29,10 @@ import type {
   ThemeUpdateInput,
   SlideCreateInput,
   SlideNotesUpdateInput,
-  SlideOrderUpdateInput
+  SlideOrderUpdateInput,
+  TalkScriptBlockCreateInput,
+  TalkScriptBlockOrderUpdateInput,
+  TalkScriptBlockUpdateInput
 } from './types';
 import type { SnapshotPatch } from './snapshot-patch';
 
@@ -63,10 +66,15 @@ export interface MainApi {
   moveDeckItem: (id: Id, direction: 'up' | 'down') => Promise<SnapshotPatch>;
   createPresentation: (title: string) => Promise<SnapshotPatch>;
   createLyric: (title: string) => Promise<SnapshotPatch>;
+  createTalk: (title: string) => Promise<SnapshotPatch>;
   createSlide: (input: SlideCreateInput) => Promise<SnapshotPatch>;
   duplicateSlide: (slideId: Id) => Promise<SnapshotPatch>;
   deleteSlide: (slideId: Id) => Promise<SnapshotPatch>;
   updateSlideNotes: (input: SlideNotesUpdateInput) => Promise<SnapshotPatch>;
+  createTalkScriptBlock: (input: TalkScriptBlockCreateInput) => Promise<SnapshotPatch>;
+  updateTalkScriptBlock: (input: TalkScriptBlockUpdateInput) => Promise<SnapshotPatch>;
+  deleteTalkScriptBlock: (id: Id) => Promise<SnapshotPatch>;
+  setTalkScriptBlockOrder: (input: TalkScriptBlockOrderUpdateInput) => Promise<SnapshotPatch>;
   movePlaylistEntry: (entryId: Id, direction: 'up' | 'down') => Promise<AppSnapshot>;
   setSlideOrder: (input: SlideOrderUpdateInput) => Promise<SnapshotPatch>;
   setLibraryOrder: (libraryId: Id, newOrder: number) => Promise<SnapshotPatch>;
@@ -101,11 +109,13 @@ export interface MainApi {
   renamePlaylist: (id: Id, name: string) => Promise<SnapshotPatch>;
   renamePresentation: (id: Id, title: string) => Promise<SnapshotPatch>;
   renameLyric: (id: Id, title: string) => Promise<SnapshotPatch>;
+  renameTalk: (id: Id, title: string) => Promise<SnapshotPatch>;
   deleteLibrary: (id: Id) => Promise<SnapshotPatch>;
   deletePlaylist: (id: Id) => Promise<SnapshotPatch>;
   deletePlaylistGroup: (id: Id) => Promise<SnapshotPatch>;
   deletePresentation: (id: Id) => Promise<SnapshotPatch>;
   deleteLyric: (id: Id) => Promise<SnapshotPatch>;
+  deleteTalk: (id: Id) => Promise<SnapshotPatch>;
   setNdiOutputEnabled: (name: NdiOutputName, enabled: boolean) => Promise<NdiOutputState>;
   getNdiOutputState: () => Promise<NdiOutputState>;
   getNdiOutputConfigs: () => Promise<NdiOutputConfigMap>;
@@ -243,10 +253,15 @@ export const IPC = {
   moveDeckItem: 'cast:moveDeckItem',
   createPresentation: 'cast:createPresentation',
   createLyric: 'cast:createLyric',
+  createTalk: 'cast:createTalk',
   createSlide: 'cast:createSlide',
   duplicateSlide: 'cast:duplicateSlide',
   deleteSlide: 'cast:deleteSlide',
   updateSlideNotes: 'cast:updateSlideNotes',
+  createTalkScriptBlock: 'cast:createTalkScriptBlock',
+  updateTalkScriptBlock: 'cast:updateTalkScriptBlock',
+  deleteTalkScriptBlock: 'cast:deleteTalkScriptBlock',
+  setTalkScriptBlockOrder: 'cast:setTalkScriptBlockOrder',
   setSlideOrder: 'cast:setSlideOrder',
   setLibraryOrder: 'cast:setLibraryOrder',
   setPlaylistOrder: 'cast:setPlaylistOrder',
@@ -280,11 +295,13 @@ export const IPC = {
   renamePlaylist: 'cast:renamePlaylist',
   renamePresentation: 'cast:renamePresentation',
   renameLyric: 'cast:renameLyric',
+  renameTalk: 'cast:renameTalk',
   deleteLibrary: 'cast:deleteLibrary',
   deletePlaylist: 'cast:deletePlaylist',
   deletePlaylistGroup: 'cast:deletePlaylistGroup',
   deletePresentation: 'cast:deletePresentation',
   deleteLyric: 'cast:deleteLyric',
+  deleteTalk: 'cast:deleteTalk',
   getAudioCoverArt: 'cast:getAudioCoverArt',
   setNdiOutputEnabled: 'ndi:setOutputEnabled',
   getNdiOutputState: 'ndi:getOutputState',

--- a/app/core/presentation-layers.ts
+++ b/app/core/presentation-layers.ts
@@ -7,6 +7,7 @@ export const LAYER_PREVIEW_SLIDE: Slide = {
   id: '__layer_preview__',
   presentationId: null,
   lyricId: null,
+  talkId: null,
   themeId: null,
   overlayId: null,
   stageId: null,

--- a/app/core/snapshot-patch.ts
+++ b/app/core/snapshot-patch.ts
@@ -1,4 +1,4 @@
-import type { AppSnapshot, Collection, Id, LibraryPlaylistBundle, Library, Lyric, MediaAsset, Overlay, Presentation, Slide, SlideElement, Stage, Theme } from './types';
+import type { AppSnapshot, Collection, Id, LibraryPlaylistBundle, Library, Lyric, MediaAsset, Overlay, Presentation, Slide, SlideElement, Stage, Talk, TalkScriptBlock, Theme } from './types';
 
 // ─── Types ──────────────────────────────────────────────────────────
 
@@ -25,7 +25,9 @@ export interface SnapshotPatch {
     libraries?: Library[];
     presentations?: Presentation[];
     lyrics?: Lyric[];
+    talks?: Talk[];
     slides?: Slide[];
+    talkScriptBlocks?: TalkScriptBlock[];
     slideElements?: SlideElement[];
     mediaAssets?: MediaAsset[];
     overlays?: Overlay[];
@@ -38,7 +40,9 @@ export interface SnapshotPatch {
     libraries?: Id[];
     presentations?: Id[];
     lyrics?: Id[];
+    talks?: Id[];
     slides?: Id[];
+    talkScriptBlocks?: Id[];
     slideElements?: Id[];
     mediaAssets?: Id[];
     overlays?: Id[];
@@ -52,7 +56,9 @@ type SnapshotTableKey =
   | 'libraries'
   | 'presentations'
   | 'lyrics'
+  | 'talks'
   | 'slides'
+  | 'talkScriptBlocks'
   | 'slideElements'
   | 'mediaAssets'
   | 'overlays'
@@ -64,7 +70,9 @@ type SnapshotTableRecordMap = {
   libraries: Library;
   presentations: Presentation;
   lyrics: Lyric;
+  talks: Talk;
   slides: Slide;
+  talkScriptBlocks: TalkScriptBlock;
   slideElements: SlideElement;
   mediaAssets: MediaAsset;
   overlays: Overlay;
@@ -91,7 +99,9 @@ export function applyPatch(snapshot: AppSnapshot, patch: SnapshotPatch): AppSnap
     libraries: mergeTable(snapshot.libraries, patch.upserts.libraries, patch.deletes.libraries),
     presentations: mergeTable(snapshot.presentations, patch.upserts.presentations, patch.deletes.presentations),
     lyrics: mergeTable(snapshot.lyrics, patch.upserts.lyrics, patch.deletes.lyrics),
+    talks: mergeTable(snapshot.talks, patch.upserts.talks, patch.deletes.talks),
     slides: mergeTable(snapshot.slides, patch.upserts.slides, patch.deletes.slides),
+    talkScriptBlocks: mergeTable(snapshot.talkScriptBlocks, patch.upserts.talkScriptBlocks, patch.deletes.talkScriptBlocks),
     slideElements: mergeTable(snapshot.slideElements, patch.upserts.slideElements, patch.deletes.slideElements),
     mediaAssets: mergeTable(snapshot.mediaAssets, patch.upserts.mediaAssets, patch.deletes.mediaAssets),
     overlays: mergeTable(snapshot.overlays, patch.upserts.overlays, patch.deletes.overlays),
@@ -115,7 +125,9 @@ export function invertPatch(snapshot: AppSnapshot, patch: SnapshotPatch): Snapsh
   invertTable(snapshot.libraries, patch.upserts.libraries, patch.deletes.libraries, inverse, 'libraries');
   invertTable(snapshot.presentations, patch.upserts.presentations, patch.deletes.presentations, inverse, 'presentations');
   invertTable(snapshot.lyrics, patch.upserts.lyrics, patch.deletes.lyrics, inverse, 'lyrics');
+  invertTable(snapshot.talks, patch.upserts.talks, patch.deletes.talks, inverse, 'talks');
   invertTable(snapshot.slides, patch.upserts.slides, patch.deletes.slides, inverse, 'slides');
+  invertTable(snapshot.talkScriptBlocks, patch.upserts.talkScriptBlocks, patch.deletes.talkScriptBlocks, inverse, 'talkScriptBlocks');
   invertTable(snapshot.slideElements, patch.upserts.slideElements, patch.deletes.slideElements, inverse, 'slideElements');
   invertTable(snapshot.mediaAssets, patch.upserts.mediaAssets, patch.deletes.mediaAssets, inverse, 'mediaAssets');
   invertTable(snapshot.overlays, patch.upserts.overlays, patch.deletes.overlays, inverse, 'overlays');
@@ -204,8 +216,14 @@ function appendInverseUpsert<K extends SnapshotTableKey>(
     case 'lyrics':
       inverse.upserts.lyrics = [...(inverse.upserts.lyrics ?? []), value as Lyric];
       return;
+    case 'talks':
+      inverse.upserts.talks = [...(inverse.upserts.talks ?? []), value as Talk];
+      return;
     case 'slides':
       inverse.upserts.slides = [...(inverse.upserts.slides ?? []), value as Slide];
+      return;
+    case 'talkScriptBlocks':
+      inverse.upserts.talkScriptBlocks = [...(inverse.upserts.talkScriptBlocks ?? []), value as TalkScriptBlock];
       return;
     case 'slideElements':
       inverse.upserts.slideElements = [...(inverse.upserts.slideElements ?? []), value as SlideElement];
@@ -222,6 +240,9 @@ function appendInverseUpsert<K extends SnapshotTableKey>(
     case 'stages':
       inverse.upserts.stages = [...(inverse.upserts.stages ?? []), value as Stage];
       return;
+    case 'collections':
+      inverse.upserts.collections = [...(inverse.upserts.collections ?? []), value as Collection];
+      return;
   }
 }
 
@@ -236,8 +257,14 @@ function appendInverseDelete(inverse: SnapshotPatch, key: SnapshotTableKey, id: 
     case 'lyrics':
       inverse.deletes.lyrics = [...(inverse.deletes.lyrics ?? []), id];
       return;
+    case 'talks':
+      inverse.deletes.talks = [...(inverse.deletes.talks ?? []), id];
+      return;
     case 'slides':
       inverse.deletes.slides = [...(inverse.deletes.slides ?? []), id];
+      return;
+    case 'talkScriptBlocks':
+      inverse.deletes.talkScriptBlocks = [...(inverse.deletes.talkScriptBlocks ?? []), id];
       return;
     case 'slideElements':
       inverse.deletes.slideElements = [...(inverse.deletes.slideElements ?? []), id];
@@ -253,6 +280,9 @@ function appendInverseDelete(inverse: SnapshotPatch, key: SnapshotTableKey, id: 
       return;
     case 'stages':
       inverse.deletes.stages = [...(inverse.deletes.stages ?? []), id];
+      return;
+    case 'collections':
+      inverse.deletes.collections = [...(inverse.deletes.collections ?? []), id];
       return;
   }
 }

--- a/app/core/themes.ts
+++ b/app/core/themes.ts
@@ -23,7 +23,7 @@ function applyTextValue(themeElement: SlideElement, textValues: string[]): Slide
 }
 
 export function isThemeCompatibleWithDeckItem(theme: Theme, deckItemType: DeckItemType): boolean {
-  if (theme.kind === 'slides') return deckItemType === 'presentation';
+  if (theme.kind === 'slides') return deckItemType === 'presentation' || deckItemType === 'talk';
   if (theme.kind === 'lyrics') return deckItemType === 'lyric';
   return false;
 }

--- a/app/core/types.ts
+++ b/app/core/types.ts
@@ -32,12 +32,13 @@ export interface PlaylistEntry {
   groupId: Id;
   presentationId: Id | null;
   lyricId: Id | null;
+  talkId: Id | null;
   order: number;
   createdAt: string;
   updatedAt: string;
 }
 
-export type DeckItemType = 'presentation' | 'lyric';
+export type DeckItemType = 'presentation' | 'lyric' | 'talk';
 export type ThemeKind = 'slides' | 'lyrics' | 'overlays';
 
 interface DeckItemBase {
@@ -58,15 +59,20 @@ export interface Lyric extends DeckItemBase {
   type: 'lyric';
 }
 
-export type DeckItem = Presentation | Lyric;
+export interface Talk extends DeckItemBase {
+  type: 'talk';
+}
 
-export type SlideKind = 'presentation' | 'lyric' | 'theme' | 'overlay' | 'stage';
+export type DeckItem = Presentation | Lyric | Talk;
+
+export type SlideKind = 'presentation' | 'lyric' | 'talk' | 'theme' | 'overlay' | 'stage';
 
 export interface Slide {
   id: Id;
   // Exactly one of the parent FKs is set; the rest are null.
   presentationId: Id | null;
   lyricId: Id | null;
+  talkId: Id | null;
   themeId: Id | null;
   overlayId: Id | null;
   stageId: Id | null;
@@ -107,7 +113,9 @@ export type TextBindingKind =
   | 'clock'
   | 'current-slide-text'
   | 'next-slide-text'
-  | 'slide-notes';
+  | 'slide-notes'
+  | 'talk-script-current'
+  | 'talk-script-progress';
 
 export type ClockFormat = '12h' | '12h-seconds' | '24h' | '24h-seconds';
 export type TimerFormat = 'mm:ss' | 'hh:mm:ss';
@@ -257,6 +265,15 @@ export interface Stage {
   updatedAt: string;
 }
 
+export interface TalkScriptBlock {
+  id: Id;
+  slideId: Id;
+  text: string;
+  order: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export type CollectionBinKind = 'deck' | 'image' | 'video' | 'audio' | 'theme' | 'overlay' | 'stage';
 
 export interface Collection {
@@ -293,6 +310,7 @@ export interface CollectionReorderInput {
 export type CollectionItemType =
   | 'presentation'
   | 'lyric'
+  | 'talk'
   | 'media_asset'
   | 'theme'
   | 'overlay'
@@ -321,6 +339,13 @@ export interface DeckBundleSlide {
   notes: string;
   order: number;
   elements: SlideElement[];
+  scriptBlocks?: DeckBundleTalkScriptBlock[];
+}
+
+export interface DeckBundleTalkScriptBlock {
+  id: Id;
+  text: string;
+  order: number;
 }
 
 export interface DeckBundleItem {
@@ -366,6 +391,7 @@ export interface DeckBundlePlaylistEntry {
   id: Id;
   presentationId: Id | null;
   lyricId: Id | null;
+  talkId?: Id | null;
   order: number;
 }
 
@@ -493,7 +519,9 @@ export interface AppSnapshot {
   libraryBundles: LibraryPlaylistBundle[];
   presentations: Presentation[];
   lyrics: Lyric[];
+  talks: Talk[];
   slides: Slide[];
+  talkScriptBlocks: TalkScriptBlock[];
   slideElements: SlideElement[];
   mediaAssets: MediaAsset[];
   overlays: Overlay[];
@@ -513,8 +541,25 @@ export type SlideBrowserMode = 'library' | 'playlist' | 'deck' | 'deck-editor';
 export interface SlideCreateInput {
   presentationId?: Id | null;
   lyricId?: Id | null;
+  talkId?: Id | null;
   width?: number;
   height?: number;
+}
+
+export interface TalkScriptBlockCreateInput {
+  slideId: Id;
+  text?: string;
+  order?: number;
+}
+
+export interface TalkScriptBlockUpdateInput {
+  id: Id;
+  text: string;
+}
+
+export interface TalkScriptBlockOrderUpdateInput {
+  id: Id;
+  newOrder: number;
 }
 
 export interface SlideNotesUpdateInput {

--- a/app/core/types.ts
+++ b/app/core/types.ts
@@ -571,6 +571,11 @@ export interface NdiOutputConfig {
 
 export type NdiOutputConfigMap = Record<NdiOutputName, NdiOutputConfig>;
 
+export interface NdiTallyState {
+  onProgram: boolean;
+  onPreview: boolean;
+}
+
 export interface NdiActiveSenderDiagnostics {
   senderName: string;
   width: number;
@@ -578,6 +583,9 @@ export interface NdiActiveSenderDiagnostics {
   withAlpha: boolean;
   asyncVideoSend: boolean;
   connectionCount: number | null;
+  // Bidirectional NDI tally signal (receiver tells sender "I'm on program /
+  // preview"). Null if the loaded runtime doesn't expose tally polling.
+  tally: NdiTallyState | null;
   startedAtMs: number;
   performance: NdiSenderPerformanceDiagnostics;
   audio: NdiSenderAudioDiagnostics;
@@ -588,6 +596,38 @@ export interface NdiFrameTelemetry {
   readbackDurationMs: number;
   skippedCaptures: number;
   framesDroppedBackpressure: number;
+  // Cross-process Date.now() timestamps. Each stage stamps as the frame
+  // travels: renderer sets signature/capture/rendererSend; main sets
+  // mainReceived and proxyForwarded; utility sets hostReceived. The native
+  // send timestamp is computed inside the service and not echoed back.
+  // Optional — older telemetry shapes still validate.
+  signatureChangedAtMs?: number | null;
+  captureStartedAtMs?: number;
+  rendererSendAtMs?: number;
+  mainReceivedAtMs?: number;
+  proxyForwardedAtMs?: number;
+  hostReceivedAtMs?: number;
+}
+
+export interface NdiPipelineStageStats {
+  p50: number;
+  p95: number;
+  lastMs: number;
+  count: number;
+}
+
+export interface NdiPipelineLatencyDiagnostics {
+  // Headline numbers — the user's symptom is sender-side latency, and
+  // signatureToWire is how long between a state change and bits on the wire.
+  frameAgeAtWire: NdiPipelineStageStats;
+  signatureToWire: NdiPipelineStageStats;
+  // Per-stage spans — for attributing where time goes when the headline
+  // numbers are too high.
+  captureToRendererSend: NdiPipelineStageStats;
+  rendererToMainIpc: NdiPipelineStageStats;
+  mainHandler: NdiPipelineStageStats;
+  mainToHostIpc: NdiPipelineStageStats;
+  hostToNative: NdiPipelineStageStats;
 }
 
 export interface NdiSenderPerformanceDiagnostics {
@@ -615,6 +655,9 @@ export interface NdiSenderPerformanceDiagnostics {
   minFrameBytes: number;
   maxFrameBytes: number;
   blackoutFramesSent: number;
+  // Stage-by-stage pipeline latency for diagnosing where sender-side time
+  // is going (renderer capture → IPC → utility process → native send).
+  pipeline: NdiPipelineLatencyDiagnostics;
 }
 
 export interface NdiSenderAudioDiagnostics {

--- a/app/database/store.ts
+++ b/app/database/store.ts
@@ -65,6 +65,11 @@ import type {
   Stage,
   StageCreateInput,
   StageUpdateInput,
+  Talk,
+  TalkScriptBlock,
+  TalkScriptBlockCreateInput,
+  TalkScriptBlockOrderUpdateInput,
+  TalkScriptBlockUpdateInput,
   Theme,
   ThemeCreateInput,
   ThemeKind,
@@ -83,7 +88,9 @@ const COLLECTIONS_SCHEMA_VERSION = 9;
 const THEME_NAMING_SCHEMA_VERSION = 10;
 const UNIFIED_SLIDES_SCHEMA_VERSION = 11;
 const PLAYLIST_GROUPS_RENAME_SCHEMA_VERSION = 12;
-const LATEST_SCHEMA_VERSION = PLAYLIST_GROUPS_RENAME_SCHEMA_VERSION;
+const TALKS_SCHEMA_VERSION = 13;
+const TALKS_SLIDES_CHECK_SCHEMA_VERSION = 14;
+const LATEST_SCHEMA_VERSION = TALKS_SLIDES_CHECK_SCHEMA_VERSION;
 const GLOBAL_SCHEMA_VERSION = 3;
 const LEGACY_SCHEMA_VERSION = 2;
 
@@ -117,6 +124,7 @@ type StaticCollectionItemType = Exclude<CollectionItemType, 'media_asset'>;
 const ITEM_TABLE_BY_TYPE: Record<StaticCollectionItemType, string> = {
   presentation: 'presentations',
   lyric: 'lyrics',
+  talk: 'talks',
   theme: 'themes',
   overlay: 'overlays',
   stage: 'stages',
@@ -128,7 +136,7 @@ function isItemTypeAllowedInBin(
   itemId: Id,
   store: CastRepository,
 ): boolean {
-  if (itemType === 'presentation' || itemType === 'lyric') return binKind === 'deck';
+  if (itemType === 'presentation' || itemType === 'lyric' || itemType === 'talk') return binKind === 'deck';
   if (itemType === 'theme') return binKind === 'theme';
   if (itemType === 'overlay') return binKind === 'overlay';
   if (itemType === 'stage') return binKind === 'stage';
@@ -146,6 +154,7 @@ function isItemTypeAllowedInBin(
 function buildPatchSpecForItemType(itemType: CollectionItemType, itemId: Id): {
   upsertPresentationIds?: Id[];
   upsertLyricIds?: Id[];
+  upsertTalkIds?: Id[];
   upsertMediaAssetIds?: Id[];
   upsertThemeIds?: Id[];
   upsertOverlayIds?: Id[];
@@ -154,6 +163,7 @@ function buildPatchSpecForItemType(itemType: CollectionItemType, itemId: Id): {
   switch (itemType) {
     case 'presentation': return { upsertPresentationIds: [itemId] };
     case 'lyric': return { upsertLyricIds: [itemId] };
+    case 'talk': return { upsertTalkIds: [itemId] };
     case 'media_asset': return { upsertMediaAssetIds: [itemId] };
     case 'theme': return { upsertThemeIds: [itemId] };
     case 'overlay': return { upsertOverlayIds: [itemId] };
@@ -452,6 +462,62 @@ export class CastRepository {
       this.renamePlaylistSegmentsToGroups();
       this.setUserVersion(PLAYLIST_GROUPS_RENAME_SCHEMA_VERSION);
     }
+
+    if (this.getUserVersion() < TALKS_SCHEMA_VERSION) {
+      this.ensureTalksSchema();
+      this.setUserVersion(TALKS_SCHEMA_VERSION);
+    }
+
+    if (this.getUserVersion() < TALKS_SLIDES_CHECK_SCHEMA_VERSION) {
+      this.repairSlidesCheckConstraintForTalks();
+      this.setUserVersion(TALKS_SLIDES_CHECK_SCHEMA_VERSION);
+    }
+  }
+
+  // v13 — add Talk deck items and per-slide script blocks.
+  private ensureTalksSchema(): void {
+    const tx = this.db.transaction(() => {
+      this.db.exec(`
+        CREATE TABLE IF NOT EXISTS talks (
+          id TEXT PRIMARY KEY,
+          title TEXT NOT NULL,
+          theme_id TEXT,
+          collection_id TEXT NOT NULL,
+          order_index INTEGER NOT NULL DEFAULT 0,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL,
+          FOREIGN KEY(theme_id) REFERENCES themes(id),
+          FOREIGN KEY(collection_id) REFERENCES deck_collections(id)
+        );
+      `);
+
+      if (!this.hasColumn('slides', 'talk_id')) {
+        this.db.exec('ALTER TABLE slides ADD COLUMN talk_id TEXT REFERENCES talks(id)');
+      }
+
+      this.db.exec(`
+        CREATE TABLE IF NOT EXISTS talk_script_blocks (
+          id TEXT PRIMARY KEY,
+          slide_id TEXT NOT NULL,
+          text TEXT NOT NULL DEFAULT '',
+          order_index INTEGER NOT NULL,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL,
+          FOREIGN KEY(slide_id) REFERENCES slides(id)
+        );
+      `);
+
+      if (!this.hasColumn('playlist_entries', 'talk_id')) {
+        this.db.exec('ALTER TABLE playlist_entries ADD COLUMN talk_id TEXT REFERENCES talks(id)');
+      }
+
+      this.db.exec('CREATE INDEX IF NOT EXISTS idx_slides_talk_id ON slides(talk_id)');
+      this.db.exec('CREATE INDEX IF NOT EXISTS idx_talk_script_blocks_slide_id ON talk_script_blocks(slide_id)');
+      this.db.exec('CREATE INDEX IF NOT EXISTS idx_playlist_entries_talk_id ON playlist_entries(talk_id)');
+      this.db.exec('CREATE INDEX IF NOT EXISTS idx_talks_order_index ON talks(order_index)');
+      this.db.exec('CREATE INDEX IF NOT EXISTS idx_talks_collection_id ON talks(collection_id)');
+    });
+    tx();
   }
 
   // v12 — rename `playlist_segments` to `playlist_groups` and the
@@ -732,10 +798,23 @@ export class CastRepository {
         FOREIGN KEY(collection_id) REFERENCES deck_collections(id)
       );
 
+      CREATE TABLE IF NOT EXISTS talks (
+        id TEXT PRIMARY KEY,
+        title TEXT NOT NULL,
+        theme_id TEXT,
+        collection_id TEXT NOT NULL,
+        order_index INTEGER NOT NULL DEFAULT 0,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        FOREIGN KEY(theme_id) REFERENCES themes(id),
+        FOREIGN KEY(collection_id) REFERENCES deck_collections(id)
+      );
+
       CREATE TABLE IF NOT EXISTS slides (
         id TEXT PRIMARY KEY,
         presentation_id TEXT,
         lyric_id TEXT,
+        talk_id TEXT,
         theme_id TEXT,
         overlay_id TEXT,
         stage_id TEXT,
@@ -748,16 +827,28 @@ export class CastRepository {
         updated_at TEXT NOT NULL,
         FOREIGN KEY(presentation_id) REFERENCES presentations(id),
         FOREIGN KEY(lyric_id) REFERENCES lyrics(id),
+        FOREIGN KEY(talk_id) REFERENCES talks(id),
         FOREIGN KEY(theme_id) REFERENCES themes(id),
         FOREIGN KEY(overlay_id) REFERENCES overlays(id),
         FOREIGN KEY(stage_id) REFERENCES stages(id),
         CHECK (
           (presentation_id IS NOT NULL) +
           (lyric_id IS NOT NULL) +
+          (talk_id IS NOT NULL) +
           (theme_id IS NOT NULL) +
           (overlay_id IS NOT NULL) +
           (stage_id IS NOT NULL) = 1
         )
+      );
+
+      CREATE TABLE IF NOT EXISTS talk_script_blocks (
+        id TEXT PRIMARY KEY,
+        slide_id TEXT NOT NULL,
+        text TEXT NOT NULL DEFAULT '',
+        order_index INTEGER NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        FOREIGN KEY(slide_id) REFERENCES slides(id)
       );
 
       CREATE TABLE IF NOT EXISTS slide_elements (
@@ -804,12 +895,14 @@ export class CastRepository {
         group_id TEXT NOT NULL,
         presentation_id TEXT,
         lyric_id TEXT,
+        talk_id TEXT,
         order_index INTEGER NOT NULL,
         created_at TEXT NOT NULL,
         updated_at TEXT NOT NULL,
         FOREIGN KEY(group_id) REFERENCES playlist_groups(id),
         FOREIGN KEY(presentation_id) REFERENCES presentations(id),
-        FOREIGN KEY(lyric_id) REFERENCES lyrics(id)
+        FOREIGN KEY(lyric_id) REFERENCES lyrics(id),
+        FOREIGN KEY(talk_id) REFERENCES talks(id)
       );
 
       CREATE TABLE IF NOT EXISTS image_assets (
@@ -948,12 +1041,15 @@ export class CastRepository {
     this.db.exec(`
       CREATE INDEX IF NOT EXISTS idx_slides_presentation_id ON slides(presentation_id);
       CREATE INDEX IF NOT EXISTS idx_slides_lyric_id ON slides(lyric_id);
+      CREATE INDEX IF NOT EXISTS idx_slides_talk_id ON slides(talk_id);
+      CREATE INDEX IF NOT EXISTS idx_talk_script_blocks_slide_id ON talk_script_blocks(slide_id);
       CREATE INDEX IF NOT EXISTS idx_slide_elements_slide_id ON slide_elements(slide_id);
       CREATE INDEX IF NOT EXISTS idx_playlists_library_id ON playlists(library_id);
       CREATE INDEX IF NOT EXISTS idx_playlist_groups_playlist_id ON playlist_groups(playlist_id);
       CREATE INDEX IF NOT EXISTS idx_playlist_entries_group_id ON playlist_entries(group_id);
       CREATE INDEX IF NOT EXISTS idx_playlist_entries_presentation_id ON playlist_entries(presentation_id);
       CREATE INDEX IF NOT EXISTS idx_playlist_entries_lyric_id ON playlist_entries(lyric_id);
+      CREATE INDEX IF NOT EXISTS idx_playlist_entries_talk_id ON playlist_entries(talk_id);
     `);
     this.createGlobalContentIndexes();
     this.createCollectionsIndexes();
@@ -986,6 +1082,12 @@ export class CastRepository {
       CREATE INDEX IF NOT EXISTS idx_themes_order_index ON themes(order_index);
       CREATE INDEX IF NOT EXISTS idx_stages_order_index ON stages(order_index);
     `);
+    if (this.hasTable('talks')) {
+      this.db.exec(`
+        CREATE INDEX IF NOT EXISTS idx_talks_order_index ON talks(order_index);
+        CREATE INDEX IF NOT EXISTS idx_talks_theme_id ON talks(theme_id);
+      `);
+    }
     // The media-asset indexes are split per type post-v11; pre-v11 schemas
     // still have a unified media_assets table.
     if (this.hasTable('image_assets')) {
@@ -1041,6 +1143,9 @@ export class CastRepository {
     }
     this.db.exec('CREATE INDEX IF NOT EXISTS idx_presentations_collection_id ON presentations(collection_id);');
     this.db.exec('CREATE INDEX IF NOT EXISTS idx_lyrics_collection_id ON lyrics(collection_id);');
+    if (this.hasTable('talks')) {
+      this.db.exec('CREATE INDEX IF NOT EXISTS idx_talks_collection_id ON talks(collection_id);');
+    }
     if (this.hasTable('media_assets')) {
       // Pre-v11 path: keep the legacy index until the migration drops the table.
       this.db.exec('CREATE INDEX IF NOT EXISTS idx_media_assets_collection_id ON media_assets(collection_id);');
@@ -1482,6 +1587,84 @@ export class CastRepository {
     return row?.sql?.includes('CHECK (') ?? false;
   }
 
+  // v14 — the v11 CHECK constraint sums only the original five owner FKs;
+  // when v13 added talk_id via ALTER TABLE the constraint was not updated, so
+  // every Talk-owned slide insert fails. Recreate the table with talk_id
+  // included in the CHECK and in the canonical column order.
+  private repairSlidesCheckConstraintForTalks(): void {
+    const row = this.db
+      .prepare("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'slides'")
+      .get() as { sql: string } | undefined;
+    if (!row?.sql) return;
+    if (row.sql.includes('(talk_id IS NOT NULL)')) return;
+
+    const previousForeignKeys = this.db.pragma('foreign_keys', { simple: true }) as number;
+    this.db.pragma('foreign_keys = OFF');
+    try {
+      const tx = this.db.transaction(() => {
+        this.recreateSlidesTableWithTalkCheck();
+      });
+      tx();
+    } finally {
+      this.db.pragma(`foreign_keys = ${previousForeignKeys ? 'ON' : 'OFF'}`);
+    }
+  }
+
+  private recreateSlidesTableWithTalkCheck(): void {
+    this.db.exec(`
+      CREATE TABLE slides_v14 (
+        id TEXT PRIMARY KEY,
+        presentation_id TEXT,
+        lyric_id TEXT,
+        talk_id TEXT,
+        theme_id TEXT,
+        overlay_id TEXT,
+        stage_id TEXT,
+        kind TEXT NOT NULL DEFAULT 'presentation',
+        width INTEGER NOT NULL,
+        height INTEGER NOT NULL,
+        notes TEXT NOT NULL DEFAULT '',
+        order_index INTEGER NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        FOREIGN KEY(presentation_id) REFERENCES presentations(id),
+        FOREIGN KEY(lyric_id) REFERENCES lyrics(id),
+        FOREIGN KEY(talk_id) REFERENCES talks(id),
+        FOREIGN KEY(theme_id) REFERENCES themes(id),
+        FOREIGN KEY(overlay_id) REFERENCES overlays(id),
+        FOREIGN KEY(stage_id) REFERENCES stages(id),
+        CHECK (
+          (presentation_id IS NOT NULL) +
+          (lyric_id IS NOT NULL) +
+          (talk_id IS NOT NULL) +
+          (theme_id IS NOT NULL) +
+          (overlay_id IS NOT NULL) +
+          (stage_id IS NOT NULL) = 1
+        )
+      );
+
+      INSERT INTO slides_v14 (id, presentation_id, lyric_id, talk_id, theme_id, overlay_id, stage_id, kind, width, height, notes, order_index, created_at, updated_at)
+      SELECT id, presentation_id, lyric_id, talk_id, theme_id, overlay_id, stage_id, kind, width, height, notes, order_index, created_at, updated_at
+      FROM slides;
+
+      DROP INDEX IF EXISTS idx_slides_presentation_id;
+      DROP INDEX IF EXISTS idx_slides_lyric_id;
+      DROP INDEX IF EXISTS idx_slides_talk_id;
+      DROP INDEX IF EXISTS idx_slides_theme_id;
+      DROP INDEX IF EXISTS idx_slides_overlay_id;
+      DROP INDEX IF EXISTS idx_slides_stage_id;
+      DROP TABLE slides;
+      ALTER TABLE slides_v14 RENAME TO slides;
+
+      CREATE INDEX IF NOT EXISTS idx_slides_presentation_id ON slides(presentation_id);
+      CREATE INDEX IF NOT EXISTS idx_slides_lyric_id ON slides(lyric_id);
+      CREATE INDEX IF NOT EXISTS idx_slides_talk_id ON slides(talk_id);
+      CREATE INDEX IF NOT EXISTS idx_slides_theme_id ON slides(theme_id);
+      CREATE INDEX IF NOT EXISTS idx_slides_overlay_id ON slides(overlay_id);
+      CREATE INDEX IF NOT EXISTS idx_slides_stage_id ON slides(stage_id);
+    `);
+  }
+
   private tableHasForeignKeyOn(table: string, column: string): boolean {
     const rows = this.db.prepare(`PRAGMA foreign_key_list(${table})`).all() as Array<{ from: string }>;
     return rows.some((row) => row.from === column);
@@ -1793,6 +1976,7 @@ export class CastRepository {
       deletedCollectionIds: [input.id],
       upsertPresentationIds: movedIds.presentations,
       upsertLyricIds: movedIds.lyrics,
+      upsertTalkIds: movedIds.talks,
       upsertMediaAssetIds: movedIds.mediaAssets,
       upsertThemeIds: movedIds.themes,
       upsertOverlayIds: movedIds.overlays,
@@ -1860,6 +2044,7 @@ export class CastRepository {
   ): {
     presentations: Id[];
     lyrics: Id[];
+    talks: Id[];
     mediaAssets: Id[];
     themes: Id[];
     overlays: Id[];
@@ -1868,6 +2053,7 @@ export class CastRepository {
     const moved = {
       presentations: [] as Id[],
       lyrics: [] as Id[],
+      talks: [] as Id[],
       mediaAssets: [] as Id[],
       themes: [] as Id[],
       overlays: [] as Id[],
@@ -1889,6 +2075,7 @@ export class CastRepository {
       case 'deck':
         reassign('presentations', moved.presentations);
         reassign('lyrics', moved.lyrics);
+        if (this.hasTable('talks')) reassign('talks', moved.talks);
         break;
       case 'image':
         reassign('image_assets', moved.mediaAssets);
@@ -2398,9 +2585,11 @@ export class CastRepository {
     const libraries = this.getLibraries();
     const presentations = this.getPresentations();
     const lyrics = this.getLyrics();
+    const talks = this.getTalks();
     const itemsById = new Map<Id, DeckItem>([
       ...presentations.map((deck) => [deck.id, deck] as const),
       ...lyrics.map((lyric) => [lyric.id, lyric] as const),
+      ...talks.map((talk) => [talk.id, talk] as const),
     ]);
     const libraryBundles = libraries.map((library) => ({
       library,
@@ -2412,7 +2601,9 @@ export class CastRepository {
       libraryBundles,
       presentations,
       lyrics,
+      talks,
       slides: this.getSlides(),
+      talkScriptBlocks: this.getTalkScriptBlocks(),
       slideElements: this.getSlideElements(),
       mediaAssets: this.getMediaAssets(),
       overlays: this.getOverlays(),
@@ -2432,6 +2623,7 @@ export class CastRepository {
     const tx = this.db.transaction(() => {
       this.db.exec(`
         DELETE FROM playlist_entries;
+        DELETE FROM talk_script_blocks;
         DELETE FROM slide_elements;
         DELETE FROM slides;
         DELETE FROM overlays;
@@ -2441,6 +2633,7 @@ export class CastRepository {
         DELETE FROM playlists;
         DELETE FROM presentations;
         DELETE FROM lyrics;
+        DELETE FROM talks;
         DELETE FROM image_assets;
         DELETE FROM video_assets;
         DELETE FROM audio_assets;
@@ -2505,25 +2698,56 @@ export class CastRepository {
         );
       }
 
+      const insertTalk = this.db.prepare(
+        'INSERT INTO talks (id, title, theme_id, collection_id, order_index, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)'
+      );
+      for (const talk of snapshot.talks) {
+        insertTalk.run(
+          talk.id,
+          talk.title,
+          talk.themeId ?? null,
+          talk.collectionId,
+          talk.order,
+          talk.createdAt,
+          talk.updatedAt,
+        );
+      }
+
       const insertSlide = this.db.prepare(
-        `INSERT INTO slides (id, presentation_id, lyric_id, theme_id, overlay_id, stage_id, kind, width, height, notes, order_index, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        `INSERT INTO slides (id, presentation_id, lyric_id, talk_id, theme_id, overlay_id, stage_id, kind, width, height, notes, order_index, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
       );
       for (const slide of snapshot.slides) {
         insertSlide.run(
           slide.id,
           slide.presentationId,
           slide.lyricId,
+          slide.talkId,
           slide.themeId ?? null,
           slide.overlayId ?? null,
           slide.stageId ?? null,
-          slide.kind ?? (slide.lyricId ? 'lyric' : 'presentation'),
+          slide.kind ?? (slide.lyricId ? 'lyric' : slide.talkId ? 'talk' : 'presentation'),
           slide.width,
           slide.height,
           slide.notes,
           slide.order,
           slide.createdAt,
           slide.updatedAt,
+        );
+      }
+
+      const insertTalkScriptBlock = this.db.prepare(
+        `INSERT INTO talk_script_blocks (id, slide_id, text, order_index, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?)`
+      );
+      for (const block of snapshot.talkScriptBlocks) {
+        insertTalkScriptBlock.run(
+          block.id,
+          block.slideId,
+          block.text,
+          block.order,
+          block.createdAt,
+          block.updatedAt,
         );
       }
 
@@ -2558,7 +2782,7 @@ export class CastRepository {
         'INSERT INTO playlist_groups (id, playlist_id, name, color_key, order_index, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)'
       );
       const insertEntry = this.db.prepare(
-        'INSERT INTO playlist_entries (id, group_id, presentation_id, lyric_id, order_index, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)'
+        'INSERT INTO playlist_entries (id, group_id, presentation_id, lyric_id, talk_id, order_index, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)'
       );
       for (const bundle of snapshot.libraryBundles) {
         for (const tree of bundle.playlists) {
@@ -2586,6 +2810,7 @@ export class CastRepository {
                 entry.groupId,
                 entry.presentationId,
                 entry.lyricId,
+                entry.talkId,
                 entry.order,
                 entry.createdAt,
                 entry.updatedAt,
@@ -2818,9 +3043,15 @@ export class CastRepository {
     const insertLyric = this.db.prepare(
       'INSERT INTO lyrics (id, title, theme_id, collection_id, order_index, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)'
     );
+    const insertTalk = this.db.prepare(
+      'INSERT INTO talks (id, title, theme_id, collection_id, order_index, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)'
+    );
     const insertSlide = this.db.prepare(
-      `INSERT INTO slides (id, presentation_id, lyric_id, theme_id, overlay_id, stage_id, kind, width, height, notes, order_index, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      `INSERT INTO slides (id, presentation_id, lyric_id, talk_id, theme_id, overlay_id, stage_id, kind, width, height, notes, order_index, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    );
+    const insertTalkScriptBlock = this.db.prepare(
+      'INSERT INTO talk_script_blocks (id, slide_id, text, order_index, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)'
     );
     const insertElement = this.db.prepare(
       `INSERT INTO slide_elements
@@ -2859,8 +3090,8 @@ export class CastRepository {
       'INSERT INTO playlist_groups (id, playlist_id, name, color_key, order_index, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)'
     );
     const insertPlaylistEntry = this.db.prepare(
-      `INSERT INTO playlist_entries (id, group_id, presentation_id, lyric_id, order_index, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?)`
+      `INSERT INTO playlist_entries (id, group_id, presentation_id, lyric_id, talk_id, order_index, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
     );
 
     const nextStageOrder = (this.db.prepare('SELECT COALESCE(MAX(order_index), -1) + 1 AS next_order FROM stages').get() as { next_order: number }).next_order;
@@ -2935,6 +3166,8 @@ export class CastRepository {
 
           if (item.type === 'presentation') {
             insertPresentation.run(newItemId, item.title, importedThemeId, importDeckCollectionId, nextContentOrder + itemIndex, now, now);
+          } else if (item.type === 'talk') {
+            insertTalk.run(newItemId, item.title, importedThemeId, importDeckCollectionId, nextContentOrder + itemIndex, now, now);
           } else {
             insertLyric.run(newItemId, item.title, importedThemeId, importDeckCollectionId, nextContentOrder + itemIndex, now, now);
           }
@@ -2948,6 +3181,7 @@ export class CastRepository {
                 newSlideId,
                 item.type === 'presentation' ? newItemId : null,
                 item.type === 'lyric' ? newItemId : null,
+                item.type === 'talk' ? newItemId : null,
                 null,
                 null,
                 null,
@@ -2979,6 +3213,9 @@ export class CastRepository {
                   now,
                 );
               });
+              for (const block of slide.scriptBlocks ?? []) {
+                insertTalkScriptBlock.run(createId(), newSlideId, block.text, block.order, now, now);
+              }
             });
         });
 
@@ -3075,7 +3312,7 @@ export class CastRepository {
                   .slice()
                   .sort((left, right) => left.order - right.order)
                   .forEach((entry, entryIndex) => {
-                    const sourceItemId = entry.presentationId ?? entry.lyricId;
+                    const sourceItemId = entry.presentationId ?? entry.lyricId ?? entry.talkId;
                     if (!sourceItemId) return;
                     const importedItemId = itemIdMap.get(sourceItemId);
                     if (!importedItemId) return;
@@ -3084,6 +3321,7 @@ export class CastRepository {
                       newGroupId,
                       entry.presentationId ? importedItemId : null,
                       entry.lyricId ? importedItemId : null,
+                      entry.talkId ? importedItemId : null,
                       entryIndex,
                       now,
                       now,
@@ -3171,14 +3409,15 @@ export class CastRepository {
 
     this.db
       .prepare(
-        `INSERT INTO playlist_entries (id, group_id, presentation_id, lyric_id, order_index, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?)`
+        `INSERT INTO playlist_entries (id, group_id, presentation_id, lyric_id, talk_id, order_index, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
       )
       .run(
         createId(),
         groupId,
         owner.type === 'presentation' ? itemId : null,
         owner.type === 'lyric' ? itemId : null,
+        owner.type === 'talk' ? itemId : null,
         currentOrder + 1,
         now,
         now,
@@ -3216,14 +3455,15 @@ export class CastRepository {
 
     this.db
       .prepare(
-        `INSERT INTO playlist_entries (id, group_id, presentation_id, lyric_id, order_index, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?)`
+        `INSERT INTO playlist_entries (id, group_id, presentation_id, lyric_id, talk_id, order_index, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
       )
       .run(
         createId(),
         groupId,
         owner.type === 'presentation' ? itemId : null,
         owner.type === 'lyric' ? itemId : null,
+        owner.type === 'talk' ? itemId : null,
         currentOrder + 1,
         now,
         now,
@@ -3327,6 +3567,17 @@ export class CastRepository {
     return this.buildPatch({ upsertLyricIds: [lyricId] });
   }
 
+  createTalk(title: string): SnapshotPatch {
+    const now = nowIso();
+    const talkId = createId();
+    const currentOrder = this.getMaxDeckOrder();
+    const deckCollectionId = this.getDefaultCollectionId('deck');
+    this.db
+      .prepare('INSERT INTO talks (id, title, theme_id, collection_id, order_index, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)')
+      .run(talkId, title, null, deckCollectionId, currentOrder + 1, now, now);
+    return this.buildPatch({ upsertTalkIds: [talkId] });
+  }
+
   createTheme(input: ThemeCreateInput): SnapshotPatch {
     const now = nowIso();
     const themeId = createId();
@@ -3418,10 +3669,15 @@ export class CastRepository {
       .prepare('SELECT id FROM lyrics WHERE theme_id = ?')
       .all(themeId) as Array<{ id: string }>)
       .map((row) => row.id);
+    const affectedTalkIds = (this.db
+      .prepare('SELECT id FROM talks WHERE theme_id = ?')
+      .all(themeId) as Array<{ id: string }>)
+      .map((row) => row.id);
     const ownerSlideId = `${themeId}:slide`;
     const tx = this.db.transaction(() => {
       this.db.prepare('UPDATE presentations SET theme_id = NULL, updated_at = ? WHERE theme_id = ?').run(nowIso(), themeId);
       this.db.prepare('UPDATE lyrics SET theme_id = NULL, updated_at = ? WHERE theme_id = ?').run(nowIso(), themeId);
+      this.db.prepare('UPDATE talks SET theme_id = NULL, updated_at = ? WHERE theme_id = ?').run(nowIso(), themeId);
       // Drop the owning slide first (its theme_id FK references the theme).
       this.deleteContainerSlide(ownerSlideId);
       this.db.prepare('DELETE FROM themes WHERE id = ?').run(themeId);
@@ -3432,6 +3688,7 @@ export class CastRepository {
     return this.buildPatch({
       upsertPresentationIds: affectedPresentationIds,
       upsertLyricIds: affectedLyricIds,
+      upsertTalkIds: affectedTalkIds,
       upsertThemeIds: remainingThemeIds,
       deletedThemeIds: [themeId],
       replaceLibraryBundles: true,
@@ -3529,6 +3786,7 @@ export class CastRepository {
     return this.buildPatch({
       upsertPresentationIds: owner.type === 'presentation' ? [itemId] : undefined,
       upsertLyricIds: owner.type === 'lyric' ? [itemId] : undefined,
+      upsertTalkIds: owner.type === 'talk' ? [itemId] : undefined,
       upsertSlideElementIds: this.getSlideElementIdsBySlideIds(slides.map((slide) => slide.id)),
       deletedSlideElementIds: deletedElementIds,
       replaceLibraryBundles: true,
@@ -3545,9 +3803,13 @@ export class CastRepository {
     const lyrics = this.db
       .prepare('SELECT id FROM lyrics WHERE theme_id = ?')
       .all(themeId) as Array<{ id: string }>;
+    const talks = this.db
+      .prepare('SELECT id FROM talks WHERE theme_id = ?')
+      .all(themeId) as Array<{ id: string }>;
 
     const linkedItems: Array<{ id: string; type: DeckItemType }> = [
       ...(theme.kind === 'slides' ? presentations.map((row) => ({ id: row.id, type: 'presentation' as DeckItemType })) : []),
+      ...(theme.kind === 'slides' ? talks.map((row) => ({ id: row.id, type: 'talk' as DeckItemType })) : []),
       ...(theme.kind === 'lyrics' ? lyrics.map((row) => ({ id: row.id, type: 'lyric' as DeckItemType })) : []),
     ];
 
@@ -3636,10 +3898,12 @@ export class CastRepository {
 
     const presentationIds = linkedItems.filter((item) => item.type === 'presentation').map((item) => item.id);
     const lyricIds = linkedItems.filter((item) => item.type === 'lyric').map((item) => item.id);
+    const talkIds = linkedItems.filter((item) => item.type === 'talk').map((item) => item.id);
 
     return this.buildPatch({
       upsertPresentationIds: presentationIds.length > 0 ? presentationIds : undefined,
       upsertLyricIds: lyricIds.length > 0 ? lyricIds : undefined,
+      upsertTalkIds: talkIds.length > 0 ? talkIds : undefined,
       upsertSlideElementIds: this.getSlideElementIdsBySlideIds(touchedSlideIds),
       deletedSlideElementIds: deletedElementIds,
       replaceLibraryBundles: true,
@@ -3655,6 +3919,7 @@ export class CastRepository {
     return this.buildPatch({
       upsertPresentationIds: owner.type === 'presentation' ? [itemId] : undefined,
       upsertLyricIds: owner.type === 'lyric' ? [itemId] : undefined,
+      upsertTalkIds: owner.type === 'talk' ? [itemId] : undefined,
       replaceLibraryBundles: true,
     });
   }
@@ -3736,6 +4001,7 @@ export class CastRepository {
     return this.buildPatch({
       upsertPresentationIds: [current, neighbor].filter((item) => item.type === 'presentation').map((item) => item.id),
       upsertLyricIds: [current, neighbor].filter((item) => item.type === 'lyric').map((item) => item.id),
+      upsertTalkIds: [current, neighbor].filter((item) => item.type === 'talk').map((item) => item.id),
       replaceLibraryBundles: true,
     });
   }
@@ -3763,12 +4029,13 @@ export class CastRepository {
 
     this.db
       .prepare(
-        'INSERT INTO slides (id, presentation_id, lyric_id, kind, width, height, notes, order_index, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
+        'INSERT INTO slides (id, presentation_id, lyric_id, talk_id, kind, width, height, notes, order_index, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
       )
       .run(
         slideId,
         owner.type === 'presentation' ? owner.id : null,
         owner.type === 'lyric' ? owner.id : null,
+        owner.type === 'talk' ? owner.id : null,
         owner.type,
         input.width ?? DEFAULT_W,
         input.height ?? DEFAULT_H,
@@ -3826,17 +4093,19 @@ export class CastRepository {
 
   deleteSlide(slideId: Id): SnapshotPatch {
     const slide = this.db
-      .prepare('SELECT presentation_id, lyric_id FROM slides WHERE id = ?')
-      .get(slideId) as { presentation_id: string | null; lyric_id: string | null } | undefined;
+      .prepare('SELECT presentation_id, lyric_id, talk_id FROM slides WHERE id = ?')
+      .get(slideId) as { presentation_id: string | null; lyric_id: string | null; talk_id: string | null } | undefined;
 
     if (!slide) return this.buildPatch({});
 
-    const ownerColumn = slide.presentation_id ? 'presentation_id' : 'lyric_id';
-    const ownerId = slide.presentation_id ?? slide.lyric_id;
+    const ownerColumn = slide.presentation_id ? 'presentation_id' : slide.lyric_id ? 'lyric_id' : 'talk_id';
+    const ownerId = slide.presentation_id ?? slide.lyric_id ?? slide.talk_id;
     if (!ownerId) return this.buildPatch({});
     const deletedElementIds = this.getSlideElementIdsBySlideIds([slideId]);
+    const deletedTalkScriptBlockIds = this.getTalkScriptBlockIdsBySlideIds([slideId]);
 
     const tx = this.db.transaction(() => {
+      this.db.prepare('DELETE FROM talk_script_blocks WHERE slide_id = ?').run(slideId);
       this.db.prepare('DELETE FROM slide_elements WHERE slide_id = ?').run(slideId);
       this.db.prepare('DELETE FROM slides WHERE id = ?').run(slideId);
       this.normalizeSlideOrder(ownerColumn, ownerId);
@@ -3847,6 +4116,7 @@ export class CastRepository {
       upsertSlideIds: this.getSlideIdsForOwner(ownerColumn, ownerId),
       deletedSlideIds: [slideId],
       deletedSlideElementIds: deletedElementIds,
+      deletedTalkScriptBlockIds,
     });
   }
 
@@ -3858,13 +4128,90 @@ export class CastRepository {
     return this.buildPatch({ upsertSlideIds: [input.slideId] });
   }
 
+  createTalkScriptBlock(input: TalkScriptBlockCreateInput): SnapshotPatch {
+    const slide = this.db
+      .prepare('SELECT id, talk_id FROM slides WHERE id = ?')
+      .get(input.slideId) as { id: string; talk_id: string | null } | undefined;
+    if (!slide?.talk_id) return this.buildPatch({});
+
+    const now = nowIso();
+    const id = createId();
+    const currentMax = (this.db
+      .prepare('SELECT COALESCE(MAX(order_index), -1) AS maxOrder FROM talk_script_blocks WHERE slide_id = ?')
+      .get(input.slideId) as { maxOrder: number }).maxOrder;
+    const order = input.order == null ? currentMax + 1 : Math.max(0, input.order);
+
+    const tx = this.db.transaction(() => {
+      this.db
+        .prepare('UPDATE talk_script_blocks SET order_index = order_index + 1, updated_at = ? WHERE slide_id = ? AND order_index >= ?')
+        .run(now, input.slideId, order);
+      this.db
+        .prepare('INSERT INTO talk_script_blocks (id, slide_id, text, order_index, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)')
+        .run(id, input.slideId, input.text ?? '', order, now, now);
+      this.normalizeTalkScriptBlockOrder(input.slideId);
+    });
+    tx();
+
+    return this.buildPatch({ upsertTalkScriptBlockIds: this.getTalkScriptBlockIdsBySlideIds([input.slideId]) });
+  }
+
+  updateTalkScriptBlock(input: TalkScriptBlockUpdateInput): SnapshotPatch {
+    const now = nowIso();
+    this.db
+      .prepare('UPDATE talk_script_blocks SET text = ?, updated_at = ? WHERE id = ?')
+      .run(input.text, now, input.id);
+    return this.buildPatch({ upsertTalkScriptBlockIds: [input.id] });
+  }
+
+  deleteTalkScriptBlock(id: Id): SnapshotPatch {
+    const row = this.db
+      .prepare('SELECT slide_id FROM talk_script_blocks WHERE id = ?')
+      .get(id) as { slide_id: string } | undefined;
+    if (!row) return this.buildPatch({});
+    const tx = this.db.transaction(() => {
+      this.db.prepare('DELETE FROM talk_script_blocks WHERE id = ?').run(id);
+      this.normalizeTalkScriptBlockOrder(row.slide_id);
+    });
+    tx();
+    return this.buildPatch({
+      upsertTalkScriptBlockIds: this.getTalkScriptBlockIdsBySlideIds([row.slide_id]),
+      deletedTalkScriptBlockIds: [id],
+    });
+  }
+
+  setTalkScriptBlockOrder(input: TalkScriptBlockOrderUpdateInput): SnapshotPatch {
+    const row = this.db
+      .prepare('SELECT slide_id, order_index FROM talk_script_blocks WHERE id = ?')
+      .get(input.id) as { slide_id: string; order_index: number } | undefined;
+    if (!row) return this.buildPatch({});
+
+    const blockIds = this.getTalkScriptBlockIdsBySlideIds([row.slide_id]);
+    const currentIndex = blockIds.indexOf(input.id);
+    if (currentIndex < 0) return this.buildPatch({});
+    const nextIndex = Math.max(0, Math.min(input.newOrder, blockIds.length - 1));
+    if (currentIndex === nextIndex) return this.buildPatch({});
+
+    const reordered = [...blockIds];
+    const [moved] = reordered.splice(currentIndex, 1);
+    reordered.splice(nextIndex, 0, moved);
+    const now = nowIso();
+    const update = this.db.prepare('UPDATE talk_script_blocks SET order_index = ?, updated_at = ? WHERE id = ?');
+    const tx = this.db.transaction(() => {
+      reordered.forEach((blockId, index) => update.run(index, now, blockId));
+    });
+    tx();
+
+    return this.buildPatch({ upsertTalkScriptBlockIds: reordered });
+  }
+
   duplicateSlide(slideId: Id): SnapshotPatch {
     const original = this.db
-      .prepare('SELECT id, presentation_id, lyric_id, width, height, notes, order_index FROM slides WHERE id = ?')
+      .prepare('SELECT id, presentation_id, lyric_id, talk_id, width, height, notes, order_index FROM slides WHERE id = ?')
       .get(slideId) as {
         id: string;
         presentation_id: string | null;
         lyric_id: string | null;
+        talk_id: string | null;
         width: number;
         height: number;
         notes: string | null;
@@ -3872,8 +4219,8 @@ export class CastRepository {
       } | undefined;
     if (!original) return this.buildPatch({});
 
-    const ownerColumn = original.presentation_id !== null ? 'presentation_id' : 'lyric_id';
-    const ownerValue = original.presentation_id ?? original.lyric_id;
+    const ownerColumn = original.presentation_id !== null ? 'presentation_id' : original.lyric_id !== null ? 'lyric_id' : 'talk_id';
+    const ownerValue = original.presentation_id ?? original.lyric_id ?? original.talk_id;
     if (!ownerValue) return this.buildPatch({});
 
     const now = nowIso();
@@ -3891,12 +4238,18 @@ export class CastRepository {
         rotation: number; opacity: number; z_index: number;
         layer: SlideElement['layer']; payload_json: string;
       }>;
+    const scriptBlocks = this.db
+      .prepare('SELECT text, order_index FROM talk_script_blocks WHERE slide_id = ? ORDER BY order_index ASC')
+      .all(slideId) as Array<{ text: string; order_index: number }>;
 
     const shiftOrder = this.db.prepare(
       `UPDATE slides SET order_index = order_index + 1, updated_at = ? WHERE ${ownerColumn} = ? AND order_index >= ?`
     );
     const insertSlide = this.db.prepare(
-      'INSERT INTO slides (id, presentation_id, lyric_id, kind, width, height, notes, order_index, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
+      'INSERT INTO slides (id, presentation_id, lyric_id, talk_id, kind, width, height, notes, order_index, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
+    );
+    const insertScriptBlock = this.db.prepare(
+      'INSERT INTO talk_script_blocks (id, slide_id, text, order_index, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)'
     );
     const insertElement = this.db.prepare(
       `INSERT INTO slide_elements
@@ -3911,7 +4264,8 @@ export class CastRepository {
         newSlideId,
         original.presentation_id,
         original.lyric_id,
-        original.presentation_id ? 'presentation' : 'lyric',
+        original.talk_id,
+        original.presentation_id ? 'presentation' : original.lyric_id ? 'lyric' : 'talk',
         original.width,
         original.height,
         original.notes ?? '',
@@ -3932,12 +4286,16 @@ export class CastRepository {
           now, now,
         );
       }
+      for (const block of scriptBlocks) {
+        insertScriptBlock.run(createId(), newSlideId, block.text, block.order_index, now, now);
+      }
     });
     tx();
 
     return this.buildPatch({
       upsertSlideIds: this.getSlideIdsForOwner(ownerColumn, ownerValue),
       upsertSlideElementIds: newElementIds,
+      upsertTalkScriptBlockIds: this.getTalkScriptBlockIdsBySlideIds([newSlideId]),
     });
   }
 
@@ -3946,15 +4304,14 @@ export class CastRepository {
 
     // Get the current slide to find its parent
     const slide = this.db
-      .prepare('SELECT id, presentation_id, lyric_id FROM slides WHERE id = ?')
-      .get(input.slideId) as { id: string; presentation_id: string | null; lyric_id: string | null } | undefined;
+      .prepare('SELECT id, presentation_id, lyric_id, talk_id FROM slides WHERE id = ?')
+      .get(input.slideId) as { id: string; presentation_id: string | null; lyric_id: string | null; talk_id: string | null } | undefined;
 
     if (!slide) return this.buildPatch({});
 
     // Determine parent column and value
-    const isDecksSlide = slide.presentation_id !== null;
-    const ownerColumn = isDecksSlide ? 'presentation_id' : 'lyric_id';
-    const ownerId = isDecksSlide ? slide.presentation_id : slide.lyric_id;
+    const ownerColumn = slide.presentation_id !== null ? 'presentation_id' : slide.lyric_id !== null ? 'lyric_id' : 'talk_id';
+    const ownerId = slide.presentation_id ?? slide.lyric_id ?? slide.talk_id;
 
     if (!ownerId) return this.buildPatch({});
 
@@ -4467,6 +4824,13 @@ export class CastRepository {
     return this.buildPatch({ upsertLyricIds: [id], replaceLibraryBundles: true });
   }
 
+  renameTalk(id: Id, title: string): SnapshotPatch {
+    this.db
+      .prepare('UPDATE talks SET title = ?, updated_at = ? WHERE id = ?')
+      .run(title, nowIso(), id);
+    return this.buildPatch({ upsertTalkIds: [id], replaceLibraryBundles: true });
+  }
+
   deleteLibrary(id: Id): SnapshotPatch {
     const tx = this.db.transaction((libraryId: Id) => {
       this.db
@@ -4612,6 +4976,54 @@ export class CastRepository {
       deletedLyricIds: [id],
       deletedSlideIds,
       deletedSlideElementIds,
+      replaceLibraryBundles: true,
+    });
+  }
+
+  deleteTalk(id: Id): SnapshotPatch {
+    const deletedSlideIds = (this.db
+      .prepare('SELECT id FROM slides WHERE talk_id = ?')
+      .all(id) as Array<{ id: string }>)
+      .map((row) => row.id);
+    const deletedSlideElementIds = this.getSlideElementIdsBySlideIds(deletedSlideIds);
+    const deletedTalkScriptBlockIds = this.getTalkScriptBlockIdsBySlideIds(deletedSlideIds);
+    const tx = this.db.transaction((talkId: Id) => {
+      this.db
+        .prepare(
+          `DELETE FROM talk_script_blocks
+           WHERE slide_id IN (SELECT id FROM slides WHERE talk_id = ?)`
+        )
+        .run(talkId);
+      this.db
+        .prepare(
+          `DELETE FROM slide_elements
+           WHERE slide_id IN (SELECT id FROM slides WHERE talk_id = ?)`
+        )
+        .run(talkId);
+      this.db
+        .prepare('DELETE FROM slides WHERE talk_id = ?')
+        .run(talkId);
+      this.db
+        .prepare('DELETE FROM playlist_entries WHERE talk_id = ?')
+        .run(talkId);
+      this.db
+        .prepare('DELETE FROM talks WHERE id = ?')
+        .run(talkId);
+    });
+
+    tx(id);
+    this.normalizeDeckItemOrder();
+    const remainingPresentationIds = (this.db.prepare('SELECT id FROM presentations ORDER BY order_index ASC').all() as Array<{ id: string }>).map((row) => row.id);
+    const remainingLyricIds = (this.db.prepare('SELECT id FROM lyrics ORDER BY order_index ASC').all() as Array<{ id: string }>).map((row) => row.id);
+    const remainingTalkIds = (this.db.prepare('SELECT id FROM talks ORDER BY order_index ASC').all() as Array<{ id: string }>).map((row) => row.id);
+    return this.buildPatch({
+      upsertPresentationIds: remainingPresentationIds,
+      upsertLyricIds: remainingLyricIds,
+      upsertTalkIds: remainingTalkIds,
+      deletedTalkIds: [id],
+      deletedSlideIds,
+      deletedSlideElementIds,
+      deletedTalkScriptBlockIds,
       replaceLibraryBundles: true,
     });
   }
@@ -4799,7 +5211,7 @@ export class CastRepository {
     };
   }
 
-  private normalizeSlideOrder(ownerColumn: 'presentation_id' | 'lyric_id', ownerId: Id): void {
+  private normalizeSlideOrder(ownerColumn: 'presentation_id' | 'lyric_id' | 'talk_id', ownerId: Id): void {
     const now = nowIso();
     this.db
       .prepare(
@@ -4814,6 +5226,23 @@ export class CastRepository {
          WHERE ${ownerColumn} = ?`
       )
       .run(ownerId, now, ownerId);
+  }
+
+  private normalizeTalkScriptBlockOrder(slideId: Id): void {
+    const now = nowIso();
+    this.db
+      .prepare(
+        `WITH ranked AS (
+           SELECT id, ROW_NUMBER() OVER (ORDER BY order_index ASC, created_at ASC, id ASC) - 1 AS next_order
+           FROM talk_script_blocks
+           WHERE slide_id = ?
+         )
+         UPDATE talk_script_blocks
+         SET order_index = (SELECT next_order FROM ranked WHERE ranked.id = talk_script_blocks.id),
+             updated_at = ?
+         WHERE slide_id = ?`
+      )
+      .run(slideId, now, slideId);
   }
 
   private assertMediaSource(src: string): void {
@@ -4833,12 +5262,16 @@ export class CastRepository {
     return 'content';
   }
 
-  private getDeckTableName(type: DeckItemType): 'presentations' | 'lyrics' {
-    return type === 'presentation' ? 'presentations' : 'lyrics';
+  private getDeckTableName(type: DeckItemType): 'presentations' | 'lyrics' | 'talks' {
+    if (type === 'presentation') return 'presentations';
+    if (type === 'lyric') return 'lyrics';
+    return 'talks';
   }
 
-  private getDeckOwnerColumn(type: DeckItemType): 'presentation_id' | 'lyric_id' {
-    return type === 'presentation' ? 'presentation_id' : 'lyric_id';
+  private getDeckOwnerColumn(type: DeckItemType): 'presentation_id' | 'lyric_id' | 'talk_id' {
+    if (type === 'presentation') return 'presentation_id';
+    if (type === 'lyric') return 'lyric_id';
+    return 'talk_id';
   }
 
   private getMaxDeckOrder(): number {
@@ -4848,6 +5281,8 @@ export class CastRepository {
          SELECT order_index FROM presentations
          UNION ALL
          SELECT order_index FROM lyrics
+         UNION ALL
+         SELECT order_index FROM talks
        )`
     ).get() as { maxOrder: number | null };
     return row.maxOrder ?? -1;
@@ -4860,6 +5295,8 @@ export class CastRepository {
          SELECT id, 'presentation' AS type, order_index, created_at FROM presentations
          UNION ALL
          SELECT id, 'lyric' AS type, order_index, created_at FROM lyrics
+         UNION ALL
+         SELECT id, 'talk' AS type, order_index, created_at FROM talks
        )
        ORDER BY order_index ASC, created_at ASC, id ASC`
     ).all() as Array<{ id: Id; type: DeckItemType; order: number }>;
@@ -4880,12 +5317,20 @@ export class CastRepository {
       return { type: 'lyric', themeId: lyric.theme_id };
     }
 
+    const talk = this.db
+      .prepare('SELECT theme_id FROM talks WHERE id = ?')
+      .get(id) as { theme_id: string | null } | undefined;
+    if (talk) {
+      return { type: 'talk', themeId: talk.theme_id };
+    }
+
     return null;
   }
 
   private resolveSlideOwnerInput(input: SlideCreateInput): (DeckOwnerRow & { id: Id }) | null {
-    if (input.presentationId && input.lyricId) return null;
-    const ownerId = input.presentationId ?? input.lyricId ?? null;
+    const providedIds = [input.presentationId, input.lyricId, input.talkId].filter(Boolean);
+    if (providedIds.length !== 1) return null;
+    const ownerId = input.presentationId ?? input.lyricId ?? input.talkId ?? null;
     if (!ownerId) return null;
 
     const owner = this.resolveDeckOwnerRow(ownerId);
@@ -4893,6 +5338,7 @@ export class CastRepository {
 
     if (owner.type === 'presentation' && input.presentationId) return { ...owner, id: input.presentationId };
     if (owner.type === 'lyric' && input.lyricId) return { ...owner, id: input.lyricId };
+    if (owner.type === 'talk' && input.talkId) return { ...owner, id: input.talkId };
     return null;
   }
 
@@ -4924,6 +5370,13 @@ export class CastRepository {
       notes: slide.notes,
       order: slide.order_index,
       elements: this.getSlideElementsBySlideId(slide.id),
+      scriptBlocks: owner.type === 'talk'
+        ? (this.getTalkScriptBlocksByIds(this.getTalkScriptBlockIdsBySlideIds([slide.id])).map((block) => ({
+          id: block.id,
+          text: block.text,
+          order: block.order,
+        })))
+        : undefined,
     }));
 
     return {
@@ -4959,6 +5412,7 @@ export class CastRepository {
         id: entry.id,
         presentationId: entry.presentationId,
         lyricId: entry.lyricId,
+        talkId: entry.talkId,
         order: entry.order,
       })),
     }));
@@ -5017,7 +5471,9 @@ export class CastRepository {
     upsertLibraryIds?: Id[];
     upsertPresentationIds?: Id[];
     upsertLyricIds?: Id[];
+    upsertTalkIds?: Id[];
     upsertSlideIds?: Id[];
+    upsertTalkScriptBlockIds?: Id[];
     upsertSlideElementIds?: Id[];
     upsertMediaAssetIds?: Id[];
     upsertOverlayIds?: Id[];
@@ -5027,7 +5483,9 @@ export class CastRepository {
     deletedLibraryIds?: Id[];
     deletedPresentationIds?: Id[];
     deletedLyricIds?: Id[];
+    deletedTalkIds?: Id[];
     deletedSlideIds?: Id[];
+    deletedTalkScriptBlockIds?: Id[];
     deletedSlideElementIds?: Id[];
     deletedMediaAssetIds?: Id[];
     deletedOverlayIds?: Id[];
@@ -5050,8 +5508,14 @@ export class CastRepository {
     if (spec.upsertLyricIds && spec.upsertLyricIds.length > 0) {
       patch.upserts.lyrics = this.getLyricsByIds(spec.upsertLyricIds);
     }
+    if (spec.upsertTalkIds && spec.upsertTalkIds.length > 0) {
+      patch.upserts.talks = this.getTalksByIds(spec.upsertTalkIds);
+    }
     if (spec.upsertSlideIds && spec.upsertSlideIds.length > 0) {
       patch.upserts.slides = this.getSlidesByIds(spec.upsertSlideIds);
+    }
+    if (spec.upsertTalkScriptBlockIds && spec.upsertTalkScriptBlockIds.length > 0) {
+      patch.upserts.talkScriptBlocks = this.getTalkScriptBlocksByIds(spec.upsertTalkScriptBlockIds);
     }
     if (spec.upsertSlideElementIds && spec.upsertSlideElementIds.length > 0) {
       patch.upserts.slideElements = this.getSlideElementsByIds(spec.upsertSlideElementIds);
@@ -5080,8 +5544,14 @@ export class CastRepository {
     if (spec.deletedLyricIds && spec.deletedLyricIds.length > 0) {
       patch.deletes.lyrics = [...spec.deletedLyricIds];
     }
+    if (spec.deletedTalkIds && spec.deletedTalkIds.length > 0) {
+      patch.deletes.talks = [...spec.deletedTalkIds];
+    }
     if (spec.deletedSlideIds && spec.deletedSlideIds.length > 0) {
       patch.deletes.slides = [...spec.deletedSlideIds];
+    }
+    if (spec.deletedTalkScriptBlockIds && spec.deletedTalkScriptBlockIds.length > 0) {
+      patch.deletes.talkScriptBlocks = [...spec.deletedTalkScriptBlockIds];
     }
     if (spec.deletedSlideElementIds && spec.deletedSlideElementIds.length > 0) {
       patch.deletes.slideElements = [...spec.deletedSlideElementIds];
@@ -5111,9 +5581,11 @@ export class CastRepository {
     const libraries = this.getLibraries();
     const presentations = this.getPresentations();
     const lyrics = this.getLyrics();
+    const talks = this.getTalks();
     const itemsById = new Map<Id, DeckItem>([
       ...presentations.map((deck) => [deck.id, deck] as const),
       ...lyrics.map((lyric) => [lyric.id, lyric] as const),
+      ...talks.map((talk) => [talk.id, talk] as const),
     ]);
     return libraries.map((library) => ({
       library,
@@ -5203,16 +5675,48 @@ export class CastRepository {
     })) as Lyric[];
   }
 
+  private getTalksByIds(ids: Id[]): Talk[] {
+    if (ids.length === 0) return [];
+    const placeholders = ids.map(() => '?').join(',');
+    const rows = this.db
+      .prepare(
+        `SELECT id, title, theme_id, collection_id, order_index, created_at, updated_at
+         FROM talks
+         WHERE id IN (${placeholders})
+         ORDER BY order_index ASC, created_at ASC`
+      )
+      .all(...ids) as Array<{
+      id: string;
+      title: string;
+      theme_id: string | null;
+      collection_id: string;
+      order_index: number;
+      created_at: string;
+      updated_at: string;
+    }>;
+    return rows.map((row) => buildDeckItem({
+      id: row.id,
+      title: row.title,
+      type: 'talk',
+      themeId: row.theme_id,
+      collectionId: row.collection_id,
+      order: row.order_index,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    })) as Talk[];
+  }
+
   private getSlidesByIds(ids: Id[]): Slide[] {
     if (ids.length === 0) return [];
     const placeholders = ids.map(() => '?').join(',');
     const rows = this.db
       .prepare(
-        `SELECT s.id, s.presentation_id, s.lyric_id, s.theme_id, s.overlay_id, s.stage_id, s.kind, s.width, s.height, s.notes, s.order_index, s.created_at, s.updated_at,
-                COALESCE(d.order_index, l.order_index) AS content_order
+        `SELECT s.id, s.presentation_id, s.lyric_id, s.talk_id, s.theme_id, s.overlay_id, s.stage_id, s.kind, s.width, s.height, s.notes, s.order_index, s.created_at, s.updated_at,
+                COALESCE(d.order_index, l.order_index, t.order_index) AS content_order
          FROM slides s
          LEFT JOIN presentations d ON d.id = s.presentation_id
          LEFT JOIN lyrics l ON l.id = s.lyric_id
+         LEFT JOIN talks t ON t.id = s.talk_id
          WHERE s.id IN (${placeholders})
          ORDER BY content_order ASC, s.order_index ASC`
       )
@@ -5220,6 +5724,7 @@ export class CastRepository {
         id: string;
         presentation_id: string | null;
         lyric_id: string | null;
+        talk_id: string | null;
         theme_id: string | null;
         overlay_id: string | null;
         stage_id: string | null;
@@ -5235,6 +5740,7 @@ export class CastRepository {
       id: row.id,
       presentationId: row.presentation_id,
       lyricId: row.lyric_id,
+      talkId: row.talk_id,
       themeId: row.theme_id,
       overlayId: row.overlay_id,
       stageId: row.stage_id,
@@ -5413,8 +5919,8 @@ export class CastRepository {
   ): void {
     this.db
       .prepare(
-        `INSERT INTO slides (id, presentation_id, lyric_id, theme_id, overlay_id, stage_id, kind, width, height, notes, order_index, created_at, updated_at)
-         VALUES (?, NULL, NULL, ?, ?, ?, ?, ?, ?, '', 0, ?, ?)`
+        `INSERT INTO slides (id, presentation_id, lyric_id, talk_id, theme_id, overlay_id, stage_id, kind, width, height, notes, order_index, created_at, updated_at)
+         VALUES (?, NULL, NULL, NULL, ?, ?, ?, ?, ?, ?, '', 0, ?, ?)`
       )
       .run(
         slideId,
@@ -5523,7 +6029,7 @@ export class CastRepository {
     }));
   }
 
-  private getSlideIdsForOwner(ownerColumn: 'presentation_id' | 'lyric_id', ownerId: Id): Id[] {
+  private getSlideIdsForOwner(ownerColumn: 'presentation_id' | 'lyric_id' | 'talk_id', ownerId: Id): Id[] {
     return (this.db
       .prepare(`SELECT id FROM slides WHERE ${ownerColumn} = ? ORDER BY order_index ASC`)
       .all(ownerId) as Array<{ id: string }>)
@@ -5535,6 +6041,15 @@ export class CastRepository {
     const placeholders = slideIds.map(() => '?').join(',');
     return (this.db
       .prepare(`SELECT id FROM slide_elements WHERE slide_id IN (${placeholders}) ORDER BY created_at ASC, id ASC`)
+      .all(...slideIds) as Array<{ id: string }>)
+      .map((row) => row.id);
+  }
+
+  private getTalkScriptBlockIdsBySlideIds(slideIds: Id[]): Id[] {
+    if (slideIds.length === 0) return [];
+    const placeholders = slideIds.map(() => '?').join(',');
+    return (this.db
+      .prepare(`SELECT id FROM talk_script_blocks WHERE slide_id IN (${placeholders}) ORDER BY order_index ASC, id ASC`)
       .all(...slideIds) as Array<{ id: string }>)
       .map((row) => row.id);
   }
@@ -5559,7 +6074,7 @@ export class CastRepository {
 
     for (const item of manifest.items) {
       if (!item?.id || !item.title) throw new Error('Invalid bundle item.');
-      if (item.type !== 'presentation' && item.type !== 'lyric') {
+      if (item.type !== 'presentation' && item.type !== 'lyric' && item.type !== 'talk') {
         throw new Error(`Unknown content item type: ${item.type}`);
       }
       if (item.themeId && !themeIds.has(item.themeId)) {
@@ -5574,6 +6089,9 @@ export class CastRepository {
       for (const slide of item.slides) {
         if (!slide?.id || !Array.isArray(slide.elements)) {
           throw new Error(`Invalid slide in ${item.title}.`);
+        }
+        if (slide.scriptBlocks !== undefined && !Array.isArray(slide.scriptBlocks)) {
+          throw new Error(`Invalid script blocks in ${item.title}.`);
         }
       }
     }
@@ -5883,24 +6401,53 @@ export class CastRepository {
     })) as Lyric[];
   }
 
+  private getTalks(): Talk[] {
+    const rows = this.db
+      .prepare(
+        'SELECT id, title, theme_id, collection_id, order_index, created_at, updated_at FROM talks ORDER BY order_index ASC, created_at ASC'
+      )
+      .all() as Array<{
+      id: string;
+      title: string;
+      theme_id: string | null;
+      collection_id: string;
+      order_index: number;
+      created_at: string;
+      updated_at: string;
+    }>;
+
+    return rows.map((row) => buildDeckItem({
+      id: row.id,
+      title: row.title,
+      type: 'talk',
+      themeId: row.theme_id,
+      collectionId: row.collection_id,
+      order: row.order_index,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at
+    })) as Talk[];
+  }
+
   private getSlides(): Slide[] {
-    // Only deck slides (presentation/lyric kind) flow through the snapshot.
+    // Only deck slides (presentation/lyric/talk kind) flow through the snapshot.
     // Theme/overlay/stage slides are surfaced via their owning container's
     // `elements` field instead.
     const rows = this.db
       .prepare(
-        `SELECT s.id, s.presentation_id, s.lyric_id, s.theme_id, s.overlay_id, s.stage_id, s.kind, s.width, s.height, s.notes, s.order_index, s.created_at, s.updated_at,
-                COALESCE(d.order_index, l.order_index) AS content_order
+        `SELECT s.id, s.presentation_id, s.lyric_id, s.talk_id, s.theme_id, s.overlay_id, s.stage_id, s.kind, s.width, s.height, s.notes, s.order_index, s.created_at, s.updated_at,
+                COALESCE(d.order_index, l.order_index, t.order_index) AS content_order
          FROM slides s
          LEFT JOIN presentations d ON d.id = s.presentation_id
          LEFT JOIN lyrics l ON l.id = s.lyric_id
-         WHERE s.presentation_id IS NOT NULL OR s.lyric_id IS NOT NULL
+         LEFT JOIN talks t ON t.id = s.talk_id
+         WHERE s.presentation_id IS NOT NULL OR s.lyric_id IS NOT NULL OR s.talk_id IS NOT NULL
          ORDER BY content_order ASC, s.order_index ASC`
       )
       .all() as Array<{
       id: string;
       presentation_id: string | null;
       lyric_id: string | null;
+      talk_id: string | null;
       theme_id: string | null;
       overlay_id: string | null;
       stage_id: string | null;
@@ -5917,6 +6464,7 @@ export class CastRepository {
       id: row.id,
       presentationId: row.presentation_id,
       lyricId: row.lyric_id,
+      talkId: row.talk_id,
       themeId: row.theme_id,
       overlayId: row.overlay_id,
       stageId: row.stage_id,
@@ -5938,7 +6486,8 @@ export class CastRepository {
          JOIN slides s ON s.id = se.slide_id
          LEFT JOIN presentations d ON d.id = s.presentation_id
          LEFT JOIN lyrics l ON l.id = s.lyric_id
-         ORDER BY COALESCE(d.order_index, l.order_index) ASC, s.order_index ASC, se.layer ASC, se.z_index ASC`
+         LEFT JOIN talks t ON t.id = s.talk_id
+         ORDER BY COALESCE(d.order_index, l.order_index, t.order_index) ASC, s.order_index ASC, se.layer ASC, se.z_index ASC`
       )
       .all() as Array<{
       id: string;
@@ -5970,6 +6519,63 @@ export class CastRepository {
       zIndex: row.z_index,
       layer: row.layer,
       payload: parseJson<SlideElementPayload>(row.payload_json),
+      createdAt: row.created_at,
+      updatedAt: row.updated_at
+    }));
+  }
+
+  private getTalkScriptBlocks(): TalkScriptBlock[] {
+    const rows = this.db
+      .prepare(
+        `SELECT b.id, b.slide_id, b.text, b.order_index, b.created_at, b.updated_at
+         FROM talk_script_blocks b
+         JOIN slides s ON s.id = b.slide_id
+         LEFT JOIN talks t ON t.id = s.talk_id
+         ORDER BY COALESCE(t.order_index, 0) ASC, s.order_index ASC, b.order_index ASC`
+      )
+      .all() as Array<{
+      id: string;
+      slide_id: string;
+      text: string;
+      order_index: number;
+      created_at: string;
+      updated_at: string;
+    }>;
+
+    return rows.map((row) => ({
+      id: row.id,
+      slideId: row.slide_id,
+      text: row.text,
+      order: row.order_index,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at
+    }));
+  }
+
+  private getTalkScriptBlocksByIds(ids: Id[]): TalkScriptBlock[] {
+    if (ids.length === 0) return [];
+    const placeholders = ids.map(() => '?').join(',');
+    const rows = this.db
+      .prepare(
+        `SELECT id, slide_id, text, order_index, created_at, updated_at
+         FROM talk_script_blocks
+         WHERE id IN (${placeholders})
+         ORDER BY order_index ASC`
+      )
+      .all(...ids) as Array<{
+      id: string;
+      slide_id: string;
+      text: string;
+      order_index: number;
+      created_at: string;
+      updated_at: string;
+    }>;
+
+    return rows.map((row) => ({
+      id: row.id,
+      slideId: row.slide_id,
+      text: row.text,
+      order: row.order_index,
       createdAt: row.created_at,
       updatedAt: row.updated_at
     }));
@@ -6028,13 +6634,14 @@ export class CastRepository {
   private getPlaylistEntries(groupId: Id): PlaylistEntry[] {
     const rows = this.db
       .prepare(
-        'SELECT id, group_id, presentation_id, lyric_id, order_index, created_at, updated_at FROM playlist_entries WHERE group_id = ? ORDER BY order_index ASC'
+        'SELECT id, group_id, presentation_id, lyric_id, talk_id, order_index, created_at, updated_at FROM playlist_entries WHERE group_id = ? ORDER BY order_index ASC'
       )
       .all(groupId) as Array<{
       id: string;
       group_id: string;
       presentation_id: string | null;
       lyric_id: string | null;
+      talk_id: string | null;
       order_index: number;
       created_at: string;
       updated_at: string;
@@ -6045,6 +6652,7 @@ export class CastRepository {
       groupId: row.group_id,
       presentationId: row.presentation_id,
       lyricId: row.lyric_id,
+      talkId: row.talk_id,
       order: row.order_index,
       createdAt: row.created_at,
       updatedAt: row.updated_at
@@ -6056,7 +6664,7 @@ export class CastRepository {
       const groups = this.getPlaylistGroups(playlist.id).map((group) => {
         const entries = this.getPlaylistEntries(group.id)
           .map((entry) => {
-            const itemId = entry.presentationId ?? entry.lyricId;
+            const itemId = entry.presentationId ?? entry.lyricId ?? entry.talkId;
             if (!itemId) return null;
             const item = itemsById.get(itemId);
             if (!item) return null;

--- a/app/database/store.ts
+++ b/app/database/store.ts
@@ -110,10 +110,13 @@ const COLLECTION_TABLE_BY_BIN: Record<CollectionBinKind, string> = {
 
 const DEFAULT_COLLECTION_NAME = 'Default Collection';
 
-const ITEM_TABLE_BY_TYPE: Record<CollectionItemType, string> = {
+// Media assets live in three split tables (image_assets/video_assets/audio_assets),
+// so they're resolved dynamically per id — see resolveItemTable below. Every
+// other item type maps statically.
+type StaticCollectionItemType = Exclude<CollectionItemType, 'media_asset'>;
+const ITEM_TABLE_BY_TYPE: Record<StaticCollectionItemType, string> = {
   presentation: 'presentations',
   lyric: 'lyrics',
-  media_asset: 'media_assets',
   theme: 'themes',
   overlay: 'overlays',
   stage: 'stages',
@@ -1810,11 +1813,8 @@ export class CastRepository {
   }
 
   setItemCollection(input: CollectionAssignmentInput): SnapshotPatch {
-    const itemTable = ITEM_TABLE_BY_TYPE[input.itemType];
-    const exists = this.db.prepare(`SELECT id FROM ${itemTable} WHERE id = ?`).get(input.itemId) as
-      | { id: string }
-      | undefined;
-    if (!exists) return this.buildPatch({});
+    const itemTable = this.resolveItemTable(input.itemType, input.itemId);
+    if (!itemTable) return this.buildPatch({});
 
     const targetBin = this.getCollectionBinKindByCollectionId(input.collectionId);
     if (!targetBin) {
@@ -1829,6 +1829,28 @@ export class CastRepository {
       .run(input.collectionId, nowIso(), input.itemId);
 
     return this.buildPatch(buildPatchSpecForItemType(input.itemType, input.itemId));
+  }
+
+  // Resolves the SQL table that holds a given collection item. Returns null
+  // when the item is missing, matching the previous "missing item → empty
+  // patch" behaviour. Media assets are spread across image/video/audio
+  // tables since the v11 schema split, so we probe each one until we find
+  // it; everything else maps statically.
+  private resolveItemTable(itemType: CollectionItemType, itemId: Id): string | null {
+    if (itemType === 'media_asset') {
+      for (const table of MEDIA_ASSET_TABLES) {
+        const row = this.db.prepare(`SELECT id FROM ${table} WHERE id = ?`).get(itemId) as
+          | { id: string }
+          | undefined;
+        if (row) return table;
+      }
+      return null;
+    }
+    const table = ITEM_TABLE_BY_TYPE[itemType];
+    const row = this.db.prepare(`SELECT id FROM ${table} WHERE id = ?`).get(itemId) as
+      | { id: string }
+      | undefined;
+    return row ? table : null;
   }
 
   private reassignItemsForCollection(

--- a/app/main/ipc.ts
+++ b/app/main/ipc.ts
@@ -26,7 +26,10 @@ import type {
   ThemeUpdateInput,
   SlideCreateInput,
   SlideNotesUpdateInput,
-  SlideOrderUpdateInput
+  SlideOrderUpdateInput,
+  TalkScriptBlockCreateInput,
+  TalkScriptBlockOrderUpdateInput,
+  TalkScriptBlockUpdateInput
 } from '@core/types';
 import { getInlineWindowMenuItems, popupInlineWindowMenu, updateApplicationMenu } from './application-menu';
 import type { AppUpdater } from './app-updater';
@@ -204,10 +207,15 @@ export const registerIpcHandlers = (
   safeHandle(IPC.createLyric, (_event, title: string) =>
     repo.createLyric(title)
   );
+  safeHandle(IPC.createTalk, (_event, title: string) => repo.createTalk(title));
   safeHandle(IPC.createSlide, (_event, input: SlideCreateInput) => repo.createSlide(input));
   safeHandle(IPC.duplicateSlide, (_event, slideId: Id) => repo.duplicateSlide(slideId));
   safeHandle(IPC.deleteSlide, (_event, slideId: Id) => repo.deleteSlide(slideId));
   safeHandle(IPC.updateSlideNotes, (_event, input: SlideNotesUpdateInput) => repo.updateSlideNotes(input));
+  safeHandle(IPC.createTalkScriptBlock, (_event, input: TalkScriptBlockCreateInput) => repo.createTalkScriptBlock(input));
+  safeHandle(IPC.updateTalkScriptBlock, (_event, input: TalkScriptBlockUpdateInput) => repo.updateTalkScriptBlock(input));
+  safeHandle(IPC.deleteTalkScriptBlock, (_event, id: Id) => repo.deleteTalkScriptBlock(id));
+  safeHandle(IPC.setTalkScriptBlockOrder, (_event, input: TalkScriptBlockOrderUpdateInput) => repo.setTalkScriptBlockOrder(input));
   safeHandle(IPC.setSlideOrder, (_event, input: SlideOrderUpdateInput) => repo.setSlideOrder(input));
   safeHandle(IPC.setLibraryOrder, (_event, libraryId: Id, newOrder: number) => repo.setLibraryOrder(libraryId, newOrder));
   safeHandle(IPC.setPlaylistOrder, (_event, playlistId: Id, newOrder: number) => repo.setPlaylistOrder(playlistId, newOrder));
@@ -265,11 +273,13 @@ export const registerIpcHandlers = (
   safeHandle(IPC.renamePlaylist, (_event, id: Id, name: string) => repo.renamePlaylist(id, name));
   safeHandle(IPC.renamePresentation, (_event, id: Id, title: string) => repo.renamePresentation(id, title));
   safeHandle(IPC.renameLyric, (_event, id: Id, title: string) => repo.renameLyric(id, title));
+  safeHandle(IPC.renameTalk, (_event, id: Id, title: string) => repo.renameTalk(id, title));
   safeHandle(IPC.deleteLibrary, (_event, id: Id) => repo.deleteLibrary(id));
   safeHandle(IPC.deletePlaylist, (_event, id: Id) => repo.deletePlaylist(id));
   safeHandle(IPC.deletePlaylistGroup, (_event, id: Id) => repo.deletePlaylistGroup(id));
   safeHandle(IPC.deletePresentation, (_event, id: Id) => repo.deletePresentation(id));
   safeHandle(IPC.deleteLyric, (_event, id: Id) => repo.deleteLyric(id));
+  safeHandle(IPC.deleteTalk, (_event, id: Id) => repo.deleteTalk(id));
   safeHandle(IPC.createCollection, (_event, input: CollectionCreateInput) => repo.createCollection(input));
   safeHandle(IPC.renameCollection, (_event, input: CollectionRenameInput) => repo.renameCollection(input));
   safeHandle(IPC.deleteCollection, (_event, input: CollectionDeleteInput) => repo.deleteCollection(input));

--- a/app/main/ipc.ts
+++ b/app/main/ipc.ts
@@ -300,6 +300,7 @@ export const registerIpcHandlers = (
       height: number;
       telemetry?: NdiFrameTelemetry;
     }) => {
+    const mainReceivedAtMs = Date.now();
     const ackName = payload?.name;
     try {
       assertTrustedIpcSender(event);
@@ -313,7 +314,10 @@ export const registerIpcHandlers = (
       if (!(buffer instanceof ArrayBuffer)) {
         throw new Error('NDI frame payload must include an ArrayBuffer');
       }
-      ndiService.receiveFrame(name, new Uint8Array(buffer), width, height, telemetry);
+      const stampedTelemetry: NdiFrameTelemetry | undefined = telemetry
+        ? { ...telemetry, mainReceivedAtMs }
+        : undefined;
+      ndiService.receiveFrame(name, new Uint8Array(buffer), width, height, stampedTelemetry);
     } catch (error) {
       console.error(`[IPC ${IPC.sendNdiFrame}]`, error);
     } finally {

--- a/app/main/ndi/ndi-host.ts
+++ b/app/main/ndi/ndi-host.ts
@@ -47,15 +47,19 @@ parentPort.on('message', (event: { data: NdiHostCommand }) => {
     case 'updateOutputConfig':
       service.updateOutputConfig(cmd.name, cmd.config);
       break;
-    case 'frame':
+    case 'frame': {
+      const stampedTelemetry = cmd.telemetry
+        ? { ...cmd.telemetry, hostReceivedAtMs: Date.now() }
+        : undefined;
       service.receiveFrame(
         cmd.name,
         new Uint8Array(cmd.buffer),
         cmd.width,
         cmd.height,
-        cmd.telemetry,
+        stampedTelemetry,
       );
       break;
+    }
     case 'audio':
       service.receiveAudioFrame(
         cmd.name,

--- a/app/main/ndi/ndi-native-module.ts
+++ b/app/main/ndi/ndi-native-module.ts
@@ -24,6 +24,12 @@ export interface NdiNativeModule {
     samplesPerChannel: number,
   ) => void;
   getSenderConnections?: (senderName: string, timeoutMs?: number) => number;
+  // Polls the NDI tally signal from receivers. Optional because older NDI
+  // runtimes / older builds of the addon don't expose it.
+  getSenderTally?: (
+    senderName: string,
+    timeoutMs?: number,
+  ) => { onProgram: boolean; onPreview: boolean } | null;
   destroySender: (senderName?: string) => void;
   getRuntimeInfo?: () => NdiRuntimeInfo;
   getAddonInfo?: () => { path: string | null };

--- a/app/main/ndi/ndi-service-proxy.ts
+++ b/app/main/ndi/ndi-service-proxy.ts
@@ -103,7 +103,10 @@ export class NdiServiceProxy implements NdiServiceLike {
     // utilityProcess.postMessage only documents MessagePort transfer support;
     // attempting ArrayBuffer transfer can throw before the NDI host receives the
     // frame, leaving the sender advertised with zero frame diagnostics.
-    this.send({ type: 'frame', name, buffer, width, height, telemetry });
+    const stamped: NdiFrameTelemetry | undefined = telemetry
+      ? { ...telemetry, proxyForwardedAtMs: Date.now() }
+      : undefined;
+    this.send({ type: 'frame', name, buffer, width, height, telemetry: stamped });
   }
 
   receiveAudioFrame(

--- a/app/main/ndi/ndi-service.ts
+++ b/app/main/ndi/ndi-service.ts
@@ -8,6 +8,8 @@ import type {
   NdiOutputConfigMap,
   NdiOutputName,
   NdiOutputState,
+  NdiPipelineLatencyDiagnostics,
+  NdiPipelineStageStats,
   NdiSenderAudioDiagnostics,
   NdiSenderPerformanceDiagnostics,
   NdiSourceStatus,
@@ -57,6 +59,26 @@ export interface BlackoutOptions {
   destroy?: boolean;
 }
 
+interface PipelineSampleBuffers {
+  frameAgeAtWire: RollingSampleBuffer;
+  signatureToWire: RollingSampleBuffer;
+  captureToRendererSend: RollingSampleBuffer;
+  rendererToMainIpc: RollingSampleBuffer;
+  mainHandler: RollingSampleBuffer;
+  mainToHostIpc: RollingSampleBuffer;
+  hostToNative: RollingSampleBuffer;
+}
+
+interface PipelineLastSamples {
+  frameAgeAtWire: number;
+  signatureToWire: number;
+  captureToRendererSend: number;
+  rendererToMainIpc: number;
+  mainHandler: number;
+  mainToHostIpc: number;
+  hostToNative: number;
+}
+
 interface SenderState {
   diagnostics: NdiActiveSenderDiagnostics;
   outputName: NdiOutputName;
@@ -70,6 +92,8 @@ interface SenderState {
   sendDurationRolling: RollingAverage;
   sendDurationSamples: RollingSampleBuffer;
   sendIntervalSamples: RollingSampleBuffer;
+  pipelineSamples: PipelineSampleBuffers;
+  pipelineLastSamples: PipelineLastSamples;
 }
 
 class RollingAverage {
@@ -261,7 +285,7 @@ export class NdiService {
     this.sourceStatus = 'live';
     this.lastError = null;
 
-    this.sendFrame(name, rgba, width, height, false);
+    this.sendFrame(name, rgba, width, height, false, telemetry);
     this.queueDiagnosticsEmit();
   }
 
@@ -509,6 +533,7 @@ export class NdiService {
           withAlpha: config.withAlpha,
           asyncVideoSend: this.asyncVideoSend,
           connectionCount: null,
+          tally: null,
           startedAtMs: Date.now(),
           performance: createEmptySenderPerformanceDiagnostics(),
           audio: createEmptySenderAudioDiagnostics(),
@@ -524,6 +549,16 @@ export class NdiService {
         sendDurationRolling: new RollingAverage(),
         sendDurationSamples: new RollingSampleBuffer(SEND_LATENCY_SAMPLE_WINDOW),
         sendIntervalSamples: new RollingSampleBuffer(SEND_LATENCY_SAMPLE_WINDOW),
+        pipelineSamples: {
+          frameAgeAtWire: new RollingSampleBuffer(SEND_LATENCY_SAMPLE_WINDOW),
+          signatureToWire: new RollingSampleBuffer(SEND_LATENCY_SAMPLE_WINDOW),
+          captureToRendererSend: new RollingSampleBuffer(SEND_LATENCY_SAMPLE_WINDOW),
+          rendererToMainIpc: new RollingSampleBuffer(SEND_LATENCY_SAMPLE_WINDOW),
+          mainHandler: new RollingSampleBuffer(SEND_LATENCY_SAMPLE_WINDOW),
+          mainToHostIpc: new RollingSampleBuffer(SEND_LATENCY_SAMPLE_WINDOW),
+          hostToNative: new RollingSampleBuffer(SEND_LATENCY_SAMPLE_WINDOW),
+        },
+        pipelineLastSamples: createEmptyPipelineLastSamples(),
       });
       this.lastError = null;
     } catch (error) {
@@ -629,7 +664,14 @@ export class NdiService {
     return rgba.byteLength === expectedLength;
   }
 
-  private sendFrame(name: NdiOutputName, rgba: Uint8Array, width: number, height: number, replayed: boolean): void {
+  private sendFrame(
+    name: NdiOutputName,
+    rgba: Uint8Array,
+    width: number,
+    height: number,
+    replayed: boolean,
+    telemetry?: NdiFrameTelemetry,
+  ): void {
     if (!this.module) return;
     const sender = this.senders.get(name);
     if (!sender) return;
@@ -637,9 +679,14 @@ export class NdiService {
     try {
       const connectionCount = this.module.getSenderConnections?.(sender.diagnostics.senderName, 0) ?? null;
       sender.diagnostics.connectionCount = typeof connectionCount === 'number' && connectionCount >= 0 ? connectionCount : null;
+      const tally = this.module.getSenderTally?.(sender.diagnostics.senderName, 0) ?? null;
+      sender.diagnostics.tally = tally && typeof tally === 'object' && 'onProgram' in tally && 'onPreview' in tally
+        ? { onProgram: !!tally.onProgram, onPreview: !!tally.onPreview }
+        : null;
       const startedAt = performance.now();
       this.module.sendRgbaFrame(sender.diagnostics.senderName, rgba, width, height);
       const duration = performance.now() - startedAt;
+      const nativeSentAtMs = Date.now();
       sender.diagnostics.performance.avgSendDurationMs = sender.sendDurationRolling.push(duration);
       sender.sendDurationSamples.push(duration);
       if (sender.lastSendAt > 0) {
@@ -658,6 +705,10 @@ export class NdiService {
       sender.diagnostics.performance.framesSent += 1;
       if (replayed) {
         sender.diagnostics.performance.framesReplayed += 1;
+      }
+
+      if (telemetry && !replayed) {
+        recordPipelineSpans(sender, telemetry, nativeSentAtMs);
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -797,6 +848,109 @@ function createEmptySenderPerformanceDiagnostics(): NdiSenderPerformanceDiagnost
     minFrameBytes: 0,
     maxFrameBytes: 0,
     blackoutFramesSent: 0,
+    pipeline: createEmptyPipelineLatency(),
+  };
+}
+
+function createEmptyPipelineStageStats(): NdiPipelineStageStats {
+  return { p50: 0, p95: 0, lastMs: 0, count: 0 };
+}
+
+function createEmptyPipelineLatency(): NdiPipelineLatencyDiagnostics {
+  return {
+    frameAgeAtWire: createEmptyPipelineStageStats(),
+    signatureToWire: createEmptyPipelineStageStats(),
+    captureToRendererSend: createEmptyPipelineStageStats(),
+    rendererToMainIpc: createEmptyPipelineStageStats(),
+    mainHandler: createEmptyPipelineStageStats(),
+    mainToHostIpc: createEmptyPipelineStageStats(),
+    hostToNative: createEmptyPipelineStageStats(),
+  };
+}
+
+function createEmptyPipelineLastSamples(): PipelineLastSamples {
+  return {
+    frameAgeAtWire: 0,
+    signatureToWire: 0,
+    captureToRendererSend: 0,
+    rendererToMainIpc: 0,
+    mainHandler: 0,
+    mainToHostIpc: 0,
+    hostToNative: 0,
+  };
+}
+
+// Record a sample only when the span is non-negative — clock skew between
+// processes (Date.now() reordering on resume, NTP step) can produce
+// nonsensical negatives that would skew percentiles.
+function pushSpan(buffer: RollingSampleBuffer, valueMs: number): number | null {
+  if (!Number.isFinite(valueMs) || valueMs < 0) return null;
+  buffer.push(valueMs);
+  return valueMs;
+}
+
+function recordPipelineSpans(
+  sender: SenderState,
+  telemetry: NdiFrameTelemetry,
+  nativeSentAtMs: number,
+): void {
+  const {
+    signatureChangedAtMs,
+    captureStartedAtMs,
+    rendererSendAtMs,
+    mainReceivedAtMs,
+    proxyForwardedAtMs,
+    hostReceivedAtMs,
+  } = telemetry;
+  const samples = sender.pipelineSamples;
+  const last = sender.pipelineLastSamples;
+
+  if (typeof captureStartedAtMs === 'number') {
+    const v = pushSpan(samples.frameAgeAtWire, nativeSentAtMs - captureStartedAtMs);
+    if (v !== null) last.frameAgeAtWire = v;
+    if (typeof rendererSendAtMs === 'number') {
+      const c = pushSpan(samples.captureToRendererSend, rendererSendAtMs - captureStartedAtMs);
+      if (c !== null) last.captureToRendererSend = c;
+    }
+  }
+  if (typeof signatureChangedAtMs === 'number') {
+    const v = pushSpan(samples.signatureToWire, nativeSentAtMs - signatureChangedAtMs);
+    if (v !== null) last.signatureToWire = v;
+  }
+  if (typeof rendererSendAtMs === 'number' && typeof mainReceivedAtMs === 'number') {
+    const v = pushSpan(samples.rendererToMainIpc, mainReceivedAtMs - rendererSendAtMs);
+    if (v !== null) last.rendererToMainIpc = v;
+  }
+  if (typeof mainReceivedAtMs === 'number' && typeof proxyForwardedAtMs === 'number') {
+    const v = pushSpan(samples.mainHandler, proxyForwardedAtMs - mainReceivedAtMs);
+    if (v !== null) last.mainHandler = v;
+  }
+  if (typeof proxyForwardedAtMs === 'number' && typeof hostReceivedAtMs === 'number') {
+    const v = pushSpan(samples.mainToHostIpc, hostReceivedAtMs - proxyForwardedAtMs);
+    if (v !== null) last.mainToHostIpc = v;
+  }
+  if (typeof hostReceivedAtMs === 'number') {
+    const v = pushSpan(samples.hostToNative, nativeSentAtMs - hostReceivedAtMs);
+    if (v !== null) last.hostToNative = v;
+  }
+
+  const pipeline = sender.diagnostics.performance.pipeline;
+  pipeline.frameAgeAtWire = computeStageStats(samples.frameAgeAtWire, last.frameAgeAtWire);
+  pipeline.signatureToWire = computeStageStats(samples.signatureToWire, last.signatureToWire);
+  pipeline.captureToRendererSend = computeStageStats(samples.captureToRendererSend, last.captureToRendererSend);
+  pipeline.rendererToMainIpc = computeStageStats(samples.rendererToMainIpc, last.rendererToMainIpc);
+  pipeline.mainHandler = computeStageStats(samples.mainHandler, last.mainHandler);
+  pipeline.mainToHostIpc = computeStageStats(samples.mainToHostIpc, last.mainToHostIpc);
+  pipeline.hostToNative = computeStageStats(samples.hostToNative, last.hostToNative);
+}
+
+function computeStageStats(buffer: RollingSampleBuffer, lastMs: number): NdiPipelineStageStats {
+  const sorted = buffer.snapshot().sort((a, b) => a - b);
+  return {
+    p50: percentile(sorted, 50),
+    p95: percentile(sorted, 95),
+    lastMs,
+    count: buffer.size,
   };
 }
 
@@ -815,7 +969,23 @@ function createEmptySenderAudioDiagnostics(): NdiSenderAudioDiagnostics {
 function cloneSenderDiagnostics(diagnostics: NdiActiveSenderDiagnostics): NdiActiveSenderDiagnostics {
   return {
     ...diagnostics,
-    performance: { ...diagnostics.performance },
+    tally: diagnostics.tally ? { ...diagnostics.tally } : null,
+    performance: {
+      ...diagnostics.performance,
+      pipeline: clonePipelineLatency(diagnostics.performance.pipeline),
+    },
     audio: { ...diagnostics.audio },
+  };
+}
+
+function clonePipelineLatency(pipeline: NdiPipelineLatencyDiagnostics): NdiPipelineLatencyDiagnostics {
+  return {
+    frameAgeAtWire: { ...pipeline.frameAgeAtWire },
+    signatureToWire: { ...pipeline.signatureToWire },
+    captureToRendererSend: { ...pipeline.captureToRendererSend },
+    rendererToMainIpc: { ...pipeline.rendererToMainIpc },
+    mainHandler: { ...pipeline.mainHandler },
+    mainToHostIpc: { ...pipeline.mainToHostIpc },
+    hostToNative: { ...pipeline.hostToNative },
   };
 }

--- a/app/main/preload.ts
+++ b/app/main/preload.ts
@@ -131,7 +131,10 @@ const api = {
     // Use ordinary IPC cloning for frame delivery. Electron's renderer
     // transfer-list path rejects ArrayBuffer here, which prevents frames from
     // reaching main and leaves NDI diagnostics stuck at zero.
-    ipcRenderer.send(IPC.sendNdiFrame, { name, buffer, width, height, telemetry });
+    const stamped: NdiFrameTelemetry | undefined = telemetry
+      ? { ...telemetry, rendererSendAtMs: Date.now() }
+      : undefined;
+    ipcRenderer.send(IPC.sendNdiFrame, { name, buffer, width, height, telemetry: stamped });
   },
   sendNdiAudio: (
     name: NdiOutputName,

--- a/app/main/preload.ts
+++ b/app/main/preload.ts
@@ -31,7 +31,10 @@ import type {
   ThemeUpdateInput,
   SlideCreateInput,
   SlideNotesUpdateInput,
-  SlideOrderUpdateInput
+  SlideOrderUpdateInput,
+  TalkScriptBlockCreateInput,
+  TalkScriptBlockOrderUpdateInput,
+  TalkScriptBlockUpdateInput
 } from '@core/types';
 
 const api = {
@@ -73,10 +76,15 @@ const api = {
   moveDeckItem: (id: Id, direction: 'up' | 'down') => ipcRenderer.invoke(IPC.moveDeckItem, id, direction),
   createPresentation: (title: string) => ipcRenderer.invoke(IPC.createPresentation, title),
   createLyric: (title: string) => ipcRenderer.invoke(IPC.createLyric, title),
+  createTalk: (title: string) => ipcRenderer.invoke(IPC.createTalk, title),
   createSlide: (input: SlideCreateInput) => ipcRenderer.invoke(IPC.createSlide, input),
   duplicateSlide: (slideId: Id) => ipcRenderer.invoke(IPC.duplicateSlide, slideId),
   deleteSlide: (slideId: Id) => ipcRenderer.invoke(IPC.deleteSlide, slideId),
   updateSlideNotes: (input: SlideNotesUpdateInput) => ipcRenderer.invoke(IPC.updateSlideNotes, input),
+  createTalkScriptBlock: (input: TalkScriptBlockCreateInput) => ipcRenderer.invoke(IPC.createTalkScriptBlock, input),
+  updateTalkScriptBlock: (input: TalkScriptBlockUpdateInput) => ipcRenderer.invoke(IPC.updateTalkScriptBlock, input),
+  deleteTalkScriptBlock: (id: Id) => ipcRenderer.invoke(IPC.deleteTalkScriptBlock, id),
+  setTalkScriptBlockOrder: (input: TalkScriptBlockOrderUpdateInput) => ipcRenderer.invoke(IPC.setTalkScriptBlockOrder, input),
   setSlideOrder: (input: SlideOrderUpdateInput) => ipcRenderer.invoke(IPC.setSlideOrder, input),
   setLibraryOrder: (libraryId: Id, newOrder: number) => ipcRenderer.invoke(IPC.setLibraryOrder, libraryId, newOrder),
   setPlaylistOrder: (playlistId: Id, newOrder: number) => ipcRenderer.invoke(IPC.setPlaylistOrder, playlistId, newOrder),
@@ -115,11 +123,13 @@ const api = {
   renamePlaylist: (id: Id, name: string) => ipcRenderer.invoke(IPC.renamePlaylist, id, name),
   renamePresentation: (id: Id, title: string) => ipcRenderer.invoke(IPC.renamePresentation, id, title),
   renameLyric: (id: Id, title: string) => ipcRenderer.invoke(IPC.renameLyric, id, title),
+  renameTalk: (id: Id, title: string) => ipcRenderer.invoke(IPC.renameTalk, id, title),
   deleteLibrary: (id: Id) => ipcRenderer.invoke(IPC.deleteLibrary, id),
   deletePlaylist: (id: Id) => ipcRenderer.invoke(IPC.deletePlaylist, id),
   deletePlaylistGroup: (id: Id) => ipcRenderer.invoke(IPC.deletePlaylistGroup, id),
   deletePresentation: (id: Id) => ipcRenderer.invoke(IPC.deletePresentation, id),
   deleteLyric: (id: Id) => ipcRenderer.invoke(IPC.deleteLyric, id),
+  deleteTalk: (id: Id) => ipcRenderer.invoke(IPC.deleteTalk, id),
   setNdiOutputEnabled: (name: NdiOutputName, enabled: boolean) =>
     ipcRenderer.invoke(IPC.setNdiOutputEnabled, name, enabled),
   getNdiOutputState: () => ipcRenderer.invoke(IPC.getNdiOutputState),

--- a/app/renderer/components/display/entity-icon.tsx
+++ b/app/renderer/components/display/entity-icon.tsx
@@ -1,5 +1,5 @@
 import type { MediaAsset, MediaAssetType, DeckItem, DeckItemType } from '@core/types';
-import { Film, Image, Mic, Music, Presentation } from 'lucide-react';
+import { FileText, Film, Image, Mic, Music, Presentation } from 'lucide-react';
 
 // ─── Media Asset Icon ────────────────────────────────
 
@@ -38,6 +38,9 @@ export function DeckItemIcon({ entity, size = 14, strokeWidth = 1.75, className 
 
   if (entityType === 'lyric') {
     return <Music size={size} strokeWidth={strokeWidth} className={className} />;
+  }
+  if (entityType === 'talk') {
+    return <FileText size={size} strokeWidth={strokeWidth} className={className} />;
   }
 
   return <Presentation size={size} strokeWidth={strokeWidth} className={className} />;

--- a/app/renderer/contexts/navigation-context.tsx
+++ b/app/renderer/contexts/navigation-context.tsx
@@ -260,7 +260,7 @@ export function NavigationProvider({ children }: { children: ReactNode }) {
     await runOperation('Creating deck...', async () => {
       const previousIds = new Set(deckItems.map((item) => item.id));
       const next = await mutatePatch(() => window.castApi.createPresentation('New Presentation'));
-      const createdId = findCreatedId(previousIds, [...next.presentations, ...next.lyrics].map((item) => item.id));
+      const createdId = findCreatedId(previousIds, [...next.presentations, ...next.lyrics, ...next.talks].map((item) => item.id));
       if (!createdId) return;
       await mutatePatch(() => window.castApi.createSlide({ presentationId: createdId }));
       setCurrentDrawerDeckItemId(createdId);
@@ -274,7 +274,7 @@ export function NavigationProvider({ children }: { children: ReactNode }) {
     await runOperation('Creating lyric...', async () => {
       const previousIds = new Set(deckItems.map((item) => item.id));
       const next = await mutatePatch(() => window.castApi.createLyric('New Lyric'));
-      const createdId = findCreatedId(previousIds, [...next.presentations, ...next.lyrics].map((item) => item.id));
+      const createdId = findCreatedId(previousIds, [...next.presentations, ...next.lyrics, ...next.talks].map((item) => item.id));
       if (!createdId) return;
       await mutatePatch(() => window.castApi.createSlide({ lyricId: createdId }));
       setCurrentDrawerDeckItemId(createdId);
@@ -288,26 +288,30 @@ export function NavigationProvider({ children }: { children: ReactNode }) {
   // with a chosen name, then optionally applies a theme and adds it to a group
   // — all atomic from the user's perspective (one click of the dialog's New button).
   const createDeckItem = useCallback(async (input: {
-    kind: 'presentation' | 'lyric';
+    kind: 'presentation' | 'lyric' | 'talk';
     name: string;
     themeId?: Id;
     groupId?: Id;
   }) => {
-    const trimmedName = input.name.trim() || (input.kind === 'lyric' ? 'New Lyric' : 'New Presentation');
-    const labelKind = input.kind === 'lyric' ? 'lyric' : 'deck';
+    const trimmedName = input.name.trim() || (input.kind === 'lyric' ? 'New Lyric' : input.kind === 'talk' ? 'New Talk' : 'New Presentation');
+    const labelKind = input.kind === 'lyric' ? 'lyric' : input.kind === 'talk' ? 'talk' : 'deck';
 
     await runOperation(`Creating ${labelKind}...`, async () => {
       const previousIds = new Set(deckItems.map((item) => item.id));
       const next = input.kind === 'lyric'
         ? await mutatePatch(() => window.castApi.createLyric(trimmedName))
-        : await mutatePatch(() => window.castApi.createPresentation(trimmedName));
-      const createdId = findCreatedId(previousIds, [...next.presentations, ...next.lyrics].map((item) => item.id));
+        : input.kind === 'talk'
+          ? await mutatePatch(() => window.castApi.createTalk(trimmedName))
+          : await mutatePatch(() => window.castApi.createPresentation(trimmedName));
+      const createdId = findCreatedId(previousIds, [...next.presentations, ...next.lyrics, ...next.talks].map((item) => item.id));
       if (!createdId) return;
 
       await mutatePatch(() => (
         input.kind === 'lyric'
           ? window.castApi.createSlide({ lyricId: createdId })
-          : window.castApi.createSlide({ presentationId: createdId })
+          : input.kind === 'talk'
+            ? window.castApi.createSlide({ talkId: createdId })
+            : window.castApi.createSlide({ presentationId: createdId })
       ));
 
       if (input.themeId) {

--- a/app/renderer/contexts/slide-context.tsx
+++ b/app/renderer/contexts/slide-context.tsx
@@ -1,6 +1,6 @@
 import { createContext, useCallback, useContext, useMemo, type ReactNode } from 'react';
-import { getSlideDeckItemId } from '@core/deck-items';
-import type { AppSnapshot, Id, Slide, SlideElement } from '@core/types';
+import { getSlideDeckItemId, isTalkDeckItem } from '@core/deck-items';
+import type { AppSnapshot, Id, Slide, SlideElement, TalkScriptBlock } from '@core/types';
 import { clamp, sortSlides } from '../utils/slides';
 import { useIndexedSelection } from '../hooks/use-indexed-selection';
 import { useCast } from './app-context';
@@ -16,6 +16,8 @@ interface SlideContextValue {
   liveElements: SlideElement[];
   nextLiveSlide: Slide | null;
   nextLiveElements: SlideElement[];
+  liveTalkScriptBlock: TalkScriptBlock | null;
+  liveTalkScriptProgress: string | null;
   slideElementsById: Map<Id, SlideElement[]>;
   isOutputArmedOnCurrent: boolean;
   setCurrentSlideIndex: (idx: number) => void;
@@ -54,11 +56,12 @@ export function SlideProvider({ children }: { children: ReactNode }) {
     selectPlaylistEntry: selectPlaylistEntryInNavigation,
     selectPlaylistDeckItem: selectPlaylistDeckItemInNavigation,
   } = useNavigation();
-  const { slidesByDeckItemId, slideElementsBySlideId } = useProjectContent();
+  const { deckItemsById, slidesByDeckItemId, slideElementsBySlideId, talkScriptBlocksBySlideId } = useProjectContent();
 
   const playlistSelection = useIndexedSelection();
   const drawerSelection = useIndexedSelection();
   const liveSelection = useIndexedSelection();
+  const talkScriptSelection = useIndexedSelection();
 
   const slides = useMemo(() => {
     if (!currentDeckItemId) return [];
@@ -92,6 +95,7 @@ export function SlideProvider({ children }: { children: ReactNode }) {
   const currentSlide = slides[currentSlideIndex] ?? null;
   const liveSlide = outputSlides[liveSlideIndex] ?? null;
   const nextLiveSlide = liveSlideIndex >= 0 ? outputSlides[liveSlideIndex + 1] ?? null : null;
+  const liveOutputDeckItem = currentOutputDeckItemId ? deckItemsById.get(currentOutputDeckItemId) ?? null : null;
 
   const liveElements = useMemo(() => {
     if (!liveSlide) return [];
@@ -102,6 +106,32 @@ export function SlideProvider({ children }: { children: ReactNode }) {
     if (!nextLiveSlide) return [];
     return slideElementsBySlideId.get(nextLiveSlide.id) ?? [];
   }, [nextLiveSlide, slideElementsBySlideId]);
+
+  const liveTalkScriptBlocks = useMemo(() => (
+    liveSlide ? talkScriptBlocksBySlideId.get(liveSlide.id) ?? [] : []
+  ), [liveSlide, talkScriptBlocksBySlideId]);
+
+  const liveTalkScriptBlockIndex = useMemo(() => {
+    if (!liveSlide || liveTalkScriptBlocks.length === 0) return NO_SLIDE_SELECTED;
+    return resolveSlideIndex(liveSlide.id, talkScriptSelection.indices, liveTalkScriptBlocks.length);
+  }, [liveSlide, liveTalkScriptBlocks.length, talkScriptSelection.indices]);
+
+  const liveTalkScriptBlock = isTalkDeckItem(liveOutputDeckItem) && liveTalkScriptBlockIndex >= 0
+    ? liveTalkScriptBlocks[liveTalkScriptBlockIndex] ?? null
+    : null;
+  const liveTalkScriptProgress = liveTalkScriptBlock
+    ? `${liveTalkScriptBlockIndex + 1} / ${liveTalkScriptBlocks.length}`
+    : null;
+
+  const setLiveTalkScriptIndexForSlide = useCallback((slide: Slide | null, mode: 'first' | 'last' = 'first') => {
+    if (!slide) return;
+    const blocks = talkScriptBlocksBySlideId.get(slide.id) ?? [];
+    if (blocks.length === 0) {
+      talkScriptSelection.update(slide.id, NO_SLIDE_SELECTED);
+      return;
+    }
+    talkScriptSelection.update(slide.id, mode === 'last' ? blocks.length - 1 : 0);
+  }, [talkScriptBlocksBySlideId, talkScriptSelection]);
 
   const slideElementsById = useMemo(() => {
     const bySlide = new Map<Id, SlideElement[]>();
@@ -171,6 +201,7 @@ export function SlideProvider({ children }: { children: ReactNode }) {
     updateVisibleSelectedSlideIndex(selectionKey, nextIndex);
     if (!canDriveOutput || !currentPlaylistEntryId) return;
     liveSelection.update(currentPlaylistEntryId, nextIndex);
+    setLiveTalkScriptIndexForSlide(slides[nextIndex] ?? null, 'first');
     armOutputPlaylistEntry(currentPlaylistEntryId);
     setStatusText(`Live slide ${nextIndex + 1}`);
   }, [
@@ -180,7 +211,9 @@ export function SlideProvider({ children }: { children: ReactNode }) {
     currentDeckItemId,
     isDetachedDeckBrowser,
     setStatusText,
+    setLiveTalkScriptIndexForSlide,
     slides.length,
+    slides,
     liveSelection.update,
     updateVisibleSelectedSlideIndex,
   ]);
@@ -188,6 +221,7 @@ export function SlideProvider({ children }: { children: ReactNode }) {
   const takeSlide = useCallback(() => {
     if (!canDriveOutput || !currentPlaylistEntryId || slides.length === 0 || currentSlideIndex < 0) return;
     liveSelection.update(currentPlaylistEntryId, currentSlideIndex);
+    setLiveTalkScriptIndexForSlide(slides[currentSlideIndex] ?? null, 'first');
     armOutputPlaylistEntry(currentPlaylistEntryId);
     setStatusText(`Taken slide ${currentSlideIndex + 1}`);
   }, [
@@ -196,7 +230,9 @@ export function SlideProvider({ children }: { children: ReactNode }) {
     currentPlaylistEntryId,
     currentSlideIndex,
     setStatusText,
+    setLiveTalkScriptIndexForSlide,
     slides.length,
+    slides,
     liveSelection.update,
   ]);
 
@@ -206,19 +242,59 @@ export function SlideProvider({ children }: { children: ReactNode }) {
     const nextIndex = resolveSlideIndex(currentPlaylistEntryId, playlistSelection.indices, contentSlides.length);
     if (contentSlides.length > 0) {
       liveSelection.update(currentPlaylistEntryId, nextIndex);
+      setLiveTalkScriptIndexForSlide(contentSlides[nextIndex] ?? null, 'first');
     }
     armOutputPlaylistEntry(currentPlaylistEntryId);
-  }, [armOutputPlaylistEntry, currentPlaylistDeckItemId, currentPlaylistEntryId, playlistSelection.indices, slidesByDeckItemId, liveSelection.update]);
+  }, [armOutputPlaylistEntry, currentPlaylistDeckItemId, currentPlaylistEntryId, playlistSelection.indices, setLiveTalkScriptIndexForSlide, slidesByDeckItemId, liveSelection.update]);
 
   const goNext = useCallback(() => {
     if (slides.length === 0) return;
+    if (
+      canDriveOutput
+      && isTalkDeckItem(currentDeckItem)
+      && currentSlideIndex === liveSlideIndex
+      && currentSlide
+    ) {
+      const blocks = talkScriptBlocksBySlideId.get(currentSlide.id) ?? [];
+      const currentBlockIndex = resolveSlideIndex(currentSlide.id, talkScriptSelection.indices, blocks.length);
+      if (blocks.length > 0 && currentBlockIndex >= 0 && currentBlockIndex < blocks.length - 1) {
+        talkScriptSelection.update(currentSlide.id, currentBlockIndex + 1);
+        setStatusText(`Script block ${currentBlockIndex + 2}/${blocks.length}`);
+        return;
+      }
+      // End of the last block on the last slide — stop. Without this,
+      // activateSlide clamps back to this slide and resets the script
+      // index to 0, which looks like the script blocks are cycling.
+      if (currentSlideIndex >= slides.length - 1) return;
+    }
     activateSlide(currentSlideIndex + 1);
-  }, [activateSlide, currentSlideIndex, slides.length]);
+  }, [activateSlide, canDriveOutput, currentDeckItem, currentSlide, currentSlideIndex, liveSlideIndex, setStatusText, slides.length, talkScriptBlocksBySlideId, talkScriptSelection]);
 
   const goPrev = useCallback(() => {
     if (slides.length === 0) return;
+    if (
+      canDriveOutput
+      && isTalkDeckItem(currentDeckItem)
+      && currentSlideIndex === liveSlideIndex
+      && currentSlide
+    ) {
+      const blocks = talkScriptBlocksBySlideId.get(currentSlide.id) ?? [];
+      const currentBlockIndex = resolveSlideIndex(currentSlide.id, talkScriptSelection.indices, blocks.length);
+      if (blocks.length > 0) {
+        if (currentBlockIndex > 0) {
+          talkScriptSelection.update(currentSlide.id, currentBlockIndex - 1);
+          setStatusText(`Script block ${currentBlockIndex}/${blocks.length}`);
+          return;
+        }
+        if (currentSlideIndex === 0) return;
+        const previousSlide = slides[currentSlideIndex - 1] ?? null;
+        activateSlide(currentSlideIndex - 1);
+        setLiveTalkScriptIndexForSlide(previousSlide, 'last');
+        return;
+      }
+    }
     activateSlide(currentSlideIndex - 1);
-  }, [activateSlide, currentSlideIndex, slides.length]);
+  }, [activateSlide, canDriveOutput, currentDeckItem, currentSlide, currentSlideIndex, liveSlideIndex, setLiveTalkScriptIndexForSlide, setStatusText, slides, talkScriptBlocksBySlideId, talkScriptSelection]);
 
   const createSlideAction = useCallback(async () => {
     if (!currentDeckItemId || !currentDeckItem) return;
@@ -227,6 +303,7 @@ export function SlideProvider({ children }: { children: ReactNode }) {
       const nextSnapshot = await mutatePatch(() => window.castApi.createSlide({
         presentationId: currentDeckItem.type === 'presentation' ? currentDeckItemId : null,
         lyricId: currentDeckItem.type === 'lyric' ? currentDeckItemId : null,
+        talkId: currentDeckItem.type === 'talk' ? currentDeckItemId : null,
       }));
       const createdSlideIndex = findCreatedSlideIndex(nextSnapshot, currentDeckItemId, previousSlideIds);
       const selectionKey = isDetachedDeckBrowser ? currentDeckItemId : currentPlaylistEntryId;
@@ -297,9 +374,10 @@ export function SlideProvider({ children }: { children: ReactNode }) {
     if (contentSlides.length === 0) return;
     const nextIndex = clamp(index, 0, contentSlides.length - 1);
     playlistSelection.update(entryId, nextIndex);
+    setLiveTalkScriptIndexForSlide(contentSlides[nextIndex] ?? null, 'first');
     activatePlaylistEntry(entryId, itemId, nextIndex);
     setStatusText(`Live slide ${nextIndex + 1}`);
-  }, [activatePlaylistEntry, setStatusText, slidesByDeckItemId, playlistSelection.update]);
+  }, [activatePlaylistEntry, setLiveTalkScriptIndexForSlide, setStatusText, slidesByDeckItemId, playlistSelection.update]);
 
   const value = useMemo<SlideContextValue>(() => ({
     slides,
@@ -310,6 +388,8 @@ export function SlideProvider({ children }: { children: ReactNode }) {
     liveElements,
     nextLiveSlide,
     nextLiveElements,
+    liveTalkScriptBlock,
+    liveTalkScriptProgress,
     slideElementsById,
     isOutputArmedOnCurrent,
     setCurrentSlideIndex,
@@ -347,6 +427,8 @@ export function SlideProvider({ children }: { children: ReactNode }) {
     isOutputArmedOnCurrent,
     liveElements,
     liveSlide,
+    liveTalkScriptBlock,
+    liveTalkScriptProgress,
     liveSlideIndex,
     nextLiveElements,
     nextLiveSlide,

--- a/app/renderer/contexts/use-project-content.ts
+++ b/app/renderer/contexts/use-project-content.ts
@@ -1,14 +1,16 @@
 import { useMemo, useRef } from 'react';
 import { getSlideDeckItemId } from '@core/deck-items';
-import type { AppSnapshot, Collection, CollectionBinKind, DeckItem, Presentation, Id, Lyric, MediaAsset, Overlay, Slide, SlideElement, Stage, Theme } from '@core/types';
+import type { AppSnapshot, Collection, CollectionBinKind, DeckItem, Presentation, Id, Lyric, MediaAsset, Overlay, Slide, SlideElement, Stage, Talk, TalkScriptBlock, Theme } from '@core/types';
 import { sortElements, sortSlides } from '../utils/slides';
 import { useCast } from './app-context';
 
 interface ProjectContent {
   presentations: Presentation[];
   lyrics: Lyric[];
+  talks: Talk[];
   deckItems: DeckItem[];
   slides: Slide[];
+  talkScriptBlocks: TalkScriptBlock[];
   slideElements: SlideElement[];
   mediaAssets: MediaAsset[];
   overlays: Overlay[];
@@ -17,6 +19,7 @@ interface ProjectContent {
   collections: Collection[];
   deckItemsById: ReadonlyMap<Id, DeckItem>;
   slidesByDeckItemId: ReadonlyMap<Id, Slide[]>;
+  talkScriptBlocksBySlideId: ReadonlyMap<Id, TalkScriptBlock[]>;
   slideElementsBySlideId: ReadonlyMap<Id, SlideElement[]>;
   mediaAssetsById: ReadonlyMap<Id, MediaAsset>;
   overlaysById: ReadonlyMap<Id, Overlay>;
@@ -42,7 +45,9 @@ export function useProjectContent(): ProjectContent {
   const prevRef = useRef<{
     presentations: Presentation[];
     lyrics: Lyric[];
+    talks: Talk[];
     slides: Slide[];
+    talkScriptBlocks: TalkScriptBlock[];
     slideElements: SlideElement[];
     mediaAssets: MediaAsset[];
     overlays: Overlay[];
@@ -55,7 +60,9 @@ export function useProjectContent(): ProjectContent {
     const raw = {
       presentations: snapshot?.presentations ?? [],
       lyrics: snapshot?.lyrics ?? [],
+      talks: snapshot?.talks ?? [],
       slides: snapshot?.slides ?? [],
+      talkScriptBlocks: snapshot?.talkScriptBlocks ?? [],
       slideElements: snapshot?.slideElements ?? [],
       mediaAssets: snapshot?.mediaAssets ?? [],
       overlays: snapshot?.overlays ?? [],
@@ -68,7 +75,9 @@ export function useProjectContent(): ProjectContent {
     const result = {
       presentations: stableArray(prev?.presentations ?? null, raw.presentations),
       lyrics: stableArray(prev?.lyrics ?? null, raw.lyrics),
+      talks: stableArray(prev?.talks ?? null, raw.talks),
       slides: stableArray(prev?.slides ?? null, raw.slides),
+      talkScriptBlocks: stableArray(prev?.talkScriptBlocks ?? null, raw.talkScriptBlocks),
       slideElements: stableArray(prev?.slideElements ?? null, raw.slideElements),
       mediaAssets: stableArray(prev?.mediaAssets ?? null, raw.mediaAssets),
       overlays: stableArray(prev?.overlays ?? null, raw.overlays),
@@ -87,9 +96,9 @@ export function useProjectContent(): ProjectContent {
       if (cached) return cached;
     }
 
-    const { presentations, lyrics, slides, slideElements, mediaAssets, overlays, themes, stages, collections } = stableInputs;
+    const { presentations, lyrics, talks, slides, talkScriptBlocks, slideElements, mediaAssets, overlays, themes, stages, collections } = stableInputs;
 
-    const deckItems = [...presentations, ...lyrics].sort((left, right) => left.order - right.order || left.createdAt.localeCompare(right.createdAt));
+    const deckItems = [...presentations, ...lyrics, ...talks].sort((left, right) => left.order - right.order || left.createdAt.localeCompare(right.createdAt));
 
     const deckItemsById = new Map<Id, DeckItem>();
     for (const item of deckItems) deckItemsById.set(item.id, item);
@@ -105,6 +114,17 @@ export function useProjectContent(): ProjectContent {
     }
     slidesByDeckItemId.forEach((contentSlides, itemId) => {
       slidesByDeckItemId.set(itemId, sortSlides(contentSlides));
+    });
+
+    const talkScriptBlocksBySlideId = new Map<Id, TalkScriptBlock[]>();
+    for (const slide of slides) talkScriptBlocksBySlideId.set(slide.id, []);
+    for (const block of talkScriptBlocks) {
+      const existing = talkScriptBlocksBySlideId.get(block.slideId) ?? [];
+      existing.push(block);
+      talkScriptBlocksBySlideId.set(block.slideId, existing);
+    }
+    talkScriptBlocksBySlideId.forEach((blocks, slideId) => {
+      talkScriptBlocksBySlideId.set(slideId, [...blocks].sort((left, right) => left.order - right.order || left.createdAt.localeCompare(right.createdAt)));
     });
 
     const slideElementsBySlideId = new Map<Id, SlideElement[]>();
@@ -148,8 +168,10 @@ export function useProjectContent(): ProjectContent {
     const content = {
       presentations,
       lyrics,
+      talks,
       deckItems,
       slides,
+      talkScriptBlocks,
       slideElements,
       mediaAssets,
       overlays,
@@ -158,6 +180,7 @@ export function useProjectContent(): ProjectContent {
       collections,
       deckItemsById,
       slidesByDeckItemId,
+      talkScriptBlocksBySlideId,
       slideElementsBySlideId,
       mediaAssetsById,
       overlaysById,

--- a/app/renderer/features/canvas/binding-context.tsx
+++ b/app/renderer/features/canvas/binding-context.tsx
@@ -4,6 +4,8 @@ export interface BindingValue {
   currentSlideText: string | null;
   nextSlideText: string | null;
   slideNotes: string | null;
+  talkScriptCurrent: string | null;
+  talkScriptProgress: string | null;
   armedAtMs: number | null;
 }
 
@@ -13,6 +15,8 @@ const EMPTY_VALUE: BindingValue = {
   currentSlideText: null,
   nextSlideText: null,
   slideNotes: null,
+  talkScriptCurrent: null,
+  talkScriptProgress: null,
   armedAtMs: null,
 };
 

--- a/app/renderer/features/canvas/use-resolved-text.ts
+++ b/app/renderer/features/canvas/use-resolved-text.ts
@@ -5,6 +5,8 @@ import { useBinding, type BindingOverride, type BindingValue } from './binding-c
 const PLACEHOLDER_CURRENT_SLIDE_TEXT = '[Current Slide]';
 const PLACEHOLDER_NEXT_SLIDE_TEXT = '[Next Slide]';
 const PLACEHOLDER_SLIDE_NOTES = '[Slide Notes]';
+const PLACEHOLDER_TALK_SCRIPT = '[Talk Script]';
+const PLACEHOLDER_TALK_PROGRESS = '[Talk Progress]';
 
 function pad(value: number): string {
   return value < 10 ? `0${value}` : `${value}`;
@@ -61,6 +63,14 @@ function resolveBindingText(binding: TextBinding, fallback: string, runtime: Bin
   if (binding.kind === 'slide-notes') {
     if (runtime.slideNotes !== null) return runtime.slideNotes;
     return fallback || PLACEHOLDER_SLIDE_NOTES;
+  }
+  if (binding.kind === 'talk-script-current') {
+    if (runtime.talkScriptCurrent !== null) return runtime.talkScriptCurrent;
+    return fallback || PLACEHOLDER_TALK_SCRIPT;
+  }
+  if (binding.kind === 'talk-script-progress') {
+    if (runtime.talkScriptProgress !== null) return runtime.talkScriptProgress;
+    return fallback || PLACEHOLDER_TALK_PROGRESS;
   }
   return fallback;
 }

--- a/app/renderer/features/command-palette/command-palette.tsx
+++ b/app/renderer/features/command-palette/command-palette.tsx
@@ -1,5 +1,6 @@
 import { Folder, Layers2, LayoutTemplate, ListMusic, Monitor, Search } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { getDeckItemLabel } from '@core/deck-items';
 import type { Id, Library, LibraryPlaylistBundle, MediaAsset, Overlay, Playlist, Stage, Theme } from '@core/types';
 import { Dialog } from '@renderer/components/overlays/dialog';
 import { DeckItemIcon, MediaAssetIcon } from '@renderer/components/display/entity-icon';
@@ -111,7 +112,7 @@ export function CommandPalette() {
       id: `deckItem:${item.id}`,
       kind: 'deckItem',
       label: item.title,
-      subtitle: item.type === 'lyric' ? 'Lyric' : 'Presentation',
+      subtitle: getDeckItemLabel(item),
       icon: <DeckItemIcon entity={item} size={16} />,
       onSelect: () => {
         navigation.browseDeckItem(item.id);

--- a/app/renderer/features/deck/create-deck-item.tsx
+++ b/app/renderer/features/deck/create-deck-item.tsx
@@ -1,5 +1,5 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
-import type { Id } from '@core/types';
+import type { DeckItemType, Id } from '@core/types';
 import { isThemeCompatibleWithDeckItem } from '@core/themes';
 import { ReacstButton } from '@renderer/components/controls/button';
 import { Dialog } from '../../components/overlays/dialog';
@@ -8,7 +8,7 @@ import { useThemeEditor } from '../../contexts/asset-editor/asset-editor-context
 import { useNavigation } from '../../contexts/navigation-context';
 import { useLyricEditor } from './lyric-editor';
 
-type DeckItemKind = 'presentation' | 'lyric';
+type DeckItemKind = DeckItemType;
 
 interface CreateDeckItemContextValue {
   open: (kind: DeckItemKind) => void;
@@ -112,8 +112,8 @@ function CreateDeckItemDialog({ isOpen, kind, onClose }: CreateDeckItemDialogPro
 
   if (!isOpen) return null;
 
-  const title = kind === 'lyric' ? 'New lyric' : 'New presentation';
-  const placeholder = kind === 'lyric' ? 'New Lyric' : 'New Presentation';
+  const title = kind === 'lyric' ? 'New lyric' : kind === 'talk' ? 'New talk' : 'New presentation';
+  const placeholder = kind === 'lyric' ? 'New Lyric' : kind === 'talk' ? 'New Talk' : 'New Presentation';
 
   return (
     <Dialog.Root open onOpenChange={(nextOpen) => { if (!nextOpen) onClose(); }}>

--- a/app/renderer/features/deck/deck-bin-panel.tsx
+++ b/app/renderer/features/deck/deck-bin-panel.tsx
@@ -106,7 +106,7 @@ function DeckItemContextMenuItems({ item, renameRef, collectionsApi }: { item: D
             {otherCollections.map((collection) => (
               <ContextMenu.Item
                 key={collection.id}
-                onSelect={() => { void collectionsApi.assignItem(item.type === 'lyric' ? 'lyric' : 'presentation', item.id, collection.id); }}
+                onSelect={() => { void collectionsApi.assignItem(item.type, item.id, collection.id); }}
               >
                 {collection.name}
               </ContextMenu.Item>

--- a/app/renderer/features/deck/import-export-panel.tsx
+++ b/app/renderer/features/deck/import-export-panel.tsx
@@ -14,7 +14,7 @@ import { BrokenReferenceReviewList } from './broken-reference-review-list';
 import { useDeckImportExport } from './use-deck-import-export';
 
 type TransferTab = 'export' | 'import';
-type TypeFilter = 'all' | 'presentation' | 'lyric' | 'playlist';
+type TypeFilter = 'all' | 'presentation' | 'lyric' | 'talk' | 'playlist';
 
 interface ItemRow {
   kind: 'item';
@@ -67,6 +67,7 @@ export function ImportExportPanel() {
         if (typeFilter === 'playlist' && row.kind !== 'playlist') return false;
         if (typeFilter === 'presentation' && (row.kind !== 'item' || row.item.type !== 'presentation')) return false;
         if (typeFilter === 'lyric' && (row.kind !== 'item' || row.item.type !== 'lyric')) return false;
+        if (typeFilter === 'talk' && (row.kind !== 'item' || row.item.type !== 'talk')) return false;
       }
       if (!normalizedFilter) return true;
       return row.title.toLowerCase().includes(normalizedFilter);
@@ -126,6 +127,7 @@ export function ImportExportPanel() {
                 <SegmentedControl.Label value="playlist">Playlists</SegmentedControl.Label>
                 <SegmentedControl.Label value="presentation">Presentations</SegmentedControl.Label>
                 <SegmentedControl.Label value="lyric">Lyrics</SegmentedControl.Label>
+                <SegmentedControl.Label value="talk">Talks</SegmentedControl.Label>
               </SegmentedControl>
             </div>
             <label className="flex h-8 w-full items-center gap-2 rounded bg-tertiary px-2 text-sm text-primary transition-colors focus-within:ring-1 focus-within:ring-brand">

--- a/app/renderer/features/deck/talk-script-blocks-panel.tsx
+++ b/app/renderer/features/deck/talk-script-blocks-panel.tsx
@@ -1,0 +1,126 @@
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import type { Id } from '@core/types';
+import { Label } from '@renderer/components/display/text';
+import DocEditor, { type Block } from '../../components/form/doc-editor';
+import { useCast } from '../../contexts/app-context';
+import { useProjectContent } from '../../contexts/use-project-content';
+
+interface TalkScriptBlocksPanelProps {
+  slideId: Id;
+}
+
+interface KnownBlock {
+  dbId: Id;
+  content: string;
+  order: number;
+}
+
+const SAVE_DEBOUNCE_MS = 350;
+
+export function TalkScriptBlocksPanel({ slideId }: TalkScriptBlocksPanelProps) {
+  const { mutatePatch } = useCast();
+  const { talkScriptBlocksBySlideId } = useProjectContent();
+
+  // Seed DocEditor only when the slide changes; once mounted, the editor
+  // owns its block state and we sync diffs back to the DB on its onChange.
+  const initialBlocks = useMemo<Block[] | undefined>(() => {
+    const fromDb = talkScriptBlocksBySlideId.get(slideId) ?? [];
+    if (fromDb.length === 0) return undefined;
+    return fromDb.map((block) => ({ id: block.id, content: block.text }));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [slideId]);
+
+  // Map of DocEditor block id → matching DB record. Existing blocks share
+  // ids with the DB; blocks DocEditor invents (split/paste/Enter) start
+  // unknown and gain a mapping when sync first creates them.
+  const knownBlocksRef = useRef<Map<string, KnownBlock>>(new Map());
+  useEffect(() => {
+    const fromDb = talkScriptBlocksBySlideId.get(slideId) ?? [];
+    knownBlocksRef.current = new Map(
+      fromDb.map((block) => [block.id, { dbId: block.id, content: block.text, order: block.order }]),
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [slideId]);
+
+  const debounceRef = useRef<number | null>(null);
+  const queueRef = useRef<Promise<unknown>>(Promise.resolve());
+  const latestBlocksRef = useRef<Block[]>([]);
+
+  const syncBlocks = useCallback(async (editorBlocks: Block[]) => {
+    const known = knownBlocksRef.current;
+    const seen = new Set<string>();
+
+    for (let index = 0; index < editorBlocks.length; index += 1) {
+      const block = editorBlocks[index];
+      seen.add(block.id);
+      const record = known.get(block.id);
+      if (record) {
+        if (record.content !== block.content) {
+          await mutatePatch(() => window.castApi.updateTalkScriptBlock({
+            id: record.dbId,
+            text: block.content,
+          }));
+          record.content = block.content;
+        }
+        if (record.order !== index) {
+          await mutatePatch(() => window.castApi.setTalkScriptBlockOrder({
+            id: record.dbId,
+            newOrder: index,
+          }));
+          record.order = index;
+        }
+        continue;
+      }
+      // Don't persist a block that's still empty — the DocEditor seeds an
+      // empty block when no DB rows exist, and Enter creates blank blocks
+      // that aren't worth a row until the user actually types into them.
+      if (block.content === '') continue;
+      const persistedIds = new Set(Array.from(known.values(), (entry) => entry.dbId));
+      const snapshot = await mutatePatch(() => window.castApi.createTalkScriptBlock({
+        slideId,
+        text: block.content,
+        order: index,
+      }));
+      const created = snapshot.talkScriptBlocks.find(
+        (b) => b.slideId === slideId && !persistedIds.has(b.id),
+      );
+      if (created) {
+        known.set(block.id, { dbId: created.id, content: block.content, order: index });
+      }
+    }
+
+    for (const [editorId, record] of Array.from(known.entries())) {
+      if (seen.has(editorId)) continue;
+      await mutatePatch(() => window.castApi.deleteTalkScriptBlock(record.dbId));
+      known.delete(editorId);
+    }
+  }, [mutatePatch, slideId]);
+
+  const handleChange = useCallback((editorBlocks: Block[]) => {
+    latestBlocksRef.current = editorBlocks;
+    if (debounceRef.current != null) window.clearTimeout(debounceRef.current);
+    debounceRef.current = window.setTimeout(() => {
+      const snapshot = latestBlocksRef.current;
+      queueRef.current = queueRef.current
+        .then(() => syncBlocks(snapshot))
+        .catch((error) => { console.error('[TalkScript] sync failed', error); });
+    }, SAVE_DEBOUNCE_MS);
+  }, [syncBlocks]);
+
+  useEffect(() => () => {
+    if (debounceRef.current != null) window.clearTimeout(debounceRef.current);
+  }, []);
+
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-secondary">
+      <div className="flex h-9 shrink-0 items-center gap-2 border-b border-primary px-3">
+        <Label.xs className="mr-auto">Script blocks</Label.xs>
+      </div>
+      <div className="min-h-0 flex-1 overflow-y-auto px-6 py-4">
+        <div className="mx-auto flex w-full max-w-3xl justify-center">
+          <DocEditor key={slideId} initialBlocks={initialBlocks} onChange={handleChange} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/renderer/features/inspector/binding-inspector.tsx
+++ b/app/renderer/features/inspector/binding-inspector.tsx
@@ -13,6 +13,8 @@ const BINDING_OPTIONS: Array<{ value: TextBindingKind | 'none'; label: string }>
   { value: 'current-slide-text', label: 'Current slide text' },
   { value: 'next-slide-text', label: 'Next slide text' },
   { value: 'slide-notes', label: 'Slide notes' },
+  { value: 'talk-script-current', label: 'Talk script current' },
+  { value: 'talk-script-progress', label: 'Talk script progress' },
 ];
 
 const CLOCK_FORMAT_OPTIONS: Array<{ value: ClockFormat; label: string }> = [
@@ -138,7 +140,7 @@ export function BindingInspector() {
         </Section.Root>
       )}
 
-      {(binding?.kind === 'current-slide-text' || binding?.kind === 'next-slide-text' || binding?.kind === 'slide-notes') && (
+      {(binding?.kind === 'current-slide-text' || binding?.kind === 'next-slide-text' || binding?.kind === 'slide-notes' || binding?.kind === 'talk-script-current' || binding?.kind === 'talk-script-progress') && (
         <Section.Root>
           <Section.Body>
             <p className="text-xs text-tertiary">

--- a/app/renderer/features/inspector/presentation-inspector.tsx
+++ b/app/renderer/features/inspector/presentation-inspector.tsx
@@ -3,6 +3,7 @@ import { Unlink } from 'lucide-react';
 import { isThemeCompatibleWithDeckItem } from '@core/themes';
 import { ReacstButton } from '@renderer/components/controls/button';
 import { FieldInput, FieldSelect } from '../../components/form/field';
+import { getDeckItemLabel } from '@core/deck-items';
 import { useNavigation } from '../../contexts/navigation-context';
 import { useProjectContent } from '../../contexts/use-project-content';
 import { useThemeEditor } from '../../contexts/asset-editor/asset-editor-context';
@@ -69,7 +70,7 @@ export function DeckItemInspector() {
     return <div className="text-sm text-tertiary">No item selected.</div>;
   }
 
-  const itemLabel = currentDeckItem.type === 'lyric' ? 'Lyric' : 'Presentation';
+  const itemLabel = getDeckItemLabel(currentDeckItem);
   const hasThemeId = Boolean(currentDeckItem.themeId);
 
   return (

--- a/app/renderer/features/library/use-library-panel-management.ts
+++ b/app/renderer/features/library/use-library-panel-management.ts
@@ -25,12 +25,13 @@ export function useLibraryPanelManagement() {
   const { snapshot, mutate, mutatePatch, setStatusText } = useCast();
 
   function getDeckItems(nextSnapshot: AppSnapshot | null | undefined) {
-    return [...(nextSnapshot?.presentations ?? []), ...(nextSnapshot?.lyrics ?? [])];
+    return [...(nextSnapshot?.presentations ?? []), ...(nextSnapshot?.lyrics ?? []), ...(nextSnapshot?.talks ?? [])];
   }
 
   function resolveDeckItemType(itemId: Id): DeckItemType | null {
     if (snapshot?.presentations.some((item) => item.id === itemId)) return 'presentation';
     if (snapshot?.lyrics.some((item) => item.id === itemId)) return 'lyric';
+    if (snapshot?.talks.some((item) => item.id === itemId)) return 'talk';
     return null;
   }
 
@@ -63,7 +64,9 @@ export function useLibraryPanelManagement() {
     if (!itemType) return;
     await mutatePatch(() => itemType === 'presentation'
       ? window.castApi.renamePresentation(id, title)
-      : window.castApi.renameLyric(id, title));
+      : itemType === 'talk'
+        ? window.castApi.renameTalk(id, title)
+        : window.castApi.renameLyric(id, title));
     setStatusText(`Renamed item: ${title}`);
   }, [mutatePatch, setStatusText, snapshot]);
 
@@ -87,7 +90,9 @@ export function useLibraryPanelManagement() {
     if (!itemType) return;
     await mutatePatch(() => itemType === 'presentation'
       ? window.castApi.deletePresentation(id)
-      : window.castApi.deleteLyric(id));
+      : itemType === 'talk'
+        ? window.castApi.deleteTalk(id)
+        : window.castApi.deleteLyric(id));
     setStatusText('Deleted item');
   }, [mutatePatch, setStatusText, snapshot]);
 
@@ -167,6 +172,15 @@ export function useLibraryPanelManagement() {
     );
   }, [createDeckItemEntryInGroup]);
 
+  const createTalkInGroup = useCallback(async (_libraryId: Id, groupId: Id) => {
+    return createDeckItemEntryInGroup(
+      groupId,
+      () => window.castApi.createTalk('New Talk'),
+      (itemId) => window.castApi.createSlide({ talkId: itemId }),
+      'Created talk and added to group'
+    );
+  }, [createDeckItemEntryInGroup]);
+
   return {
     renameLibrary,
     renamePlaylist,
@@ -185,6 +199,7 @@ export function useLibraryPanelManagement() {
     movePlaylistEntry,
     addDeckItemToGroup,
     createPresentationInGroup,
-    createLyricInGroup
+    createLyricInGroup,
+    createTalkInGroup
   };
 }

--- a/app/renderer/features/observability/observability-panel.tsx
+++ b/app/renderer/features/observability/observability-panel.tsx
@@ -1,5 +1,13 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import type { LogReadResult, LogSessionSummary, NdiActiveSenderDiagnostics, NdiOutputName } from '@core/types';
+import type {
+  LogReadResult,
+  LogSessionSummary,
+  NdiActiveSenderDiagnostics,
+  NdiOutputName,
+  NdiPipelineStageStats,
+  NdiSenderPerformanceDiagnostics,
+  NdiTallyState,
+} from '@core/types';
 import { useNdi } from '../../contexts/app-context';
 import { useImageCacheStats } from '../canvas/use-image-cache-stats';
 import {
@@ -121,6 +129,72 @@ function SenderCard({ name, sender }: { name: NdiOutputName; sender: NdiActiveSe
         <Stat label="Silence frames" value={formatNumber(audio.audioSilenceFramesSent)} />
         <Stat label="Audio rejected" value={formatNumber(audio.audioFramesRejected)} highlight={audio.audioFramesRejected > 0} />
         <Stat label="Audio format" value={audio.lastSampleRate > 0 ? `${audio.lastSampleRate} Hz × ${audio.lastChannels}ch` : 'inactive'} />
+      </div>
+      <PipelineLatencyGroup pipeline={performance.pipeline} />
+      <ReceiverHealthGroup connectionCount={sender.connectionCount} tally={sender.tally} />
+    </div>
+  );
+}
+
+function PipelineLatencyGroup({ pipeline }: { pipeline: NdiSenderPerformanceDiagnostics['pipeline'] }) {
+  // Captures the full sender-side pipeline: from the moment a state change
+  // is observed in the renderer to the moment bits leave the native NDI
+  // send call. Stage breakdown helps localize which IPC hop or process is
+  // dominating when the headline numbers spike.
+  return (
+    <div className="mt-3 border-t border-secondary/40 pt-2">
+      <div className="pb-1 text-xs font-semibold uppercase tracking-wide text-tertiary">
+        Pipeline latency (ms · p50 / p95 · last)
+      </div>
+      <div className="grid grid-cols-2 gap-x-6 gap-y-1 text-sm text-secondary md:grid-cols-3">
+        <PipelineStat label="Frame age at wire" stats={pipeline.frameAgeAtWire} warnP95={50} />
+        <PipelineStat label="Signature → wire" stats={pipeline.signatureToWire} warnP95={66} />
+        <PipelineStat label="Capture → renderer send" stats={pipeline.captureToRendererSend} warnP95={20} />
+        <PipelineStat label="Renderer → main IPC" stats={pipeline.rendererToMainIpc} warnP95={10} />
+        <PipelineStat label="Main handler" stats={pipeline.mainHandler} warnP95={5} />
+        <PipelineStat label="Main → host IPC" stats={pipeline.mainToHostIpc} warnP95={10} />
+        <PipelineStat label="Host → native send" stats={pipeline.hostToNative} warnP95={20} />
+      </div>
+    </div>
+  );
+}
+
+function PipelineStat({
+  label,
+  stats,
+  warnP95,
+}: {
+  label: string;
+  stats: NdiPipelineStageStats;
+  warnP95: number;
+}) {
+  const text = stats.count === 0
+    ? '—'
+    : `${stats.p50.toFixed(1)} / ${stats.p95.toFixed(1)} · ${stats.lastMs.toFixed(1)}`;
+  return <Stat label={label} value={text} highlight={stats.p95 > warnP95} />;
+}
+
+function ReceiverHealthGroup({
+  connectionCount,
+  tally,
+}: {
+  connectionCount: number | null;
+  tally: NdiTallyState | null;
+}) {
+  // Tally + connection count come from the receiver via the NDI SDK. They
+  // confirm the receiver is actually subscribed and considers itself live —
+  // useful context for interpreting pipeline-latency numbers above.
+  const tallyText = tally
+    ? `${tally.onProgram ? 'PGM' : '—'} · ${tally.onPreview ? 'PVW' : '—'}`
+    : 'unsupported';
+  return (
+    <div className="mt-3 border-t border-secondary/40 pt-2">
+      <div className="pb-1 text-xs font-semibold uppercase tracking-wide text-tertiary">
+        Receiver health
+      </div>
+      <div className="grid grid-cols-2 gap-x-6 gap-y-1 text-sm text-secondary md:grid-cols-3">
+        <Stat label="Connections" value={connectionCount ?? 'unknown'} />
+        <Stat label="Tally" value={tallyText} />
       </div>
     </div>
   );

--- a/app/renderer/features/playback/ndi-frame-capture.tsx
+++ b/app/renderer/features/playback/ndi-frame-capture.tsx
@@ -53,6 +53,14 @@ export function NdiFrameCapture({ senderName, scene, surface = 'show', enabled }
   const pendingDroppedBackpressureRef = useRef(0);
   const inFlightSentAtRef = useRef<number | null>(null);
   const captureStartedAtRef = useRef(0);
+  // Date.now() epoch-ms equivalents of the perf.now() timestamps above. Used
+  // as cross-process pipeline-latency stamps (renderer's perf.now() can't be
+  // compared to main/utility perf.now() — different time origins).
+  const captureStartedAtMsRef = useRef(0);
+  // Set when the RAF tick first observes a new sceneSignature, cleared when
+  // the resulting frame is shipped. Null for heartbeat / video-driven
+  // captures where no state change triggered the frame.
+  const signatureChangedAtMsRef = useRef<number | null>(null);
   const requestIdRef = useRef(0);
   const framesAckedRef = useRef(0);
   const workerRef = useRef<Worker | null>(null);
@@ -79,6 +87,8 @@ export function NdiFrameCapture({ senderName, scene, surface = 'show', enabled }
       }
       if (data.type !== 'captured') return;
       const captureDurationMs = performance.now() - captureStartedAtRef.current;
+      const signatureChangedAtMs = signatureChangedAtMsRef.current;
+      signatureChangedAtMsRef.current = null;
       window.castApi.sendNdiFrame(
         senderName,
         data.buffer,
@@ -89,6 +99,8 @@ export function NdiFrameCapture({ senderName, scene, surface = 'show', enabled }
           readbackDurationMs: data.readbackDurationMs,
           skippedCaptures: pendingSkippedCapturesRef.current,
           framesDroppedBackpressure: pendingDroppedBackpressureRef.current,
+          signatureChangedAtMs,
+          captureStartedAtMs: captureStartedAtMsRef.current,
         },
       );
       pendingSkippedCapturesRef.current = 0;
@@ -109,6 +121,7 @@ export function NdiFrameCapture({ senderName, scene, surface = 'show', enabled }
     if (!worker) return false;
 
     captureStartedAtRef.current = performance.now();
+    captureStartedAtMsRef.current = Date.now();
     inFlightSentAtRef.current = performance.now();
     const requestId = ++requestIdRef.current;
 
@@ -186,6 +199,12 @@ export function NdiFrameCapture({ senderName, scene, surface = 'show', enabled }
           if (inFlightSentAtRef.current !== null) {
             pendingDroppedBackpressureRef.current += 1;
           } else {
+            // Record signature-change timestamp so we can measure
+            // state-change → bits-on-wire latency end-to-end. Heartbeat /
+            // video-driven captures (no signature change) leave this null.
+            if (signatureChanged && signatureChangedAtMsRef.current === null) {
+              signatureChangedAtMsRef.current = Date.now();
+            }
             stageRef.current?.batchDraw();
             if (captureFrame()) {
               lastSignature = currentSignature;

--- a/app/renderer/features/playback/ndi-frame-capture.tsx
+++ b/app/renderer/features/playback/ndi-frame-capture.tsx
@@ -61,6 +61,8 @@ function bindingValueForSignature(binding: TextBinding, runtime: BindingValue): 
   if (binding.kind === 'current-slide-text') return runtime.currentSlideText ?? '';
   if (binding.kind === 'next-slide-text') return runtime.nextSlideText ?? '';
   if (binding.kind === 'slide-notes') return runtime.slideNotes ?? '';
+  if (binding.kind === 'talk-script-current') return runtime.talkScriptCurrent ?? '';
+  if (binding.kind === 'talk-script-progress') return runtime.talkScriptProgress ?? '';
   return null;
 }
 

--- a/app/renderer/features/playback/ndi-frame-capture.tsx
+++ b/app/renderer/features/playback/ndi-frame-capture.tsx
@@ -2,11 +2,12 @@ import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { Stage, Layer, Group } from 'react-konva';
 import type Konva from 'konva';
 import { NDI_OUTPUT_WIDTH, NDI_OUTPUT_HEIGHT } from '@core/ndi';
-import type { NdiOutputName } from '@core/types';
+import type { NdiOutputName, TextBinding } from '@core/types';
 import { useNdi } from '../../contexts/app-context';
 import { SceneNodeMedia } from '../canvas/scene-node-media';
 import { SceneNodeShape } from '../canvas/scene-node-shape';
 import { SceneNodeText } from '../canvas/scene-node-text';
+import { useBinding, type BindingValue } from '../canvas/binding-context';
 import type { RenderNode, RenderScene, SceneSurface } from '../canvas/scene-types';
 import { useNdiCaptureSource } from './ndi-capture-source';
 import NdiReadbackWorker from './ndi-readback-worker?worker';
@@ -27,13 +28,50 @@ function renderNodeContent(node: RenderNode, surface: SceneSurface, onImageLoad?
 // Cheap signature used to decide whether the output has visibly changed
 // since the last capture. Video nodes are excluded because their contents
 // tick forward every frame without any RenderNode field changing; the same
-// is true for text elements with clock/timer bindings (see hasDynamicText
-// in the capture loop below) — both rely on RAF-driven re-capture instead
-// of signature changes.
-function sceneSignature(nodes: readonly RenderNode[], withAlpha: boolean): string {
-  let out = withAlpha ? 'a1' : 'a0';
+// is true for text elements with ticking clock/timer bindings (see
+// hasTickingTextBinding in the capture loop below). Slide text and notes
+// bindings are included through bindingSignature because their source values
+// can change without any RenderNode field changing.
+function sceneSignature(nodes: readonly RenderNode[], withAlpha: boolean, bindingSignature: string): string {
+  let out = (withAlpha ? 'a1' : 'a0') + bindingSignature;
   for (const node of nodes) {
     out += '|' + node.id + ':' + node.element.updatedAt + ':' + (node.visual.visible === false ? '0' : '1');
+  }
+  return out;
+}
+
+function nodeRuntime(node: RenderNode, bindingValue: BindingValue): BindingValue {
+  return {
+    ...bindingValue,
+    ...node.bindingOverride,
+  };
+}
+
+function textBindingForNode(node: RenderNode): TextBinding | undefined {
+  if (node.element.type !== 'text') return undefined;
+  return (node.element.payload as { binding?: TextBinding }).binding;
+}
+
+function visibleTextBindingForNode(node: RenderNode): TextBinding | undefined {
+  if (node.visual.visible === false) return undefined;
+  return textBindingForNode(node);
+}
+
+function bindingValueForSignature(binding: TextBinding, runtime: BindingValue): string | null {
+  if (binding.kind === 'current-slide-text') return runtime.currentSlideText ?? '';
+  if (binding.kind === 'next-slide-text') return runtime.nextSlideText ?? '';
+  if (binding.kind === 'slide-notes') return runtime.slideNotes ?? '';
+  return null;
+}
+
+function sceneBindingSignature(nodes: readonly RenderNode[], bindingValue: BindingValue): string {
+  let out = '';
+  for (const node of nodes) {
+    const binding = visibleTextBindingForNode(node);
+    if (!binding) continue;
+    const value = bindingValueForSignature(binding, nodeRuntime(node, bindingValue));
+    if (value === null) continue;
+    out += '|b:' + node.id + ':' + binding.kind + ':' + value.length + ':' + value;
   }
   return out;
 }
@@ -42,12 +80,12 @@ function sceneSignature(nodes: readonly RenderNode[], withAlpha: boolean): strin
 // RenderNode field change (clock advances every second; timer counts down).
 // When any such element is on the slide we have to capture every RAF tick,
 // because sceneSignature() will never observe their updates.
-function hasTickingTextBinding(nodes: readonly RenderNode[]): boolean {
+function hasTickingTextBinding(nodes: readonly RenderNode[], bindingValue: BindingValue): boolean {
   for (const node of nodes) {
-    if (node.element.type !== 'text') continue;
-    if (node.visual.visible === false) continue;
-    const binding = (node.element.payload as { binding?: { kind?: string } }).binding;
-    if (binding?.kind === 'clock' || binding?.kind === 'timer') return true;
+    const binding = visibleTextBindingForNode(node);
+    if (!binding) continue;
+    if (binding.kind === 'clock') return true;
+    if (binding.kind === 'timer' && nodeRuntime(node, bindingValue).armedAtMs !== null) return true;
   }
   return false;
 }
@@ -65,6 +103,7 @@ interface NdiFrameCaptureProps {
 
 export function NdiFrameCapture({ senderName, scene, surface = 'show', enabled }: NdiFrameCaptureProps) {
   const { state: { outputConfigs } } = useNdi();
+  const bindingValue = useBinding();
   const stageRef = useRef<Konva.Stage>(null);
   const pendingSkippedCapturesRef = useRef(0);
   const pendingDroppedBackpressureRef = useRef(0);
@@ -86,7 +125,14 @@ export function NdiFrameCapture({ senderName, scene, surface = 'show', enabled }
     () => scene.nodes.some((node) => node.element.type === 'video'),
     [scene.nodes],
   );
-  const hasDynamicText = useMemo(() => hasTickingTextBinding(scene.nodes), [scene.nodes]);
+  const bindingSignature = useMemo(
+    () => sceneBindingSignature(scene.nodes, bindingValue),
+    [bindingValue, scene.nodes],
+  );
+  const hasDynamicText = useMemo(
+    () => hasTickingTextBinding(scene.nodes, bindingValue),
+    [bindingValue, scene.nodes],
+  );
   const withAlpha = outputConfigs[senderName].withAlpha;
 
   // Spin up a dedicated worker that owns an OffscreenCanvas and performs the
@@ -210,7 +256,7 @@ export function NdiFrameCapture({ senderName, scene, surface = 'show', enabled }
           inFlightSentAtRef.current = null;
         }
 
-        const currentSignature = sceneSignature(scene.nodes, withAlpha);
+        const currentSignature = sceneSignature(scene.nodes, withAlpha, bindingSignature);
         const signatureChanged = currentSignature !== lastSignature;
         const needsInitialFrame = framesAckedRef.current === 0;
         if (needsInitialFrame || signatureChanged || hasVideoNodes || hasDynamicText) {
@@ -241,7 +287,7 @@ export function NdiFrameCapture({ senderName, scene, surface = 'show', enabled }
       if (rafId !== null) cancelAnimationFrame(rafId);
       inFlightSentAtRef.current = null;
     };
-  }, [captureFrame, enabled, hasVideoNodes, hasDynamicText, scene, withAlpha]);
+  }, [bindingSignature, captureFrame, enabled, hasVideoNodes, hasDynamicText, scene, withAlpha]);
 
   if (!enabled) return null;
   if (sharedCaptureSource) return null;

--- a/app/renderer/features/playback/ndi-frame-capture.tsx
+++ b/app/renderer/features/playback/ndi-frame-capture.tsx
@@ -26,13 +26,30 @@ function renderNodeContent(node: RenderNode, surface: SceneSurface, onImageLoad?
 
 // Cheap signature used to decide whether the output has visibly changed
 // since the last capture. Video nodes are excluded because their contents
-// tick forward every frame without any RenderNode field changing.
+// tick forward every frame without any RenderNode field changing; the same
+// is true for text elements with clock/timer bindings (see hasDynamicText
+// in the capture loop below) — both rely on RAF-driven re-capture instead
+// of signature changes.
 function sceneSignature(nodes: readonly RenderNode[], withAlpha: boolean): string {
   let out = withAlpha ? 'a1' : 'a0';
   for (const node of nodes) {
     out += '|' + node.id + ':' + node.element.updatedAt + ':' + (node.visual.visible === false ? '0' : '1');
   }
   return out;
+}
+
+// Detect text elements whose visible content ticks independently of any
+// RenderNode field change (clock advances every second; timer counts down).
+// When any such element is on the slide we have to capture every RAF tick,
+// because sceneSignature() will never observe their updates.
+function hasTickingTextBinding(nodes: readonly RenderNode[]): boolean {
+  for (const node of nodes) {
+    if (node.element.type !== 'text') continue;
+    if (node.visual.visible === false) continue;
+    const binding = (node.element.payload as { binding?: { kind?: string } }).binding;
+    if (binding?.kind === 'clock' || binding?.kind === 'timer') return true;
+  }
+  return false;
 }
 
 interface NdiFrameCaptureProps {
@@ -69,6 +86,7 @@ export function NdiFrameCapture({ senderName, scene, surface = 'show', enabled }
     () => scene.nodes.some((node) => node.element.type === 'video'),
     [scene.nodes],
   );
+  const hasDynamicText = useMemo(() => hasTickingTextBinding(scene.nodes), [scene.nodes]);
   const withAlpha = outputConfigs[senderName].withAlpha;
 
   // Spin up a dedicated worker that owns an OffscreenCanvas and performs the
@@ -195,7 +213,7 @@ export function NdiFrameCapture({ senderName, scene, surface = 'show', enabled }
         const currentSignature = sceneSignature(scene.nodes, withAlpha);
         const signatureChanged = currentSignature !== lastSignature;
         const needsInitialFrame = framesAckedRef.current === 0;
-        if (needsInitialFrame || signatureChanged || hasVideoNodes) {
+        if (needsInitialFrame || signatureChanged || hasVideoNodes || hasDynamicText) {
           if (inFlightSentAtRef.current !== null) {
             pendingDroppedBackpressureRef.current += 1;
           } else {
@@ -223,7 +241,7 @@ export function NdiFrameCapture({ senderName, scene, surface = 'show', enabled }
       if (rafId !== null) cancelAnimationFrame(rafId);
       inFlightSentAtRef.current = null;
     };
-  }, [captureFrame, enabled, hasVideoNodes, scene, withAlpha]);
+  }, [captureFrame, enabled, hasVideoNodes, hasDynamicText, scene, withAlpha]);
 
   if (!enabled) return null;
   if (sharedCaptureSource) return null;

--- a/app/renderer/features/playback/use-stage-scene.ts
+++ b/app/renderer/features/playback/use-stage-scene.ts
@@ -33,19 +33,21 @@ function extractSlideText(elements: Array<{ type: string; payload: unknown }>): 
 
 export function useStageBindingValue(): BindingValue {
   const { armedAtMs } = useStagePlayback();
-  const { liveSlide, liveElements, nextLiveSlide, nextLiveElements } = useSlides();
+  const { liveSlide, liveElements, nextLiveSlide, nextLiveElements, liveTalkScriptBlock, liveTalkScriptProgress } = useSlides();
 
   return useMemo(() => ({
     currentSlideText: liveSlide ? extractSlideText(liveElements) : null,
     nextSlideText: nextLiveSlide ? extractSlideText(nextLiveElements) : null,
     slideNotes: liveSlide ? liveSlide.notes : null,
+    talkScriptCurrent: liveTalkScriptBlock?.text ?? null,
+    talkScriptProgress: liveTalkScriptProgress,
     armedAtMs,
-  }), [armedAtMs, liveElements, liveSlide, nextLiveElements, nextLiveSlide]);
+  }), [armedAtMs, liveElements, liveSlide, liveTalkScriptBlock, liveTalkScriptProgress, nextLiveElements, nextLiveSlide]);
 }
 
 export function useProgramBindingValue(): BindingValue {
   const { currentOutputDeckItemId, outputArmVersion } = useNavigation();
-  const { liveSlide, liveElements, nextLiveSlide, nextLiveElements } = useSlides();
+  const { liveSlide, liveElements, nextLiveSlide, nextLiveElements, liveTalkScriptBlock, liveTalkScriptProgress } = useSlides();
   const [armedAtMs, setArmedAtMs] = useState<number | null>(null);
 
   useEffect(() => {
@@ -60,6 +62,8 @@ export function useProgramBindingValue(): BindingValue {
     currentSlideText: liveSlide ? extractSlideText(liveElements) : null,
     nextSlideText: nextLiveSlide ? extractSlideText(nextLiveElements) : null,
     slideNotes: liveSlide ? liveSlide.notes : null,
+    talkScriptCurrent: liveTalkScriptBlock?.text ?? null,
+    talkScriptProgress: liveTalkScriptProgress,
     armedAtMs,
-  }), [armedAtMs, liveElements, liveSlide, nextLiveElements, nextLiveSlide]);
+  }), [armedAtMs, liveElements, liveSlide, liveTalkScriptBlock, liveTalkScriptProgress, nextLiveElements, nextLiveSlide]);
 }

--- a/app/renderer/features/workbench/resource-drawer.tsx
+++ b/app/renderer/features/workbench/resource-drawer.tsx
@@ -214,6 +214,7 @@ function MoreActionsMenu({ onImportClick }: { onImportClick: () => void }) {
           <>
             <Dropdown.Item onClick={() => openCreateDeckItem('presentation')}>New presentation</Dropdown.Item>
             <Dropdown.Item onClick={() => openCreateDeckItem('lyric')}>New lyric</Dropdown.Item>
+            <Dropdown.Item onClick={() => openCreateDeckItem('talk')}>New talk</Dropdown.Item>
             <Dropdown.Separator />
             <SortMenuItems options={DECK_SORT_OPTIONS} sort={deckSort.sort} onChange={deckSort.setSort} />
           </>

--- a/app/renderer/screens/deck-editor/page.tsx
+++ b/app/renderer/screens/deck-editor/page.tsx
@@ -22,6 +22,7 @@ import { Label } from '@renderer/components/display/text';
 import { DeckEditorInspectorPanel } from './inspector-panel';
 import { DeckEditorLayersPanel } from './layers-panel';
 import { DeckEditorScreenProvider, useDeckEditorScreen } from './screen-context';
+import { TalkScriptBlocksPanel } from '../../features/deck/talk-script-blocks-panel';
 
 export function DeckEditorScreen() {
   return (
@@ -57,6 +58,9 @@ function DeckEditorScreenContent() {
                         </Dropdown.Item>
                         <Dropdown.Item onClick={() => actions.openCreateDeckItem('presentation')}>
                           New presentation
+                        </Dropdown.Item>
+                        <Dropdown.Item onClick={() => actions.openCreateDeckItem('talk')}>
+                          New talk
                         </Dropdown.Item>
                         <Dropdown.Separator />
                         <Dropdown.Item onClick={() => { void actions.createSlide(); }} disabled={!state.currentDeckItem}>
@@ -125,14 +129,18 @@ function DeckEditorScreenContent() {
                     </ReacstButton>
                   </div>
                 </div> */}
-                <FieldTextarea
-                  value={state.notesPanel.notesDraft}
-                  onChange={state.notesPanel.handleNotesChange}
-                  onBlur={state.notesPanel.handleSaveNotes}
-                  placeholder={state.notesPanel.placeholder}
-                  resize="none"
-                  className="h-full min-h-0 w-full resize-none rounded-none border-none bg-transparent p-4 focus:border-0 paragraph-sm"
-                />
+                {state.currentDeckItem?.type === 'talk' && state.currentSlide ? (
+                  <TalkScriptBlocksPanel slideId={state.currentSlide.id} />
+                ) : (
+                  <FieldTextarea
+                    value={state.notesPanel.notesDraft}
+                    onChange={state.notesPanel.handleNotesChange}
+                    onBlur={state.notesPanel.handleSaveNotes}
+                    placeholder={state.notesPanel.placeholder}
+                    resize="none"
+                    className="h-full min-h-0 w-full resize-none rounded-none border-none bg-transparent p-4 focus:border-0 paragraph-sm"
+                  />
+                )}
               </section>
             </SplitPanel.Segment>
           </SplitPanel.Panel>

--- a/app/renderer/types/navigation-context-types.ts
+++ b/app/renderer/types/navigation-context-types.ts
@@ -1,4 +1,4 @@
-import type { DeckItem, Id, LibraryPlaylistBundle } from '@core/types';
+import type { DeckItem, DeckItemType, Id, LibraryPlaylistBundle } from '@core/types';
 
 export interface NavigationStateValue {
   currentLibraryId: Id | null;
@@ -33,7 +33,7 @@ export interface NavigationActionsValue {
   createPresentation: () => Promise<void>;
   createEmptyLyric: () => Promise<void>;
   createDeckItem: (input: {
-    kind: 'presentation' | 'lyric';
+    kind: DeckItemType;
     name: string;
     themeId?: Id;
     groupId?: Id;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lumacast",
   "productName": "LumaCast",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "private": true,
   "description": "Cross-platform presentation tool with reusable content hierarchy, slide rendering, and NDI output",
   "author": "IT-PSAPE",

--- a/packages/ndi-native/index.d.ts
+++ b/packages/ndi-native/index.d.ts
@@ -33,6 +33,14 @@ export function sendAudioFrame(
 
 export function getSenderConnections(senderName: string, timeoutMs?: number): number;
 
+// Polls the bidirectional NDI tally signal that receivers send back. Returns
+// null when the loaded NDI runtime doesn't export NDIlib_send_get_tally or no
+// sender is registered for senderName.
+export function getSenderTally(
+  senderName: string,
+  timeoutMs?: number,
+): { onProgram: boolean; onPreview: boolean } | null;
+
 export function destroySender(senderName?: string): void;
 
 export function getRuntimeInfo(): NdiRuntimeInfo;

--- a/packages/ndi-native/src/ndi_native.cc
+++ b/packages/ndi-native/src/ndi_native.cc
@@ -64,6 +64,11 @@ struct NDIlib_video_frame_v2_t {
   int64_t timestamp;
 };
 
+struct NDIlib_tally_t {
+  bool on_program;
+  bool on_preview;
+};
+
 // Planar 32-bit float audio. Channels are stored back-to-back: channel 0's
 // samples first, then channel 1's, separated by channel_stride_in_bytes.
 struct NDIlib_audio_frame_v2_t {
@@ -87,6 +92,7 @@ using FnNdiSendVideoV2 = void (*)(NDIlib_send_instance_t, const NDIlib_video_fra
 using FnNdiSendVideoAsyncV2 = void (*)(NDIlib_send_instance_t, const NDIlib_video_frame_v2_t*);
 using FnNdiSendAudioV2 = void (*)(NDIlib_send_instance_t, const NDIlib_audio_frame_v2_t*);
 using FnNdiSendGetNoConnections = int32_t (*)(NDIlib_send_instance_t, uint32_t);
+using FnNdiSendGetTally = bool (*)(NDIlib_send_instance_t, NDIlib_tally_t*, uint32_t);
 
 struct NdiSymbols {
   FnNdiInitialize initialize = nullptr;
@@ -97,6 +103,7 @@ struct NdiSymbols {
   FnNdiSendVideoAsyncV2 sendVideoAsyncV2 = nullptr;
   FnNdiSendAudioV2 sendAudioV2 = nullptr;
   FnNdiSendGetNoConnections sendGetNoConnections = nullptr;
+  FnNdiSendGetTally sendGetTally = nullptr;
 };
 
 class DynamicLibrary {
@@ -371,6 +378,8 @@ void LoadRuntimeIfNeeded(SenderState& state) {
       ResolveOptional<FnNdiSendAudioV2>(state.runtime, "NDIlib_send_send_audio_v2");
   state.symbols.sendGetNoConnections =
       ResolveOptional<FnNdiSendGetNoConnections>(state.runtime, "NDIlib_send_get_no_connections");
+  state.symbols.sendGetTally =
+      ResolveOptional<FnNdiSendGetTally>(state.runtime, "NDIlib_send_get_tally");
 
   state.runtimeLoaded = true;
 }
@@ -909,6 +918,44 @@ Napi::Value GetSenderConnections(const Napi::CallbackInfo& info) {
   return Napi::Number::New(env, count);
 }
 
+Napi::Value GetSenderTally(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+
+  if (info.Length() < 1 || info.Length() > 2 || !info[0].IsString() || (info.Length() == 2 && !info[1].IsNumber())) {
+    Napi::TypeError::New(env, "getSenderTally expects (senderName, timeoutMs?)").ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+
+  const std::string senderName = info[0].As<Napi::String>().Utf8Value();
+  const uint32_t timeoutMs = info.Length() == 2
+      ? static_cast<uint32_t>(std::max<int32_t>(0, info[1].As<Napi::Number>().Int32Value()))
+      : 0U;
+
+  if (senderName.empty()) {
+    Napi::TypeError::New(env, "senderName must be non-empty").ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+
+  auto& state = State();
+  std::lock_guard<std::mutex> guard(state.mutex);
+
+  if (state.symbols.sendGetTally == nullptr) {
+    return env.Null();
+  }
+
+  auto senderIt = state.senders.find(senderName);
+  if (senderIt == state.senders.end() || senderIt->second.sender == nullptr) {
+    return env.Null();
+  }
+
+  NDIlib_tally_t tally{};
+  state.symbols.sendGetTally(senderIt->second.sender, &tally, timeoutMs);
+  Napi::Object out = Napi::Object::New(env);
+  out.Set("onProgram", Napi::Boolean::New(env, tally.on_program));
+  out.Set("onPreview", Napi::Boolean::New(env, tally.on_preview));
+  return out;
+}
+
 Napi::Value DestroySender(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
 
@@ -969,6 +1016,7 @@ Napi::Object Init(Napi::Env env, Napi::Object exports) {
   exports.Set("sendRgbaFrame", Napi::Function::New(env, SendRgbaFrame));
   exports.Set("sendAudioFrame", Napi::Function::New(env, SendAudioFrame));
   exports.Set("getSenderConnections", Napi::Function::New(env, GetSenderConnections));
+  exports.Set("getSenderTally", Napi::Function::New(env, GetSenderTally));
   exports.Set("destroySender", Napi::Function::New(env, DestroySender));
   exports.Set("getRuntimeInfo", Napi::Function::New(env, GetRuntimeInfo));
   return exports;


### PR DESCRIPTION
## Summary

This PR collects all `dev` commits ahead of `main` for the **0.1.12** release.

### New: Talks deck item
A third deck item type alongside presentations and lyrics. Talks own slides like a presentation, but each slide carries an ordered list of script blocks that drive live navigation and stage text bindings.

- Schema v13 adds `talks`, `slides.talk_id`, `talk_script_blocks`, and `playlist_entries.talk_id`.
- Schema v14 recreates `slides` to include `talk_id` in the owner-FK CHECK constraint, which v13's `ALTER TABLE` could not update.
- `goNext`/`goPrev` step through script blocks before advancing slides.
- New text bindings: `talk-script-current`, `talk-script-progress`.
- Import/export and bundles round-trip script blocks; theme compatibility extends to talks for `slides`-kind themes.

### NDI sender
- **Latency instrumentation** (originally PR #60's goal): per-frame timestamps across capture → IPC → main → host → wire, surfaced as p50/p95/last/count in the observability panel. Adds `NDIlib_send_get_tally` binding to `@lumacast/ndi-native` and a Receiver Health section. Pure measurement — no behavior change.
- **Force NDI capture on every RAF tick** when clock/timer text bindings are on screen.
- **Fix NDI capture for bound text changes**.

### Fixes
- Collection assignment for media assets.
- Pre-existing `snapshot-patch` bug: collection upserts/deletes had no inverse case, making collection mutations silently non-undoable.

### Other
- Removed transient debug `console.log`s from `CreateDeckItemDialog`.
- Version bump to **0.1.12**.

## Test plan

### Talks
- [ ] Existing 0.1.11 projects open cleanly; v13 → v14 migration runs once without errors.
- [ ] Create a Talk, add slides and script blocks; `goNext`/`goPrev` step blocks then advance slides.
- [ ] `talk-script-current` / `talk-script-progress` bindings render on stage and over NDI.
- [ ] Duplicate / delete Talk slides preserves script blocks correctly.
- [ ] Import/export filter includes Talks; deck bundles round-trip script blocks.
- [ ] Theme assignment works for both Presentation and Talk (slides-kind themes).
- [ ] Existing presentation and lyric flows unchanged (regression check).

### NDI
- [ ] `npm run typecheck`, `npm test`, `npm run build` pass.
- [ ] Native addon rebuilds against Electron's ABI via `npm run predev` / `prebuild`.
- [ ] Observability panel populates pipeline latency rows as frames flow; `signatureToWire` p50/p95 populate on resize.
- [ ] Connection count and tally state reflect a real receiver (or show "unsupported" on older runtimes).
- [ ] Bound text updates push NDI frames; clock/timer bindings keep ticking.

### Misc
- [ ] Undoing a collection rename / delete restores prior state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)