### PR TITLE
Fix log errors, expose Move to collection, bump to 0.1.13

### DIFF
--- a/app/database/store.ts
+++ b/app/database/store.ts
@@ -3584,9 +3584,12 @@ export class CastRepository {
     const slideId = `${themeId}:slide`;
     const currentOrder =
       (this.db.prepare('SELECT MAX(order_index) AS maxOrder FROM themes').get() as { maxOrder: number | null }).maxOrder ?? -1;
-    const elements = input.elements
+    const sourceElements = input.elements
       ? JSON.parse(JSON.stringify(input.elements)) as SlideElement[]
       : createDefaultThemeElements(input.kind, slideId, now);
+    // New container — regenerate element IDs so cloned input can't collide
+    // with the source theme's existing slide_elements rows.
+    const elements = sourceElements.map((el) => ({ ...el, id: createId(), slideId }));
     const collectionId = input.collectionId ?? this.getDefaultCollectionId('theme');
     const width = input.width ?? DEFAULT_W;
     const height = input.height ?? DEFAULT_H;
@@ -4732,7 +4735,9 @@ export class CastRepository {
     const now = nowIso();
     const overlayId = createId();
     const slideId = `${overlayId}:slide`;
-    const elements = input.elements ?? [];
+    // New container — regenerate element IDs so cloned/duplicated input
+    // can't collide with the source overlay's existing slide_elements rows.
+    const elements = (input.elements ?? []).map((el) => ({ ...el, id: createId(), slideId }));
     const collectionId = input.collectionId ?? this.getDefaultCollectionId('overlay');
 
     const tx = this.db.transaction(() => {
@@ -5054,7 +5059,9 @@ export class CastRepository {
     const now = nowIso();
     const stageId = createId();
     const slideId = `${stageId}:slide`;
-    const elements = input.elements ?? [];
+    // New container — regenerate element IDs so cloned input can't collide
+    // with the source stage's existing slide_elements rows.
+    const elements = (input.elements ?? []).map((el) => ({ ...el, id: createId(), slideId }));
     const width = input.width ?? 1920;
     const height = input.height ?? 1080;
     const nextOrderRow = this.db

--- a/app/main/index.ts
+++ b/app/main/index.ts
@@ -44,7 +44,7 @@ try {
   // Logger will fall back to stderr-only if the Documents dir is not writable.
   console.error('[Main process documents dir mkdir failed]', error);
 }
-initializeLogger(documentsDataDir);
+initializeLogger(documentsDataDir, { appVersion: app.getVersion() });
 console.log(`[main] userData=${app.getPath('userData')}`);
 console.log(`[main] documentsDataDir=${documentsDataDir}`);
 console.log(`[main] logFile=${getLogFilePath()}`);
@@ -231,8 +231,8 @@ function createMainWindow(): void {
   window.webContents.on('preload-error', (_event, preloadPath, error) => {
     console.error('[renderer] preload-error', { preloadPath, message: error?.message, stack: error?.stack });
   });
-  window.webContents.on('console-message', (_event, level, message, line, sourceId) => {
-    console.log(`[renderer:console l=${level}] ${message} (${sourceId}:${line})`);
+  window.webContents.on('console-message', (event) => {
+    console.log(`[renderer:console l=${event.level}] ${event.message} (${event.sourceId}:${event.lineNumber})`);
   });
   window.on('unresponsive', () => {
     console.warn('[window] unresponsive');

--- a/app/main/logger.ts
+++ b/app/main/logger.ts
@@ -20,7 +20,11 @@ let initialized = false;
 // it explicitly so the tailer's offset semantics are unambiguous).
 let sessionStartByteOffset = 0;
 
-export function initializeLogger(baseDir: string): void {
+export interface LoggerInitOptions {
+  appVersion?: string;
+}
+
+export function initializeLogger(baseDir: string, options: LoggerInitOptions = {}): void {
   if (initialized) return;
   initialized = true;
 
@@ -54,6 +58,7 @@ export function initializeLogger(baseDir: string): void {
 
   writeLine('INFO', [
     `[logger] Logging to ${logFilePath}`,
+    `app=${options.appVersion ?? 'n/a'}`,
     `pid=${process.pid}`,
     `platform=${process.platform}`,
     `arch=${process.arch}`,
@@ -176,8 +181,20 @@ function patchConsole(method: ConsoleMethod): void {
   const original = console[method].bind(console);
   console[method] = (...args: unknown[]) => {
     original(...args);
-    writeLine(LEVEL_BY_METHOD[method], args);
+    writeLine(deriveLevel(method, args), args);
   };
+}
+
+// Node routes process warnings (e.g., ExperimentalWarning) through
+// console.error, but they're advisory — surface them as WARN.
+function deriveLevel(method: ConsoleMethod, args: unknown[]): string {
+  const base = LEVEL_BY_METHOD[method];
+  if (base !== 'ERROR') return base;
+  const first = args[0];
+  if (typeof first === 'string' && /^\(node:\d+\)\s+\w*Warning:/.test(first)) {
+    return 'WARN';
+  }
+  return base;
 }
 
 function writeLine(level: string, args: unknown[]): void {

--- a/app/renderer/features/assets/audio/audio-bin-panel.tsx
+++ b/app/renderer/features/assets/audio/audio-bin-panel.tsx
@@ -124,18 +124,18 @@ function AudioRowBody({ asset, isActive, onArm, collectionsApi }: AudioRowProps)
       </SelectableRow.Root>
       <ContextMenu.Portal>
         <ContextMenu.Menu>
-          {otherCollections.length > 0 ? (
-            <>
-              <ContextMenu.Submenu label="Move to collection">
-                {otherCollections.map((collection) => (
-                  <ContextMenu.Item key={collection.id} onSelect={() => handleMoveToCollection(collection.id)}>
-                    {collection.name}
-                  </ContextMenu.Item>
-                ))}
-              </ContextMenu.Submenu>
-              <ContextMenu.Separator />
-            </>
-          ) : null}
+          <ContextMenu.Submenu label="Move to collection">
+            {otherCollections.length > 0 ? (
+              otherCollections.map((collection) => (
+                <ContextMenu.Item key={collection.id} onSelect={() => handleMoveToCollection(collection.id)}>
+                  {collection.name}
+                </ContextMenu.Item>
+              ))
+            ) : (
+              <ContextMenu.Item disabled onSelect={() => {}}>No other collections</ContextMenu.Item>
+            )}
+          </ContextMenu.Submenu>
+          <ContextMenu.Separator />
           <ContextMenu.Item variant="destructive" onSelect={() => { void handleDelete(); }}>Delete</ContextMenu.Item>
         </ContextMenu.Menu>
       </ContextMenu.Portal>

--- a/app/renderer/features/assets/overlays/overlay-bin-panel.tsx
+++ b/app/renderer/features/assets/overlays/overlay-bin-panel.tsx
@@ -145,18 +145,20 @@ function OverlayCardBody({ overlay, index, isActive, onActivate, onEdit, setWork
           <ContextMenu.Item onSelect={handleEdit}>Edit</ContextMenu.Item>
           <ContextMenu.Item onSelect={() => { renameRef.current?.startEditing(); }}>Rename</ContextMenu.Item>
           <ContextMenu.Item onSelect={() => { duplicateOverlay(overlay.id); }}>Duplicate</ContextMenu.Item>
-          {otherCollections.length > 0 ? (
-            <ContextMenu.Submenu label="Move to collection">
-              {otherCollections.map((collection) => (
+          <ContextMenu.Submenu label="Move to collection">
+            {otherCollections.length > 0 ? (
+              otherCollections.map((collection) => (
                 <ContextMenu.Item
                   key={collection.id}
                   onSelect={() => { void collectionsApi.assignItem('overlay', overlay.id, collection.id); }}
                 >
                   {collection.name}
                 </ContextMenu.Item>
-              ))}
-            </ContextMenu.Submenu>
-          ) : null}
+              ))
+            ) : (
+              <ContextMenu.Item disabled onSelect={() => {}}>No other collections</ContextMenu.Item>
+            )}
+          </ContextMenu.Submenu>
           <ContextMenu.Separator />
           <ContextMenu.Item variant="destructive" onSelect={() => { void handleDelete(); }}>Delete</ContextMenu.Item>
         </ContextMenu.Menu>

--- a/app/renderer/features/assets/stages/stage-bin-panel.tsx
+++ b/app/renderer/features/assets/stages/stage-bin-panel.tsx
@@ -100,6 +100,7 @@ function StageCardBody({ stage, index, isActive, onActivate, onEdit, collections
   const renameRef = useRef<RenameFieldHandle>(null);
   const confirm = useConfirm();
   const { ref: triggerRef, ...triggerHandlers } = useContextMenuTrigger();
+  const otherCollections = collectionsApi.collections.filter((c) => c.id !== stage.collectionId);
 
   function handleActivate() {
     onActivate(isActive ? null : stage.id);
@@ -145,18 +146,20 @@ function StageCardBody({ stage, index, isActive, onActivate, onEdit, collections
           <ContextMenu.Item onSelect={handleEdit}>Edit</ContextMenu.Item>
           <ContextMenu.Item onSelect={() => { renameRef.current?.startEditing(); }}>Rename</ContextMenu.Item>
           <ContextMenu.Item onSelect={() => { duplicateStage(stage.id); }}>Duplicate</ContextMenu.Item>
-          {collectionsApi.collections.filter((c) => c.id !== stage.collectionId).length > 0 ? (
-            <ContextMenu.Submenu label="Move to collection">
-              {collectionsApi.collections.filter((c) => c.id !== stage.collectionId).map((collection) => (
+          <ContextMenu.Submenu label="Move to collection">
+            {otherCollections.length > 0 ? (
+              otherCollections.map((collection) => (
                 <ContextMenu.Item
                   key={collection.id}
                   onSelect={() => { void collectionsApi.assignItem('stage', stage.id, collection.id); }}
                 >
                   {collection.name}
                 </ContextMenu.Item>
-              ))}
-            </ContextMenu.Submenu>
-          ) : null}
+              ))
+            ) : (
+              <ContextMenu.Item disabled onSelect={() => {}}>No other collections</ContextMenu.Item>
+            )}
+          </ContextMenu.Submenu>
           <ContextMenu.Separator />
           <ContextMenu.Item variant="destructive" onSelect={() => { void handleDelete(); }}>Delete</ContextMenu.Item>
         </ContextMenu.Menu>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lumacast",
   "productName": "LumaCast",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "private": true,
   "description": "Cross-platform presentation tool with reusable content hierarchy, slide rendering, and NDI output",
   "author": "IT-PSAPE",


### PR DESCRIPTION
## Summary
- **Logger**: include app version in the session header; reclassify Node `ExperimentalWarning` lines from `ERROR` to `WARN`
- **Electron API**: update `console-message` listener to the new `Event<WebContentsConsoleMessageEventParams>` signature, silencing the deprecation warning
- **DB fix**: regenerate `slide_elements.id` values in `createOverlay`/`createTheme`/`createStage` so cloned/duplicated inputs cannot collide with the source container's rows (resolves recurring `UNIQUE constraint failed: slide_elements.id` errors on overlay duplication)
- **UI**: always show the **Move to collection** submenu in the audio, overlay, and stage bin context menus, with a disabled "No other collections" placeholder when only the default collection exists
- **Version**: bump to `0.1.13`

## Test plan
- [ ] Launch the app — confirm the session log header includes `app=0.1.13`
- [ ] Confirm Node ExperimentalWarning lines are now logged at `WARN` level
- [ ] Confirm no `console-message arguments are deprecated` warning appears in the log
- [ ] Duplicate an overlay; confirm no `UNIQUE constraint failed` errors
- [ ] Right-click an item in the audio, overlay, and stage bins — confirm "Move to collection" appears; with only the default collection it shows a disabled "No other collections" placeholder; after creating a second collection via the picker it lists real entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)