### PR TITLE
Talk decks, NDI fixes, slide FK fix, 0.1.13

### DIFF
--- a/app/core/presentation-layers.ts
+++ b/app/core/presentation-layers.ts
@@ -3,6 +3,12 @@ import type { MediaAsset, Overlay, Slide, SlideElement } from './types';
 export const OUTPUT_FRAME_WIDTH = 1920;
 export const OUTPUT_FRAME_HEIGHT = 1080;
 
+// Sentinel element id for the dedicated video-layer node. Rendering treats
+// this node as "owned by the playback transport" and reads from the layer
+// registry instead of creating its own <video> element.
+export const LAYER_VIDEO_NODE_ID = '__layer_video';
+export const LAYER_MEDIA_NODE_ID = '__layer_media';
+
 export const LAYER_PREVIEW_SLIDE: Slide = {
   id: '__layer_preview__',
   presentationId: null,
@@ -32,7 +38,7 @@ interface PlaybackLayerElementOptions {
 }
 
 export function mediaAssetToLayerElement(asset: MediaAsset, options: PlaybackLayerElementOptions = {}): SlideElement {
-  const { id = '__layer_media', zIndex = 0, videoPlayback } = options;
+  const { id = LAYER_MEDIA_NODE_ID, zIndex = 0, videoPlayback } = options;
 
   if (asset.type === 'audio') {
     return {

--- a/app/renderer/contexts/asset-editor/asset-editor-context.tsx
+++ b/app/renderer/contexts/asset-editor/asset-editor-context.tsx
@@ -671,6 +671,7 @@ export function AssetEditorProvider({ children }: { children: ReactNode }) {
 
   const deckHasPendingChanges = useMemo(() => {
     for (const slideId of Object.keys(stagedSlides)) {
+      if (!persistedElementsBySlideId.has(slideId)) continue;
       const persisted = persistedElementsBySlideId.get(slideId) ?? [];
       const staged = stagedSlides[slideId] ?? [];
       if (slideElementsSignature(persisted) !== slideElementsSignature(staged)) return true;
@@ -686,9 +687,20 @@ export function AssetEditorProvider({ children }: { children: ReactNode }) {
     setStagedSlides((current) => ({ ...current, [slideId]: cloneElements(elements) }));
   }, []);
 
+  useEffect(() => {
+    setStagedSlides((current) => {
+      const stale = Object.keys(current).filter((slideId) => !persistedElementsBySlideId.has(slideId));
+      if (stale.length === 0) return current;
+      const next = { ...current };
+      for (const slideId of stale) delete next[slideId];
+      return next;
+    });
+  }, [persistedElementsBySlideId]);
+
   const pushDeckChanges = useCallback(async () => {
     if (isDeckPushingChanges) return;
     const pendingSlideIds = Object.keys(stagedSlides).filter((slideId) => {
+      if (!persistedElementsBySlideId.has(slideId)) return false;
       const persisted = persistedElementsBySlideId.get(slideId) ?? [];
       const staged = stagedSlides[slideId] ?? [];
       return slideElementsSignature(persisted) !== slideElementsSignature(staged);

--- a/app/renderer/contexts/playback/playback-context.tsx
+++ b/app/renderer/contexts/playback/playback-context.tsx
@@ -3,7 +3,7 @@ import type { Id, MediaAsset, Overlay } from '@core/types';
 import { useCast } from '../app-context';
 import { useNavigation } from '../navigation-context';
 import { useProjectContent } from '../use-project-content';
-import { getLayerVideoElement, retainVideoSource, subscribeToVideoPool } from '../../features/canvas/use-k-video';
+import { getLayerVideoElement, retainVideoSource, subscribeToVideoPool, type VideoLayerHandle } from '../../features/canvas/use-k-video';
 import { addNdiAudioElement, removeNdiAudioElement } from '../../features/playback/ndi-audio-capture';
 import { recordObsEvent } from '../../features/observability/metrics-store';
 import {
@@ -616,10 +616,10 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
 
   // ── Video transport ──
   //
-  // The layer video is rendered through the Konva canvas via the shared
-  // `videoPool` in use-k-video. We don't own that <video> element — instead we
-  // look it up by src via `getLayerVideoElement`, subscribe to pool changes,
-  // and drive play/pause/seek directly on the looked-up element.
+  // The layer video is owned by the use-k-video layer registry via
+  // `retainVideoSource`. We hold the retain handle for its lifetime, update
+  // playback options through it, and look up the live <video> element by src
+  // for direct seek/play/pause control.
 
   const videoAssets = useMemo(
     () => mediaAssets.filter((asset) => asset.type === 'video'),
@@ -640,15 +640,29 @@ export function PlaybackProvider({ children }: { children: ReactNode }) {
   }), [videoLoopEnabled, videoMuted, videoRequestedPlay]);
 
   // Keep the armed layer video alive even if the currently visible surface
-  // changes and temporarily unmounts the SceneStage that was using it.
+  // changes and temporarily unmounts the SceneStage that was using it. The
+  // retain handle is created once per src and updated in place for option
+  // changes (mute/loop/play) so toggling a transport control never tears
+  // down the underlying <video> and resets currentTime.
+  const videoLayerHandleRef = useRef<VideoLayerHandle | null>(null);
+  const videoLayerPlaybackRef = useRef(videoLayerPlayback);
+  videoLayerPlaybackRef.current = videoLayerPlayback;
   useEffect(() => {
     if (!videoLayerAsset?.src) return undefined;
-    return retainVideoSource(videoLayerAsset.src, videoLayerPlayback);
-  }, [videoLayerAsset?.src, videoLayerPlayback]);
+    const handle = retainVideoSource(videoLayerAsset.src, videoLayerPlaybackRef.current);
+    videoLayerHandleRef.current = handle;
+    return () => {
+      videoLayerHandleRef.current = null;
+      handle.release();
+    };
+  }, [videoLayerAsset?.src]);
+  useEffect(() => {
+    videoLayerHandleRef.current?.setOptions(videoLayerPlayback);
+  }, [videoLayerPlayback]);
 
-  // Track whichever HTMLVideoElement the canvas pool is using for the current
-  // layer video. Re-checks on pool changes (entry created/loaded/removed) and
-  // when videoLayerAsset changes.
+  // Track the live HTMLVideoElement for the armed layer video. Re-checks
+  // when the registry signals an entry was created/loaded/removed, and when
+  // videoLayerAsset changes.
   useEffect(() => {
     function refresh() {
       const next = videoLayerAsset ? getLayerVideoElement(videoLayerAsset.src) : null;

--- a/app/renderer/features/canvas/build-render-scene.ts
+++ b/app/renderer/features/canvas/build-render-scene.ts
@@ -1,5 +1,5 @@
 import { readVisualPayload } from '@core/element-payload';
-import { LAYER_PREVIEW_SLIDE, mediaAssetToLayerElement, overlayToLayerElements } from '@core/presentation-layers';
+import { LAYER_PREVIEW_SLIDE, LAYER_VIDEO_NODE_ID, mediaAssetToLayerElement, overlayToLayerElements } from '@core/presentation-layers';
 import type { MediaAsset, Overlay, Slide, SlideElement } from '@core/types';
 import { sortElements } from '../../utils/slides';
 import type { BindingOverride } from './binding-context';
@@ -91,7 +91,7 @@ export function buildLayeredRenderScene({
 }: LayeredSceneInput): RenderScene {
   const merged: SceneElementInput[] = [];
   if (videoAsset) merged.push({ element: mediaAssetToLayerElement(videoAsset, {
-    id: '__layer_video',
+    id: LAYER_VIDEO_NODE_ID,
     zIndex: -1,
     videoPlayback,
   }) });

--- a/app/renderer/features/canvas/scene-node-media.tsx
+++ b/app/renderer/features/canvas/scene-node-media.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type Konva from 'konva';
 import { Group, Image as KonvaImage, Line, Rect } from 'react-konva';
+import { LAYER_VIDEO_NODE_ID } from '@core/presentation-layers';
 import type { VideoElementPayload } from '@core/types';
 import type { RenderNode, ResolvedMediaState, SceneSurface } from './scene-types';
 import { resolveMediaCover } from './resolve-media-cover';
@@ -107,12 +108,13 @@ export function SceneNodeMedia({ node, surface = 'show', onLoad }: SceneNodeMedi
   const videoPayload = node.element.type === 'video' ? node.element.payload as VideoElementPayload : null;
   const videoOptions = resolveVideoOptions(videoPayload, surface);
   const imageState = useKImage(imageSrc);
+  const isLayerVideoNode = node.element.id === LAYER_VIDEO_NODE_ID;
   const videoState = useKVideo(videoPayload?.src ?? null, {
     autoplay: videoOptions.autoplay,
     loop: videoOptions.loop,
     muted: videoOptions.muted,
     playbackRate: videoOptions.playbackRate,
-  });
+  }, isLayerVideoNode);
   const requestKey = getMediaRequestKey(node);
   const resolvedState = node.element.type === 'image' ? imageState : videoState;
   const loadedMedia = useMemo<LoadedMedia | null>(() => {

--- a/app/renderer/features/canvas/use-k-video.ts
+++ b/app/renderer/features/canvas/use-k-video.ts
@@ -8,128 +8,109 @@ interface UseKVideoOptions {
   playbackRate: number;
 }
 
-interface VideoPoolEntry {
-  key: string;
+// Video transport is split in two:
+//
+//  1. The dedicated video layer — exactly one HTMLVideoElement per `src`,
+//     owned by `retainVideoSource` and looked up via `getLayerVideoElement`.
+//     The playback context drives this element (play/pause/seek/mute via the
+//     transport UI) and keeps it alive across surface unmounts so audio does
+//     not stop when leaving Show.
+//
+//  2. Every other rendered video — slides, overlays, stages, editor canvases,
+//     bin thumbnails — gets its own per-instance HTMLVideoElement via
+//     `useKVideo`. No state is shared across instances, so a muted slide can
+//     never have its audio leaked by another consumer of the same `src`, and
+//     a preview never inherits transport state from the live layer.
+
+interface LayerEntry {
+  src: string;
+  video: HTMLVideoElement;
   status: 'loading' | 'broken' | 'loaded';
   refCount: number;
-  video: HTMLVideoElement;
-  listeners: Set<() => void>;
-  consumers: Map<symbol, UseKVideoOptions>;
+  options: UseKVideoOptions;
   cleanup: () => void;
 }
 
-const videoPool = new Map<string, VideoPoolEntry>();
-const videoPoolListeners = new Set<() => void>();
+const layerRegistry = new Map<string, LayerEntry>();
+const layerListeners = new Set<() => void>();
 
-// Pool identity is `src` alone. All per-surface playback state (autoplay,
-// loop, muted, playbackRate) is layered on top via consumer aggregation, so
-// toggling any of those does not swap the underlying <video> element and
-// never loses currentTime.
-function getVideoPoolKey(src: string): string {
-  return src;
+function notifyLayerListeners() {
+  layerListeners.forEach((listener) => { listener(); });
 }
 
-function notifyVideoPoolListeners() {
-  videoPoolListeners.forEach((listener) => listener());
-}
-
-// Subscribes to pool membership changes (entries added/removed/loaded). Lets
-// outside controllers watch for the layer-video element to come online.
+// Notifies when a layer-registry entry is created, loaded, broken, or
+// destroyed. Used by the playback context to (re-)resolve the layer element
+// via `getLayerVideoElement`.
 export function subscribeToVideoPool(listener: () => void): () => void {
-  videoPoolListeners.add(listener);
-  return () => { videoPoolListeners.delete(listener); };
+  layerListeners.add(listener);
+  return () => { layerListeners.delete(listener); };
 }
 
-// Looks up the loaded HTMLVideoElement for `src` regardless of playback flags.
 export function getLayerVideoElement(src: string | null): HTMLVideoElement | null {
   if (!src) return null;
-  const entry = videoPool.get(getVideoPoolKey(src));
+  const entry = layerRegistry.get(src);
   if (!entry || entry.status !== 'loaded') return null;
   return entry.video;
 }
 
-export function retainVideoSource(src: string, options: UseKVideoOptions): () => void {
-  const consumerId = Symbol(src);
-  const entry = acquireVideoEntry(src, options, consumerId);
-  let released = false;
-  return () => {
-    if (released) return;
-    released = true;
-    releaseVideoEntry(entry, consumerId);
-  };
-}
-
-function toResolvedMediaState(entry: VideoPoolEntry): ResolvedMediaState {
-  if (entry.status === 'loaded') {
-    return { status: 'loaded', resource: entry.video };
-  }
-
-  return { status: entry.status };
-}
-
-function notifyListeners(entry: VideoPoolEntry) {
-  entry.listeners.forEach((listener) => {
-    listener();
-  });
-}
-
-function syncVideoEntryState(entry: VideoPoolEntry) {
-  const consumers = Array.from(entry.consumers.values());
-  const autoplay = consumers.some((consumer) => consumer.autoplay);
-  const muted = consumers.every((consumer) => consumer.muted);
-  const loop = consumers.some((consumer) => consumer.loop);
-  const playbackRate = consumers[0]?.playbackRate ?? 1;
-
-  entry.video.autoplay = autoplay;
-  entry.video.loop = loop;
-  entry.video.muted = muted;
-  entry.video.playbackRate = playbackRate;
-
-  if (entry.status !== 'loaded') return;
-  if (autoplay) {
-    void entry.video.play().catch(() => undefined);
-    return;
-  }
-  if (!entry.video.paused) {
-    entry.video.pause();
-  }
-}
-
-function createVideoPoolEntry(src: string, { autoplay, loop, muted, playbackRate }: UseKVideoOptions): VideoPoolEntry {
+function createVideoElement(src: string, options: UseKVideoOptions): HTMLVideoElement {
   const video = document.createElement('video');
   video.src = src;
-  video.autoplay = autoplay;
-  video.loop = loop;
-  video.muted = muted;
-  video.playbackRate = playbackRate;
+  video.autoplay = options.autoplay;
+  video.loop = options.loop;
+  video.muted = options.muted;
+  video.playbackRate = options.playbackRate;
   video.playsInline = true;
   video.crossOrigin = 'anonymous';
   video.preload = 'metadata';
+  return video;
+}
 
-  const entry: VideoPoolEntry = {
-    key: getVideoPoolKey(src),
+function destroyVideoElement(video: HTMLVideoElement) {
+  video.pause();
+  video.removeAttribute('src');
+  video.load();
+}
+
+function applyVideoOptions(video: HTMLVideoElement, options: UseKVideoOptions) {
+  video.loop = options.loop;
+  if (video.muted !== options.muted) video.muted = options.muted;
+  if (video.playbackRate !== options.playbackRate) video.playbackRate = options.playbackRate;
+  if (options.autoplay) {
+    if (video.paused) void video.play().catch(() => undefined);
+    return;
+  }
+  if (!video.paused) video.pause();
+}
+
+export interface VideoLayerHandle {
+  release(): void;
+  setOptions(options: UseKVideoOptions): void;
+}
+
+function makeLayerEntry(src: string, options: UseKVideoOptions): LayerEntry {
+  const video = createVideoElement(src, options);
+  const entry: LayerEntry = {
+    src,
+    video,
     status: 'loading',
     refCount: 0,
-    video,
-    listeners: new Set(),
-    consumers: new Map(),
+    options,
     cleanup: () => undefined,
   };
 
   const handleReady = () => {
+    if (entry.status === 'loaded') return;
     entry.status = 'loaded';
-    notifyListeners(entry);
-    notifyVideoPoolListeners();
-    if (autoplay) {
+    notifyLayerListeners();
+    if (entry.options.autoplay) {
       void video.play().catch(() => undefined);
     }
   };
-
   const handleError = () => {
     if (entry.status === 'loaded') return;
     entry.status = 'broken';
-    notifyListeners(entry);
-    notifyVideoPoolListeners();
+    notifyLayerListeners();
   };
 
   video.addEventListener('loadeddata', handleReady);
@@ -137,106 +118,122 @@ function createVideoPoolEntry(src: string, { autoplay, loop, muted, playbackRate
   entry.cleanup = () => {
     video.removeEventListener('loadeddata', handleReady);
     video.removeEventListener('error', handleError);
-    video.pause();
-    video.removeAttribute('src');
-    video.load();
+    destroyVideoElement(video);
   };
 
   if (video.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA) {
-    handleReady();
+    entry.status = 'loaded';
   } else {
     video.load();
   }
-
   return entry;
 }
 
-function acquireVideoEntry(src: string, options: UseKVideoOptions, consumerId: symbol): VideoPoolEntry {
-  const key = getVideoPoolKey(src);
-  let entry = videoPool.get(key);
+export function retainVideoSource(src: string, initialOptions: UseKVideoOptions): VideoLayerHandle {
+  let entry = layerRegistry.get(src);
   const created = !entry;
   if (!entry) {
-    entry = createVideoPoolEntry(src, options);
-    videoPool.set(key, entry);
+    entry = makeLayerEntry(src, initialOptions);
+    layerRegistry.set(src, entry);
   }
+  const e = entry;
+  e.refCount += 1;
+  e.options = initialOptions;
+  applyVideoOptions(e.video, initialOptions);
+  if (created) notifyLayerListeners();
 
-  entry.consumers.set(consumerId, options);
-  entry.refCount += 1;
-  syncVideoEntryState(entry);
-  if (created) notifyVideoPoolListeners();
-  return entry;
+  let released = false;
+  return {
+    release() {
+      if (released) return;
+      released = true;
+      e.refCount -= 1;
+      if (e.refCount > 0) return;
+      layerRegistry.delete(e.src);
+      e.cleanup();
+      notifyLayerListeners();
+    },
+    setOptions(next: UseKVideoOptions) {
+      if (released) return;
+      e.options = next;
+      applyVideoOptions(e.video, next);
+    },
+  };
 }
 
-function updateVideoEntryConsumer(entry: VideoPoolEntry, consumerId: symbol, options: UseKVideoOptions) {
-  if (!entry.consumers.has(consumerId)) return;
-  entry.consumers.set(consumerId, options);
-  syncVideoEntryState(entry);
-}
-
-function releaseVideoEntry(entry: VideoPoolEntry, consumerId: symbol) {
-  entry.consumers.delete(consumerId);
-  entry.refCount -= 1;
-  if (entry.refCount > 0) {
-    syncVideoEntryState(entry);
-    return;
-  }
-
-  videoPool.delete(entry.key);
-  entry.cleanup();
-  notifyVideoPoolListeners();
-}
-
-export function useKVideo(src: string | null, { autoplay, loop, muted, playbackRate }: UseKVideoOptions): ResolvedMediaState {
+// `layerOwned` opts the hook into reading the dedicated layer element from
+// the registry instead of creating its own. SceneNodeMedia sets this when the
+// node is the sentinel layer-video node so all live surfaces (show, NDI,
+// stage) render frames from the same playback-transport-owned element.
+export function useKVideo(
+  src: string | null,
+  { autoplay, loop, muted, playbackRate }: UseKVideoOptions,
+  layerOwned: boolean = false,
+): ResolvedMediaState {
   const [state, setState] = useState<ResolvedMediaState>({ status: 'empty' });
-  const activeEntryRef = useRef<VideoPoolEntry | null>(null);
-  const consumerIdRef = useRef(Symbol('use-k-video'));
+  const videoRef = useRef<HTMLVideoElement | null>(null);
   const optionsRef = useRef<UseKVideoOptions>({ autoplay, loop, muted, playbackRate });
   optionsRef.current = { autoplay, loop, muted, playbackRate };
 
   useEffect(() => {
     if (!src) {
-      const currentEntry = activeEntryRef.current;
-      if (currentEntry) {
-        releaseVideoEntry(currentEntry, consumerIdRef.current);
-      }
-      activeEntryRef.current = null;
+      videoRef.current = null;
       setState({ status: 'empty' });
       return;
     }
 
-    const entry = acquireVideoEntry(src, optionsRef.current, consumerIdRef.current);
-    activeEntryRef.current = entry;
-    setState(toResolvedMediaState(entry));
+    if (layerOwned) {
+      const refresh = () => {
+        const entry = layerRegistry.get(src);
+        if (!entry) {
+          setState({ status: 'loading' });
+          return;
+        }
+        if (entry.status === 'loaded') {
+          setState({ status: 'loaded', resource: entry.video });
+          return;
+        }
+        setState({ status: entry.status });
+      };
+      refresh();
+      layerListeners.add(refresh);
+      return () => { layerListeners.delete(refresh); };
+    }
 
-    const handleChange = () => {
-      setState(toResolvedMediaState(entry));
+    const video = createVideoElement(src, optionsRef.current);
+    videoRef.current = video;
+    setState({ status: 'loading' });
+
+    const handleReady = () => {
+      setState({ status: 'loaded', resource: video });
+      applyVideoOptions(video, optionsRef.current);
+    };
+    const handleError = () => {
+      setState({ status: 'broken' });
     };
 
-    entry.listeners.add(handleChange);
+    video.addEventListener('loadeddata', handleReady);
+    video.addEventListener('error', handleError);
+    if (video.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA) {
+      handleReady();
+    } else {
+      video.load();
+    }
 
     return () => {
-      entry.listeners.delete(handleChange);
-      if (activeEntryRef.current === entry) {
-        activeEntryRef.current = null;
-      }
-      releaseVideoEntry(entry, consumerIdRef.current);
+      video.removeEventListener('loadeddata', handleReady);
+      video.removeEventListener('error', handleError);
+      destroyVideoElement(video);
+      videoRef.current = null;
     };
-  }, [src]);
+  }, [src, layerOwned]);
 
   useEffect(() => {
-    const entry = activeEntryRef.current;
-    if (!entry) return;
-    updateVideoEntryConsumer(entry, consumerIdRef.current, { autoplay, loop, muted, playbackRate });
-  }, [autoplay, loop, muted, playbackRate]);
-
-  useEffect(() => {
-    return () => {
-      const currentEntry = activeEntryRef.current;
-      if (!currentEntry) return;
-      releaseVideoEntry(currentEntry, consumerIdRef.current);
-      activeEntryRef.current = null;
-    };
-  }, []);
+    if (layerOwned) return;
+    const video = videoRef.current;
+    if (!video) return;
+    applyVideoOptions(video, { autoplay, loop, muted, playbackRate });
+  }, [layerOwned, autoplay, loop, muted, playbackRate]);
 
   return state;
 }


### PR DESCRIPTION
## Summary
- Fix FK constraint error when pushing element edits to a slide that was deleted while changes were staged (prevents repeating `cast:createElementsBatch` FOREIGN KEY failures seen in customer logs).
- Add Talk deck items with per-slide script blocks.
- NDI capture fixes: force capture on every RAF tick for clock/timer text bindings, plus fix for bound text changes.
- Add NDI sender pipeline latency instrumentation.
- Fix collection assignment for media assets; expose "Move to collection".
- Bump version to 0.1.13.

## Test plan
- [ ] Edit a slide, delete it (or switch decks), then trigger a save — no FK constraint errors in logs; staged changes clear cleanly.
- [ ] Create/edit Talk deck items and verify per-slide script blocks persist.
- [ ] Verify NDI capture continues to update when clock/timer bindings are on screen.
- [ ] Move a media asset between collections and confirm it lands in the target collection.
- [ ] App identifies itself as 0.1.13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)