### PR TITLE
Add macro scope, lifecycle control, looping, and per-step delays (#70)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,70 @@
+# Automation (Macros & Cues)
+
+The automation context drives presentation side-effects (overlays, media, stages, layers) from
+triggers fired by slides, deck items, or app startup. This glossary fixes the language around
+macros, cues, scope, and lifecycle so that code, UI, and discussion stay aligned.
+
+## Language
+
+**Macro**:
+A named, ordered list of **Cues**. The unit of triggering, scope, looping, and lifecycle.
+_Avoid_: Cue Group, Action Group — a Macro *is* the group; there is no separate grouping concept.
+
+**Cue**:
+One atomic side-effect (activate an overlay, set a media layer, arm a video, …). Cues are
+content-deduped and shared across Macros, so a Cue is shared *identity*, not a per-use instance.
+A Cue inherits its Macro's **Scope**.
+_Avoid_: Action, Step (the DB tables are named `cues` / `action_steps`, but the domain term is Cue).
+
+**Cue step** (macro step / `MacroCue`):
+One ordered use of a **Cue** inside a **Macro**, carrying its own before/after **delays**. Delays
+are per-step (per occurrence), not part of the shared Cue identity — the same Cue can appear with
+different delays in different Macros.
+
+**Scope**:
+The context a Macro's lifetime is bound to. Levels: **global**, **deck item**, **slide**. The
+*level* is authored on the Macro; the *concrete context* (which slide / deck item) is captured
+from the trigger at run time.
+_Avoid_: Context (overloaded), Boundary.
+
+**Macro Run** (instance):
+One triggered execution of a Macro, bound to a concrete Scope context, with its own run id.
+Several Runs of the same Macro can be active at once — triggers **stack**, never dedupe.
+_Avoid_: Execution, Invocation (use Run consistently).
+
+**Scope exit**:
+The moment a Run's bound context stops being live — advancing off the bound slide, or switching
+to a different deck item. Global Runs never exit (until app close).
+
+**Cancel**:
+Stop a Run's pending delays and future loop iterations. Already-applied effects stay on screen.
+
+**Revert**:
+**Cancel** plus undo the Run's applied effects, using each Cue's static inverse (e.g.
+`overlay.activate` → clear that overlay). Does **not** restore whatever was on screen *before*
+the Macro ran.
+_Avoid_: Clear — `*.clear` / `*.clearAll` are forward Cue kinds that put the screen into a clean
+state; "Revert" is the lifecycle undo. Keep them distinct.
+
+## Relationships
+
+- A **Macro** contains one or more ordered **Cues**.
+- A **Trigger Binding** fires a **Macro** (scoped/lifecycle-managed) or a bare **Cue** (always
+  global fire-and-forget).
+- A **Macro Run** belongs to exactly one **Scope** context, resolved from its trigger.
+- **Scope exit** applies a Run's authored on-exit behavior: Cancel, Revert, or nothing.
+
+## Example dialogue
+
+> **Dev:** "If a slide triggers a looping Macro and the operator advances, what happens?"
+> **Domain expert:** "The Run exits scope. If the Macro's on-exit is Cancel, pending delays and
+> the next loop iteration stop but the overlay it already showed stays up. If it's Revert, that
+> overlay is also cleared via its inverse."
+> **Dev:** "And if they re-take the same slide while it's still running?"
+> **Domain expert:** "A second Run stacks alongside the first — triggers never dedupe."
+
+## Flagged ambiguities
+
+- "Clear" meant both a forward Cue kind and the lifecycle undo — resolved: the lifecycle undo is
+  **Revert**; "clear" refers only to the `*.clear` Cue kinds.
+- "Group" implied a Cue Group entity — resolved: there is no Cue Group; the **Macro** is the group.

--- a/app/core/types.ts
+++ b/app/core/types.ts
@@ -561,16 +561,25 @@ export type CueKind =
   | 'stage.clear'
   | 'layer.clear'
   | 'layer.clearAll'
-  | 'flow.wait';
+  | 'flow.lifecycle';
 export type TriggerType = 'slide.take' | 'slide.activate' | 'app.startup';
 export type TriggerBindingTargetType = 'cue' | 'macro';
+
+/** Level a macro's lifetime is bound to. The concrete context is captured from the trigger. */
+export type ScopeLevel = 'global' | 'deckItem' | 'slide';
+/** What happens to a macro run when its bound scope context stops being live. */
+export type OnScopeExit = 'cancel' | 'revert' | 'none';
+/** Lifecycle action a `flow.lifecycle` cue performs against targeted runs. */
+export type LifecycleAction = 'cancel' | 'revert';
+/** `'*'` targets all active runs; an Id targets every running instance of that macro. */
+export type LifecycleTarget = Id | '*';
 
 export type CuePayload =
   | { overlayId: Id }
   | { assetId: Id }
   | { stageId: Id }
   | { layer: CueClearLayer }
-  | { ms: number }
+  | { action: LifecycleAction; target: LifecycleTarget }
   | Record<string, never>;
 
 export interface Cue {
@@ -588,6 +597,10 @@ export interface MacroCue {
   cueId: Id;
   cue: Cue;
   orderIndex: number;
+  // Delays are per-occurrence (per macro step), not part of the shared cue
+  // identity — the same cue can appear with different delays in different macros.
+  delayBeforeMs: number;
+  delayAfterMs: number;
   createdAt: string;
   updatedAt: string;
 }
@@ -598,6 +611,11 @@ export interface Macro {
   description: string;
   collectionId: Id;
   cues: MacroCue[];
+  scopeLevel: ScopeLevel;
+  onScopeExit: OnScopeExit;
+  loopEnabled: boolean;
+  /** null = loop until scope exit / cancel; a number caps the iterations. */
+  loopCount: number | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -631,9 +649,15 @@ export interface MacroCreateInput {
   name: string;
   description?: string;
   collectionId?: Id;
+  scopeLevel?: ScopeLevel;
+  onScopeExit?: OnScopeExit;
+  loopEnabled?: boolean;
+  loopCount?: number | null;
   cues?: Array<{
     cueId: Id;
     orderIndex: number;
+    delayBeforeMs?: number;
+    delayAfterMs?: number;
   }>;
 }
 
@@ -641,10 +665,16 @@ export interface MacroUpdateInput {
   id: Id;
   name?: string;
   description?: string;
+  scopeLevel?: ScopeLevel;
+  onScopeExit?: OnScopeExit;
+  loopEnabled?: boolean;
+  loopCount?: number | null;
   cues?: Array<{
     id?: Id;
     cueId: Id;
     orderIndex: number;
+    delayBeforeMs?: number;
+    delayAfterMs?: number;
   }>;
 }
 

--- a/app/database/store.ts
+++ b/app/database/store.ts
@@ -55,6 +55,8 @@ import type {
   MacroCreateInput,
   MacroCue,
   MacroUpdateInput,
+  OnScopeExit,
+  ScopeLevel,
   MediaAsset,
   MediaAssetCreateInput,
   MediaAssetType,
@@ -111,7 +113,8 @@ const CUES_MACROS_SCHEMA_VERSION = 16;
 const MACROS_SEQUENTIAL_SCHEMA_VERSION = 17;
 const TRIGGER_BINDINGS_TARGET_REBUILD_SCHEMA_VERSION = 18;
 const SLIDE_BACKGROUND_SCHEMA_VERSION = 19;
-const LATEST_SCHEMA_VERSION = SLIDE_BACKGROUND_SCHEMA_VERSION;
+const MACRO_SCOPE_LIFECYCLE_SCHEMA_VERSION = 20;
+const LATEST_SCHEMA_VERSION = MACRO_SCOPE_LIFECYCLE_SCHEMA_VERSION;
 const GLOBAL_SCHEMA_VERSION = 3;
 const LEGACY_SCHEMA_VERSION = 2;
 
@@ -218,6 +221,18 @@ const parseJson = <T>(value: string): T => {
     console.error('[DB] Failed to parse JSON:', error, value.slice(0, 200));
     throw new Error(`Corrupted JSON data in database: ${(error as Error).message}`);
   }
+};
+
+const normalizeDelayMs = (value: number | undefined): number => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? Math.max(0, Math.round(parsed)) : 0;
+};
+
+const normalizeLoopCount = (value: number | null | undefined): number | null => {
+  if (value === null || value === undefined) return null;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return null;
+  return Math.round(parsed);
 };
 
 // One-shot rename of a pre-rename Recast database (and its WAL/SHM/backups)
@@ -523,11 +538,121 @@ export class CastRepository {
       this.ensureSlideBackgroundColumn();
       this.setUserVersion(SLIDE_BACKGROUND_SCHEMA_VERSION);
     }
+
+    if (this.getUserVersion() < MACRO_SCOPE_LIFECYCLE_SCHEMA_VERSION) {
+      this.migrateMacroScopeLifecycle();
+      this.setUserVersion(MACRO_SCOPE_LIFECYCLE_SCHEMA_VERSION);
+    }
   }
 
   private ensureSlideBackgroundColumn(): void {
     if (this.hasColumn('slides', 'background_json')) return;
     this.db.exec('ALTER TABLE slides ADD COLUMN background_json TEXT');
+  }
+
+  // v20 — fold scope/loop/lifecycle into macros and per-step delays into
+  // action_steps. Adds scope_level/on_scope_exit/loop_enabled/loop_count to
+  // `actions`, delay_before_ms/delay_after_ms to `action_steps`, then retires
+  // the standalone `flow.wait` cue kind by folding each wait into an adjacent
+  // step's delay and deleting the wait cues/steps plus bare-cue bindings to them.
+  //
+  // Delays live on the step (per-occurrence), not the cue, because cues are
+  // content-deduped and shared across macros — a delay belongs to where a cue
+  // is used, not to the cue's shared identity.
+  private migrateMacroScopeLifecycle(): void {
+    const tx = this.db.transaction(() => {
+      if (this.hasTable('actions')) {
+        if (!this.hasColumn('actions', 'scope_level')) {
+          this.db.exec("ALTER TABLE actions ADD COLUMN scope_level TEXT NOT NULL DEFAULT 'global'");
+        }
+        if (!this.hasColumn('actions', 'on_scope_exit')) {
+          this.db.exec("ALTER TABLE actions ADD COLUMN on_scope_exit TEXT NOT NULL DEFAULT 'cancel'");
+        }
+        if (!this.hasColumn('actions', 'loop_enabled')) {
+          this.db.exec('ALTER TABLE actions ADD COLUMN loop_enabled INTEGER NOT NULL DEFAULT 0');
+        }
+        if (!this.hasColumn('actions', 'loop_count')) {
+          this.db.exec('ALTER TABLE actions ADD COLUMN loop_count INTEGER');
+        }
+      }
+
+      if (this.hasTable('action_steps')) {
+        if (!this.hasColumn('action_steps', 'delay_before_ms')) {
+          this.db.exec('ALTER TABLE action_steps ADD COLUMN delay_before_ms INTEGER NOT NULL DEFAULT 0');
+        }
+        if (!this.hasColumn('action_steps', 'delay_after_ms')) {
+          this.db.exec('ALTER TABLE action_steps ADD COLUMN delay_after_ms INTEGER NOT NULL DEFAULT 0');
+        }
+        this.foldFlowWaitStepsIntoDelays();
+      }
+    });
+    tx();
+  }
+
+  // Convert every `flow.wait` step into delay milliseconds on a neighbouring
+  // step, then delete the wait cues and steps. Within each macro, ordered by
+  // order_index: a wait folds into the following non-wait step's delay_before_ms;
+  // if there is no following step, it folds into the preceding non-wait step's
+  // delay_after_ms; consecutive waits accumulate. Waits with no neighbour (a
+  // macro made only of waits) are discarded. Because delays are written to the
+  // step (not the shared cue), there is no cross-macro contamination.
+  private foldFlowWaitStepsIntoDelays(): void {
+    interface StepRow {
+      stepId: string;
+      orderIndex: number;
+      kind: string;
+      ms: number;
+    }
+    const steps = this.db
+      .prepare(
+        `SELECT s.id AS stepId, s.action_id AS macroId, s.order_index AS orderIndex,
+                c.kind AS kind, c.payload_json AS payloadJson
+         FROM action_steps s
+         JOIN cues c ON c.id = s.cue_id
+         ORDER BY s.action_id, s.order_index`,
+      )
+      .all() as Array<{ stepId: string; macroId: string; orderIndex: number; kind: string; payloadJson: string }>;
+
+    const byMacro = new Map<string, StepRow[]>();
+    for (const row of steps) {
+      let ms = 0;
+      if (row.kind === 'flow.wait') {
+        try {
+          const parsed = JSON.parse(row.payloadJson ?? '{}') as { ms?: number };
+          ms = Number.isFinite(parsed.ms) ? Math.max(0, Math.round(Number(parsed.ms))) : 0;
+        } catch { ms = 0; }
+      }
+      const list = byMacro.get(row.macroId) ?? [];
+      list.push({ stepId: row.stepId, orderIndex: row.orderIndex, kind: row.kind, ms });
+      byMacro.set(row.macroId, list);
+    }
+
+    const addBefore = this.db.prepare('UPDATE action_steps SET delay_before_ms = delay_before_ms + ? WHERE id = ?');
+    const addAfter = this.db.prepare('UPDATE action_steps SET delay_after_ms = delay_after_ms + ? WHERE id = ?');
+
+    for (const list of byMacro.values()) {
+      list.sort((a, b) => a.orderIndex - b.orderIndex);
+      for (let i = 0; i < list.length; i += 1) {
+        const step = list[i];
+        if (step.kind !== 'flow.wait' || step.ms <= 0) continue;
+        const next = list.slice(i + 1).find((s) => s.kind !== 'flow.wait');
+        if (next) {
+          addBefore.run(step.ms, next.stepId);
+        } else {
+          const prev = list.slice(0, i).reverse().find((s) => s.kind !== 'flow.wait');
+          if (prev) addAfter.run(step.ms, prev.stepId);
+        }
+      }
+    }
+
+    // Retire the kind entirely: drop every flow.wait cue along with its macro
+    // steps and any bare-cue trigger bindings that pointed at it.
+    const leftoverWaitCues = this.db.prepare("SELECT id FROM cues WHERE kind = 'flow.wait'").all() as Array<{ id: string }>;
+    for (const { id } of leftoverWaitCues) {
+      this.db.prepare("DELETE FROM trigger_bindings WHERE target_type = 'cue' AND target_id = ?").run(id);
+      this.db.prepare('DELETE FROM action_steps WHERE cue_id = ?').run(id);
+      this.db.prepare('DELETE FROM cues WHERE id = ?').run(id);
+    }
   }
 
   // v18 — rebuild trigger_bindings to drop the legacy `action_id` column.
@@ -1370,6 +1495,10 @@ export class CastRepository {
         name TEXT NOT NULL,
         description TEXT NOT NULL DEFAULT '',
         collection_id TEXT NOT NULL,
+        scope_level TEXT NOT NULL DEFAULT 'global',
+        on_scope_exit TEXT NOT NULL DEFAULT 'cancel',
+        loop_enabled INTEGER NOT NULL DEFAULT 0,
+        loop_count INTEGER,
         created_at TEXT NOT NULL,
         updated_at TEXT NOT NULL,
         FOREIGN KEY(collection_id) REFERENCES macro_collections(id)
@@ -1392,6 +1521,8 @@ export class CastRepository {
         order_index INTEGER NOT NULL,
         payload_json TEXT NOT NULL,
         failure_policy TEXT NOT NULL DEFAULT 'continue',
+        delay_before_ms INTEGER NOT NULL DEFAULT 0,
+        delay_after_ms INTEGER NOT NULL DEFAULT 0,
         created_at TEXT NOT NULL,
         updated_at TEXT NOT NULL,
         FOREIGN KEY(action_id) REFERENCES actions(id) ON DELETE CASCADE,
@@ -3100,12 +3231,17 @@ export class CastRepository {
 
   listMacros(): Macro[] {
     const rows = this.db.prepare(
-      'SELECT id, name, description, collection_id, created_at, updated_at FROM actions ORDER BY updated_at DESC, created_at DESC, id ASC'
+      `SELECT id, name, description, collection_id, scope_level, on_scope_exit, loop_enabled, loop_count, created_at, updated_at
+       FROM actions ORDER BY updated_at DESC, created_at DESC, id ASC`
     ).all() as Array<{
       id: string;
       name: string;
       description: string;
       collection_id: string;
+      scope_level: string;
+      on_scope_exit: string;
+      loop_enabled: number;
+      loop_count: number | null;
       created_at: string;
       updated_at: string;
     }>;
@@ -3118,6 +3254,10 @@ export class CastRepository {
       description: row.description,
       collectionId: row.collection_id,
       cues: cuesByMacroId.get(row.id) ?? [],
+      scopeLevel: row.scope_level as ScopeLevel,
+      onScopeExit: row.on_scope_exit as OnScopeExit,
+      loopEnabled: row.loop_enabled === 1,
+      loopCount: row.loop_count,
       createdAt: row.created_at,
       updatedAt: row.updated_at,
     }));
@@ -3130,18 +3270,24 @@ export class CastRepository {
     const description = input.description?.trim() ?? '';
     const cues = input.cues ?? [];
     const collectionId = input.collectionId ?? this.getDefaultCollectionId('macro');
+    const scopeLevel: ScopeLevel = input.scopeLevel ?? 'global';
+    const onScopeExit: OnScopeExit = input.onScopeExit ?? 'cancel';
+    const loopEnabled = input.loopEnabled ? 1 : 0;
+    const loopCount = normalizeLoopCount(input.loopCount);
 
     const insertMacro = this.db.prepare(
-      'INSERT INTO actions (id, name, description, collection_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)'
+      `INSERT INTO actions
+       (id, name, description, collection_id, scope_level, on_scope_exit, loop_enabled, loop_count, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     );
     const insertMacroCue = this.db.prepare(
       `INSERT INTO action_steps
-       (id, action_id, cue_id, kind, order_index, payload_json, failure_policy, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+       (id, action_id, cue_id, kind, order_index, payload_json, failure_policy, delay_before_ms, delay_after_ms, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     );
 
     const tx = this.db.transaction(() => {
-      insertMacro.run(macroId, name, description, collectionId, now, now);
+      insertMacro.run(macroId, name, description, collectionId, scopeLevel, onScopeExit, loopEnabled, loopCount, now, now);
       for (const macroCue of cues) {
         const cue = this.getCue(macroCue.cueId);
         insertMacroCue.run(
@@ -3152,6 +3298,8 @@ export class CastRepository {
           macroCue.orderIndex,
           JSON.stringify(cue.payload),
           cue.failurePolicy,
+          normalizeDelayMs(macroCue.delayBeforeMs),
+          normalizeDelayMs(macroCue.delayAfterMs),
           now,
           now,
         );
@@ -3164,18 +3312,28 @@ export class CastRepository {
 
   updateMacro(input: MacroUpdateInput): SnapshotPatch {
     const existing = this.db.prepare(
-      'SELECT id, name, description FROM actions WHERE id = ?'
-    ).get(input.id) as { id: string; name: string; description: string } | undefined;
+      'SELECT id, name, description, scope_level, on_scope_exit, loop_enabled, loop_count FROM actions WHERE id = ?'
+    ).get(input.id) as {
+      id: string;
+      name: string;
+      description: string;
+      scope_level: string;
+      on_scope_exit: string;
+      loop_enabled: number;
+      loop_count: number | null;
+    } | undefined;
     if (!existing) return this.buildPatch({});
 
     const updateMacro = this.db.prepare(
-      'UPDATE actions SET name = ?, description = ?, updated_at = ? WHERE id = ?'
+      `UPDATE actions
+       SET name = ?, description = ?, scope_level = ?, on_scope_exit = ?, loop_enabled = ?, loop_count = ?, updated_at = ?
+       WHERE id = ?`
     );
     const deleteMacroCues = this.db.prepare('DELETE FROM action_steps WHERE action_id = ?');
     const insertMacroCue = this.db.prepare(
       `INSERT INTO action_steps
-       (id, action_id, cue_id, kind, order_index, payload_json, failure_policy, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+       (id, action_id, cue_id, kind, order_index, payload_json, failure_policy, delay_before_ms, delay_after_ms, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
     );
     const now = nowIso();
 
@@ -3183,6 +3341,10 @@ export class CastRepository {
       updateMacro.run(
         input.name?.trim() || existing.name,
         input.description?.trim() ?? existing.description,
+        input.scopeLevel ?? existing.scope_level,
+        input.onScopeExit ?? existing.on_scope_exit,
+        input.loopEnabled !== undefined ? (input.loopEnabled ? 1 : 0) : existing.loop_enabled,
+        input.loopCount !== undefined ? normalizeLoopCount(input.loopCount) : existing.loop_count,
         now,
         input.id,
       );
@@ -3199,6 +3361,8 @@ export class CastRepository {
             macroCue.orderIndex,
             JSON.stringify(cue.payload),
             cue.failurePolicy,
+            normalizeDelayMs(macroCue.delayBeforeMs),
+            normalizeDelayMs(macroCue.delayAfterMs),
             now,
             now,
           );
@@ -5998,9 +6162,12 @@ export class CastRepository {
 
     const placeholders = macroIds.map(() => '?').join(', ');
     const rows = this.db.prepare(
-      `SELECT step.id, step.action_id, step.cue_id, step.order_index, step.created_at, step.updated_at,
+      `SELECT step.id, step.action_id, step.cue_id, step.order_index,
+              step.delay_before_ms AS step_delay_before_ms, step.delay_after_ms AS step_delay_after_ms,
+              step.created_at, step.updated_at,
               cue.kind AS cue_kind, cue.payload_json AS cue_payload_json,
-              cue.failure_policy AS cue_failure_policy, cue.created_at AS cue_created_at, cue.updated_at AS cue_updated_at
+              cue.failure_policy AS cue_failure_policy,
+              cue.created_at AS cue_created_at, cue.updated_at AS cue_updated_at
        FROM action_steps step
        JOIN cues cue ON cue.id = step.cue_id
        WHERE step.action_id IN (${placeholders})
@@ -6010,6 +6177,8 @@ export class CastRepository {
       action_id: string;
       cue_id: string;
       order_index: number;
+      step_delay_before_ms: number;
+      step_delay_after_ms: number;
       created_at: string;
       updated_at: string;
       cue_kind: string;
@@ -6034,6 +6203,8 @@ export class CastRepository {
           updatedAt: row.cue_updated_at,
         },
         orderIndex: row.order_index,
+        delayBeforeMs: row.step_delay_before_ms,
+        delayAfterMs: row.step_delay_after_ms,
         createdAt: row.created_at,
         updatedAt: row.updated_at,
       });
@@ -6075,7 +6246,7 @@ export class CastRepository {
       case 'stage.clear': return 'Clear stage';
       case 'layer.clear': return 'Clear layer';
       case 'layer.clearAll': return 'Clear all layers';
-      case 'flow.wait': return 'Wait';
+      case 'flow.lifecycle': return 'Lifecycle control';
     }
   }
 

--- a/app/renderer/components/form/dropdown.tsx
+++ b/app/renderer/components/form/dropdown.tsx
@@ -8,6 +8,8 @@ interface DropdownContextValue {
   open: boolean;
   triggerRef: React.RefObject<HTMLButtonElement | null>;
   panelRef: React.RefObject<HTMLDivElement | null>;
+  // Trigger width captured when the menu opens, so the panel can match it.
+  triggerWidth: number | undefined;
   onOpen: () => void;
   onClose: () => void;
   handleKeyDown: (event: React.KeyboardEvent) => void;
@@ -31,6 +33,7 @@ interface RootProps {
 function Root({ className, children }: RootProps) {
   const [open, setOpen] = useState(false);
   const [typeAhead, setTypeAhead] = useState('');
+  const [triggerWidth, setTriggerWidth] = useState<number | undefined>(undefined);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
   const highlightedRef = useRef(-1);
@@ -54,6 +57,8 @@ function Root({ className, children }: RootProps) {
   }
 
   const handleOpen = useCallback(() => {
+    // Snapshot the trigger's width so the panel can size to match it.
+    setTriggerWidth(triggerRef.current?.offsetWidth);
     setOpen(true);
     highlightedRef.current = -1;
   }, []);
@@ -143,10 +148,11 @@ function Root({ className, children }: RootProps) {
     open,
     triggerRef,
     panelRef,
+    triggerWidth,
     onOpen: handleOpen,
     onClose: handleClose,
     handleKeyDown,
-  }), [open, handleOpen, handleClose, handleKeyDown]);
+  }), [open, triggerWidth, handleOpen, handleClose, handleKeyDown]);
 
   return (
     <DropdownContext.Provider value={ctx}>
@@ -211,8 +217,10 @@ function Panel({ children, className, placement }: PanelProps) {
         ref={ctx.panelRef}
         role="menu"
         onKeyDown={ctx.handleKeyDown}
+        // Match the trigger's width. The `min-w-30` floor means a narrow trigger
+        // still gets a usable panel: the used width is max(triggerWidth, 7.5rem).
+        style={{ width: ctx.triggerWidth }}
         className={cn('min-w-30 rounded-md border border-primary bg-primary shadow-lg max-h-60 overflow-y-auto p-1', className)}
-      // style={{ minWidth: ctx.triggerRef.current?.offsetWidth }}
       >
         {children}
       </div>

--- a/app/renderer/features/automation/automation-context.tsx
+++ b/app/renderer/features/automation/automation-context.tsx
@@ -6,11 +6,16 @@ import type {
   CueKind,
   CuePayload,
   Id,
+  LifecycleAction,
+  LifecycleTarget,
   Macro,
+  OnScopeExit,
+  ScopeLevel,
   TriggerBinding,
   TriggerBindingTargetType,
   TriggerType,
 } from '@core/types';
+import { getSlideDeckItemId } from '@core/deck-items';
 import { useCast } from '@renderer/contexts/app-context';
 import { useProjectContent } from '@renderer/contexts/use-project-content';
 import { useAudio, usePresentationLayerActions, usePresentationMediaLayer, usePresentationOverlayLayer, useStagePlayback, useVideo } from '@renderer/contexts/playback/playback-context';
@@ -28,10 +33,17 @@ interface AutomationContextValue {
   actions: {
     setCurrentMacroId: (id: Id | null) => void;
     createMacro: () => Promise<Macro>;
-    updateMacroFields: (id: Id, fields: { name?: string; description?: string }) => Promise<void>;
+    updateMacroFields: (id: Id, fields: {
+      name?: string;
+      description?: string;
+      scopeLevel?: ScopeLevel;
+      onScopeExit?: OnScopeExit;
+      loopEnabled?: boolean;
+      loopCount?: number | null;
+    }) => Promise<void>;
     deleteMacro: (id: Id) => Promise<void>;
     duplicateMacro: (id: Id) => Promise<Macro | null>;
-    setMacroCues: (macroId: Id, cues: Array<{ id?: Id; cueId: Id; orderIndex: number }>) => Promise<void>;
+    setMacroCues: (macroId: Id, cues: Array<{ id?: Id; cueId: Id; orderIndex: number; delayBeforeMs?: number; delayAfterMs?: number }>) => Promise<void>;
     runCue: (cueId: Id) => Promise<void>;
     runMacro: (macroId: Id) => Promise<void>;
     ensureCue: (input: { kind: CueKind; payload: CuePayload; failurePolicy?: CueFailurePolicy }) => Promise<Cue>;
@@ -42,11 +54,57 @@ interface AutomationContextValue {
   };
 }
 
+// One triggered execution of a macro, bound to a concrete scope context.
+// Lives in an in-memory registry so scope-exit sweeps and lifecycle cues can
+// target it. Triggers stack — each fire creates a new run.
+interface MacroRun {
+  runId: string;
+  macroId: Id;
+  scope: ScopeLevel;
+  boundContextId: Id | null;
+  onScopeExit: OnScopeExit;
+  appliedCues: Cue[];
+  aborters: Set<() => void>;
+  cancelled: boolean;
+}
+
+let runCounter = 0;
+const nextRunId = (): string => {
+  runCounter += 1;
+  return `run_${Date.now()}_${runCounter}`;
+};
+
+// A delay that can be aborted mid-flight. Aborting resolves the promise so the
+// awaiting macro loop unwinds immediately instead of hanging. A 0ms delay with
+// a run still schedules a macrotask so a delay-less loop yields to the event
+// loop (and can be cancelled) rather than spinning the thread.
+function cancellableDelay(ms: number, run: MacroRun | null): Promise<void> {
+  const safeMs = Number.isFinite(ms) ? Math.max(0, ms) : 0;
+  if (safeMs === 0 && !run) return Promise.resolve();
+  return new Promise<void>((resolve) => {
+    const timer = window.setTimeout(() => {
+      run?.aborters.delete(abort);
+      resolve();
+    }, safeMs);
+    const abort = () => {
+      window.clearTimeout(timer);
+      resolve();
+    };
+    run?.aborters.add(abort);
+  });
+}
+
+function cancelRun(run: MacroRun): void {
+  run.cancelled = true;
+  for (const abort of run.aborters) abort();
+  run.aborters.clear();
+}
+
 const AutomationContext = createContext<AutomationContextValue | null>(null);
 
 export function AutomationProvider({ children }: { children: ReactNode }) {
   const { snapshot, mutatePatch, runOperation, setStatusText } = useCast();
-  const { cues, macros, triggerBindings, cuesById, macrosById } = useProjectContent();
+  const { cues, macros, triggerBindings, cuesById, macrosById, slides } = useProjectContent();
   const overlayLayer = usePresentationOverlayLayer();
   const mediaLayer = usePresentationMediaLayer();
   const layerActions = usePresentationLayerActions();
@@ -63,95 +121,246 @@ export function AutomationProvider({ children }: { children: ReactNode }) {
   // fresh cue — leaving an orphan duplicate.
   const inFlightCuesRef = useRef<Map<string, Promise<Cue>>>(new Map());
 
-  const runCue = useCallback(async (cueId: Id) => {
-    const cue = cuesById.get(cueId);
-    if (!cue) return;
+  // Active macro runs, keyed by run id. Mutable across renders so scope-exit
+  // sweeps and lifecycle cues can reach in-flight runs.
+  const runsRef = useRef<Map<string, MacroRun>>(new Map());
+  // slideId -> owning deck item id, refreshed each render for use inside handlers.
+  const slideDeckItemByIdRef = useRef<Map<Id, Id | null>>(new Map());
+  slideDeckItemByIdRef.current = useMemo(() => {
+    const map = new Map<Id, Id | null>();
+    for (const slide of slides) map.set(slide.id, getSlideDeckItemId(slide));
+    return map;
+  }, [slides]);
 
-    recordObsEvent('playback', 'Cue started', { cueId, kind: cue.kind });
+  // Apply a cue's side-effect. `flow.lifecycle` is handled by the caller since
+  // it acts on the run registry rather than a presentation layer.
+  const applyCueAction = useCallback((cue: Cue) => {
+    switch (cue.kind) {
+      case 'overlay.activate':
+        overlayLayer.activateOverlay((cue.payload as { overlayId: Id }).overlayId);
+        break;
+      case 'overlay.clear':
+        overlayLayer.clearOverlay((cue.payload as { overlayId: Id }).overlayId);
+        break;
+      case 'overlay.clearAll':
+        overlayLayer.clearAllOverlays();
+        break;
+      case 'mediaLayer.set':
+        mediaLayer.setMediaLayerAsset((cue.payload as { assetId: Id }).assetId);
+        break;
+      case 'video.arm':
+        video.armVideo((cue.payload as { assetId: Id }).assetId);
+        break;
+      case 'video.clear':
+        video.clearVideo();
+        break;
+      case 'audio.arm':
+        audio.armAudio((cue.payload as { assetId: Id }).assetId);
+        break;
+      case 'audio.clear':
+        audio.clearAudio();
+        break;
+      case 'stage.set':
+        stage.setCurrentStageId((cue.payload as { stageId: Id }).stageId);
+        break;
+      case 'stage.clear':
+        stage.setCurrentStageId(null);
+        break;
+      case 'layer.clear':
+        layerActions.clearLayer((cue.payload as { layer: CueClearLayer }).layer);
+        break;
+      case 'layer.clearAll':
+        layerActions.clearAllLayers();
+        break;
+      case 'flow.lifecycle':
+        break;
+    }
+  }, [audio, layerActions, mediaLayer, overlayLayer, stage, video]);
 
-    try {
+  // Stop a run and undo the effects it applied, in reverse order, via each
+  // cue's static inverse. Cues with no inverse (clears, lifecycle) are skipped.
+  const revertRun = useCallback((run: MacroRun) => {
+    cancelRun(run);
+    for (let i = run.appliedCues.length - 1; i >= 0; i -= 1) {
+      const cue = run.appliedCues[i];
       switch (cue.kind) {
         case 'overlay.activate':
-          overlayLayer.activateOverlay((cue.payload as { overlayId: Id }).overlayId);
-          break;
-        case 'overlay.clear':
           overlayLayer.clearOverlay((cue.payload as { overlayId: Id }).overlayId);
           break;
-        case 'overlay.clearAll':
-          overlayLayer.clearAllOverlays();
-          break;
         case 'mediaLayer.set':
-          mediaLayer.setMediaLayerAsset((cue.payload as { assetId: Id }).assetId);
+          layerActions.clearLayer('media');
           break;
         case 'video.arm':
-          video.armVideo((cue.payload as { assetId: Id }).assetId);
-          break;
-        case 'video.clear':
           video.clearVideo();
           break;
         case 'audio.arm':
-          audio.armAudio((cue.payload as { assetId: Id }).assetId);
-          break;
-        case 'audio.clear':
           audio.clearAudio();
           break;
         case 'stage.set':
-          stage.setCurrentStageId((cue.payload as { stageId: Id }).stageId);
-          break;
-        case 'stage.clear':
           stage.setCurrentStageId(null);
           break;
-        case 'layer.clear':
-          layerActions.clearLayer((cue.payload as { layer: CueClearLayer }).layer);
+        default:
           break;
-        case 'layer.clearAll':
-          layerActions.clearAllLayers();
-          break;
-        case 'flow.wait': {
-          const rawMs = Number((cue.payload as { ms: number }).ms);
-          const ms = Number.isFinite(rawMs) ? Math.max(0, rawMs) : 0;
-          await new Promise<void>((resolve) => {
-            window.setTimeout(resolve, ms);
-          });
-          break;
-        }
       }
-      recordObsEvent('playback', 'Cue completed', { cueId, kind: cue.kind });
+    }
+  }, [audio, layerActions, overlayLayer, stage, video]);
+
+  // Cancel or revert targeted runs. `'*'` hits every active run; an id hits
+  // every running instance of that macro. The invoking run is spared so a
+  // "reset everything" macro can clear others and keep executing.
+  const applyLifecycle = useCallback((action: LifecycleAction, target: LifecycleTarget, selfRunId: string | null) => {
+    const targets: MacroRun[] = [];
+    for (const run of runsRef.current.values()) {
+      if (selfRunId && run.runId === selfRunId) continue;
+      if (target === '*' || run.macroId === target) targets.push(run);
+    }
+    for (const run of targets) {
+      if (action === 'revert') revertRun(run);
+      else cancelRun(run);
+      runsRef.current.delete(run.runId);
+    }
+  }, [revertRun]);
+
+  // Delays are per-occurrence (a macro step), passed in by the caller rather
+  // than read off the shared cue. Bare cues run with no delay.
+  const executeCue = useCallback(async (cue: Cue, delayBeforeMs: number, delayAfterMs: number, run: MacroRun | null) => {
+    if (run?.cancelled) return;
+    if (delayBeforeMs > 0) {
+      await cancellableDelay(delayBeforeMs, run);
+      if (run?.cancelled) return;
+    }
+
+    recordObsEvent('playback', 'Cue started', { cueId: cue.id, kind: cue.kind });
+    try {
+      if (cue.kind === 'flow.lifecycle') {
+        const { action, target } = cue.payload as { action: LifecycleAction; target: LifecycleTarget };
+        applyLifecycle(action, target, run?.runId ?? null);
+      } else {
+        applyCueAction(cue);
+        if (run) run.appliedCues.push(cue);
+      }
+      recordObsEvent('playback', 'Cue completed', { cueId: cue.id, kind: cue.kind });
     } catch (error) {
       recordObsEvent('error', 'Cue failed', {
-        cueId,
+        cueId: cue.id,
         kind: cue.kind,
         error: error instanceof Error ? error.message : String(error),
       }, 'error');
       if (cue.failurePolicy === 'abort') throw error;
     }
-  }, [audio, cuesById, layerActions, mediaLayer, overlayLayer, stage, video]);
 
-  const runMacro = useCallback(async (macroId: Id) => {
+    if (run?.cancelled) return;
+    if (delayAfterMs > 0) {
+      await cancellableDelay(delayAfterMs, run);
+    }
+  }, [applyCueAction, applyLifecycle]);
+
+  // Public single-cue runner (bare-cue trigger bindings, command palette).
+  // Runs unscoped/global with no lifecycle tracking and no delay.
+  const runCue = useCallback(async (cueId: Id) => {
+    const cue = cuesById.get(cueId);
+    if (!cue) return;
+    await executeCue(cue, 0, 0, null);
+  }, [cuesById, executeCue]);
+
+  // Start a tracked macro run. The scope level is authored on the macro; the
+  // concrete bound context is resolved from the trigger source, falling back to
+  // global when there is no slide context (manual run / app.startup).
+  const startMacroRun = useCallback(async (macroId: Id, triggerType: TriggerType | null, sourceId: Id | null) => {
     const macro = macrosById.get(macroId);
     if (!macro) return;
 
-    recordObsEvent('playback', 'Macro started', { macroId, name: macro.name });
-
-    const ordered = macro.cues.slice().sort((left, right) => left.orderIndex - right.orderIndex);
-    for (const link of ordered) {
-      try {
-        await runCue(link.cueId);
-      } catch (error) {
-        // runCue rethrows only when the cue's failurePolicy is 'abort'.
-        setStatusText(`Macro aborted: ${macro.name}`);
-        recordObsEvent('playback', 'Macro aborted', {
-          macroId,
-          name: macro.name,
-          error: error instanceof Error ? error.message : String(error),
-        }, 'warn');
-        return;
-      }
+    const isSlideTrigger = sourceId !== null && (triggerType === 'slide.take' || triggerType === 'slide.activate');
+    let scope: ScopeLevel = macro.scopeLevel;
+    let boundContextId: Id | null = null;
+    if (scope === 'slide') {
+      if (isSlideTrigger) boundContextId = sourceId;
+      else scope = 'global';
+    } else if (scope === 'deckItem') {
+      const deckItemId = isSlideTrigger ? slideDeckItemByIdRef.current.get(sourceId) ?? null : null;
+      if (deckItemId) boundContextId = deckItemId;
+      else scope = 'global';
     }
 
-    setStatusText(`Macro ran: ${macro.name}`);
-    recordObsEvent('playback', 'Macro completed', { macroId, name: macro.name });
-  }, [macrosById, runCue, setStatusText]);
+    const run: MacroRun = {
+      runId: nextRunId(),
+      macroId,
+      scope,
+      boundContextId,
+      onScopeExit: macro.onScopeExit,
+      appliedCues: [],
+      aborters: new Set(),
+      cancelled: false,
+    };
+    runsRef.current.set(run.runId, run);
+    recordObsEvent('playback', 'Macro started', { macroId, name: macro.name, runId: run.runId, scope, boundContextId });
+
+    const ordered = macro.cues.slice().sort((left, right) => left.orderIndex - right.orderIndex);
+    const maxIterations = macro.loopEnabled ? (macro.loopCount ?? Number.POSITIVE_INFINITY) : 1;
+    let aborted = false;
+
+    try {
+      let iteration = 0;
+      while (iteration < maxIterations && !run.cancelled) {
+        for (const link of ordered) {
+          if (run.cancelled) break;
+          const cue = cuesById.get(link.cueId);
+          if (!cue) continue;
+          try {
+            await executeCue(cue, link.delayBeforeMs, link.delayAfterMs, run);
+          } catch (error) {
+            setStatusText(`Macro aborted: ${macro.name}`);
+            recordObsEvent('playback', 'Macro aborted', {
+              macroId,
+              name: macro.name,
+              error: error instanceof Error ? error.message : String(error),
+            }, 'warn');
+            aborted = true;
+            break;
+          }
+        }
+        if (aborted || run.cancelled) break;
+        iteration += 1;
+        if (macro.loopEnabled && iteration < maxIterations) {
+          // Yield a macrotask between iterations so a delay-less loop can't
+          // block the thread and remains interruptible by scope changes.
+          await cancellableDelay(0, run);
+        }
+      }
+
+      if (!aborted && !run.cancelled) {
+        setStatusText(`Macro ran: ${macro.name}`);
+        recordObsEvent('playback', 'Macro completed', { macroId, name: macro.name, runId: run.runId });
+      }
+    } finally {
+      run.aborters.clear();
+      runsRef.current.delete(run.runId);
+    }
+  }, [macrosById, cuesById, executeCue, setStatusText]);
+
+  const runMacro = useCallback(async (macroId: Id) => {
+    await startMacroRun(macroId, null, null);
+  }, [startMacroRun]);
+
+  // The live slide changed: expire runs whose bound scope context no longer
+  // matches, applying each run's authored on-exit behavior. Global runs and
+  // runs whose context still matches are left alone; 'none' runs keep going.
+  const handleScopeChange = useCallback((newSlideId: Id | null) => {
+    const newDeckItemId = newSlideId ? slideDeckItemByIdRef.current.get(newSlideId) ?? null : null;
+    for (const run of [...runsRef.current.values()]) {
+      let exited = false;
+      if (run.scope === 'slide') exited = run.boundContextId !== newSlideId;
+      else if (run.scope === 'deckItem') exited = run.boundContextId !== newDeckItemId;
+      if (!exited) continue;
+      if (run.onScopeExit === 'cancel') {
+        cancelRun(run);
+        runsRef.current.delete(run.runId);
+      } else if (run.onScopeExit === 'revert') {
+        revertRun(run);
+        runsRef.current.delete(run.runId);
+      }
+    }
+  }, [revertRun]);
 
   const ensureCue = useCallback(async (input: { kind: CueKind; payload: CuePayload; failurePolicy?: CueFailurePolicy }) => {
     const payloadKey = JSON.stringify(input.payload);
@@ -196,7 +405,14 @@ export function AutomationProvider({ children }: { children: ReactNode }) {
     return created;
   }, [macros, mutatePatch, runOperation, setStatusText]);
 
-  const updateMacroFields = useCallback(async (id: Id, fields: { name?: string; description?: string }) => {
+  const updateMacroFields = useCallback(async (id: Id, fields: {
+    name?: string;
+    description?: string;
+    scopeLevel?: ScopeLevel;
+    onScopeExit?: OnScopeExit;
+    loopEnabled?: boolean;
+    loopCount?: number | null;
+  }) => {
     await mutatePatch(() => window.castApi.updateMacro({ id, ...fields }));
   }, [mutatePatch]);
 
@@ -212,6 +428,10 @@ export function AutomationProvider({ children }: { children: ReactNode }) {
     const nextSnapshot = await mutatePatch(() => window.castApi.createMacro({
       name: `${source.name} copy`,
       description: source.description,
+      scopeLevel: source.scopeLevel,
+      onScopeExit: source.onScopeExit,
+      loopEnabled: source.loopEnabled,
+      loopCount: source.loopCount,
       cues: source.cues.map((link) => ({ cueId: link.cueId, orderIndex: link.orderIndex })),
     }));
     const created = nextSnapshot.macros.find((macro) => !previousIds.has(macro.id));
@@ -220,7 +440,7 @@ export function AutomationProvider({ children }: { children: ReactNode }) {
     return created;
   }, [macros, macrosById, mutatePatch, setStatusText]);
 
-  const setMacroCues = useCallback(async (macroId: Id, nextCues: Array<{ id?: Id; cueId: Id; orderIndex: number }>) => {
+  const setMacroCues = useCallback(async (macroId: Id, nextCues: Array<{ id?: Id; cueId: Id; orderIndex: number; delayBeforeMs?: number; delayAfterMs?: number }>) => {
     await mutatePatch(() => window.castApi.updateMacro({ id: macroId, cues: nextCues }));
   }, [mutatePatch]);
 
@@ -255,6 +475,12 @@ export function AutomationProvider({ children }: { children: ReactNode }) {
   }, [triggerBindings]);
 
   const fireTrigger = useCallback((triggerType: TriggerType, sourceId: Id | null) => {
+    // Slide activation moves the live context. Sweep first so runs bound to the
+    // slide we're leaving are expired; runs bound to the incoming slide survive.
+    if (triggerType === 'slide.activate') {
+      handleScopeChange(sourceId);
+    }
+
     const matches = triggerBindings.filter((binding) => binding.triggerType === triggerType && binding.sourceId === sourceId && binding.enabled);
     recordObsEvent('playback', 'Automation trigger fired', {
       triggerType,
@@ -264,9 +490,9 @@ export function AutomationProvider({ children }: { children: ReactNode }) {
 
     for (const binding of matches) {
       if (binding.targetType === 'cue') void runCue(binding.targetId);
-      else void runMacro(binding.targetId);
+      else void startMacroRun(binding.targetId, triggerType, sourceId);
     }
-  }, [triggerBindings, runCue, runMacro]);
+  }, [triggerBindings, runCue, startMacroRun, handleScopeChange]);
 
   useEffect(() => {
     function handleTrigger(event: Event) {

--- a/app/renderer/features/automation/cue-icons.ts
+++ b/app/renderer/features/automation/cue-icons.ts
@@ -1,5 +1,5 @@
 import type { LucideIcon } from 'lucide-react';
-import { Film, Image, Layers2, RectangleHorizontal, Volume2, Workflow, XCircle } from 'lucide-react';
+import { Ban, Film, Image, Layers2, RectangleHorizontal, Volume2, Workflow, XCircle } from 'lucide-react';
 import type { Cue, Id, MediaAsset } from '@core/types';
 
 export const MACRO_ICON: LucideIcon = Workflow;
@@ -19,6 +19,8 @@ export function getCueIcon(cue: Cue, mediaAssets: Pick<MediaAsset, 'id' | 'type'
       const asset = mediaAssets.find((entry) => entry.id === id);
       return asset?.type === 'video' ? Film : Image;
     }
+    case 'flow.lifecycle':
+      return Ban;
     case 'overlay.clear':
     case 'overlay.clearAll':
     case 'stage.clear':
@@ -26,7 +28,6 @@ export function getCueIcon(cue: Cue, mediaAssets: Pick<MediaAsset, 'id' | 'type'
     case 'audio.clear':
     case 'layer.clear':
     case 'layer.clearAll':
-    case 'flow.wait':
     default:
       return XCircle;
   }

--- a/app/renderer/features/automation/describe-cue.ts
+++ b/app/renderer/features/automation/describe-cue.ts
@@ -1,4 +1,4 @@
-import type { Cue, CueClearLayer, CueKind, Id, MediaAsset, Overlay, Stage } from '@core/types';
+import type { Cue, CueClearLayer, CueKind, Id, LifecycleAction, LifecycleTarget, MediaAsset, Overlay, Stage } from '@core/types';
 
 export const CUE_KIND_LABELS: Record<CueKind, string> = {
   'overlay.activate': 'Activate overlay',
@@ -13,13 +13,19 @@ export const CUE_KIND_LABELS: Record<CueKind, string> = {
   'stage.clear': 'Clear stage',
   'layer.clear': 'Clear layer',
   'layer.clearAll': 'Clear all layers',
-  'flow.wait': 'Wait',
+  'flow.lifecycle': 'Lifecycle control',
+};
+
+const LIFECYCLE_ACTION_LABELS: Record<LifecycleAction, string> = {
+  cancel: 'Cancel',
+  revert: 'Revert',
 };
 
 export interface DescribeCueContext {
   overlays: Pick<Overlay, 'id' | 'name'>[];
   stages: Pick<Stage, 'id' | 'name'>[];
   mediaAssets: Pick<MediaAsset, 'id' | 'name' | 'type'>[];
+  macros?: Array<{ id: Id; name: string }>;
 }
 
 // Build a human-readable label for a cue. Cues have no stored name — the
@@ -53,9 +59,13 @@ function describeTarget(cue: Cue, context: DescribeCueContext): string | null {
       const layer = (cue.payload as { layer?: CueClearLayer }).layer;
       return layer ?? null;
     }
-    case 'flow.wait': {
-      const ms = (cue.payload as { ms?: number }).ms;
-      return typeof ms === 'number' ? `${ms} ms` : null;
+    case 'flow.lifecycle': {
+      const { action, target } = cue.payload as { action?: LifecycleAction; target?: LifecycleTarget };
+      if (!action) return null;
+      const actionLabel = LIFECYCLE_ACTION_LABELS[action];
+      if (target === '*') return `${actionLabel} all active`;
+      const macroName = target ? findName(context.macros ?? [], target) : null;
+      return `${actionLabel} ${macroName ?? 'macro'}`;
     }
     default:
       return null;

--- a/app/renderer/features/automation/slide-bindings-menu.tsx
+++ b/app/renderer/features/automation/slide-bindings-menu.tsx
@@ -57,7 +57,7 @@ export function SlideBindingsMenu({ slideId }: { slideId: Id }) {
           : cue ? getCueIcon(cue, mediaAssets) : null;
         const label = binding.targetType === 'macro'
           ? (macro?.name ?? 'Unknown macro')
-          : describeCue(cue, { overlays, stages, mediaAssets });
+          : describeCue(cue, { overlays, stages, mediaAssets, macros });
         const canEdit = binding.targetType === 'macro'
           ? Boolean(macro)
           : cue?.kind === 'stage.set'

--- a/app/renderer/features/playback/program-panel.tsx
+++ b/app/renderer/features/playback/program-panel.tsx
@@ -22,6 +22,7 @@ import { OverlayBinPanel } from '../assets/overlays/overlay-bin-panel';
 import { StageBinPanel } from '../assets/stages/stage-bin-panel';
 import { MacroBinPanel } from '../automation/macro-bin-panel';
 import { useAutomation } from '../automation/automation-context';
+import { dispatchAutomationTriggerEvent } from '../automation/automation-events';
 import { CollectionPicker } from '../workbench/collection-picker';
 import { useBinCollections } from '../workbench/use-bin-collections';
 import { useProgramOutput } from './use-program-output';
@@ -62,12 +63,20 @@ export function ProgramPanel() {
 
   function handleClearMedia() { clearLayer('media'); }
   function handleClearVideo() { clearLayer('video'); }
-  function handleClearContent() { clearLayer('content'); }
+  // Clearing content blanks the live slide. Signal "no slide live" so slide-/
+  // deck-item-scoped macro runs are swept (same path as advancing off a slide).
+  // Only the operator clear buttons do this — the layer.clear/clearAll *cues*
+  // call clearLayer directly and must not sweep, or a macro would cancel itself.
+  function handleClearContent() {
+    clearLayer('content');
+    dispatchAutomationTriggerEvent({ triggerType: 'slide.activate', sourceId: null });
+  }
   function handleClearOverlay() { clearLayer('overlay'); }
   function handleClearAudio() { audio.clearAudio(); }
   function handleClearAll() {
     audio.clearAudio();
     clearAllLayers();
+    dispatchAutomationTriggerEvent({ triggerType: 'slide.activate', sourceId: null });
   }
 
   function handleOverlayModeToggle() {

--- a/app/renderer/screens/macro-editor/canvas-panel.tsx
+++ b/app/renderer/screens/macro-editor/canvas-panel.tsx
@@ -77,9 +77,9 @@ function CanvasCueCard({
   isSelected: boolean;
   onClick: () => void;
 }) {
-  const { overlays, stages, mediaAssets } = useProjectContent();
+  const { overlays, stages, mediaAssets, macros } = useProjectContent();
   const label = row.link
-    ? describeCue(row.link.cue, { overlays, stages, mediaAssets })
+    ? describeCue(row.link.cue, { overlays, stages, mediaAssets, macros })
     : row.draftKind
     ? CUE_KIND_LABELS[row.draftKind]
     : null;

--- a/app/renderer/screens/macro-editor/inspector-panel.tsx
+++ b/app/renderer/screens/macro-editor/inspector-panel.tsx
@@ -10,7 +10,7 @@ import { useProjectContent } from '@renderer/contexts/use-project-content';
 import { useSlides } from '@renderer/contexts/slide-context';
 import { useInspector } from '@renderer/features/inspector/inspector-context';
 import { useAutomation } from '@renderer/features/automation/automation-context';
-import type { CueClearLayer, CueFailurePolicy, CueKind, CuePayload, Id } from '@core/types';
+import type { CueClearLayer, CueFailurePolicy, CueKind, CuePayload, Id, LifecycleAction, LifecycleTarget, OnScopeExit, ScopeLevel } from '@core/types';
 import { CUE_KIND_LABELS } from '@renderer/features/automation/describe-cue';
 import { parseNumber } from '@renderer/utils/slides';
 import { useMacroEditorScreen, type MacroEditorCueRow } from './screen-context';
@@ -26,6 +26,20 @@ const CLEAR_LAYER_OPTIONS: Array<{ value: CueClearLayer; label: string }> = [
   { value: 'video', label: 'Video' },
   { value: 'content', label: 'Content' },
   { value: 'overlay', label: 'Overlay' },
+];
+const LIFECYCLE_ACTION_OPTIONS: Array<{ value: LifecycleAction; label: string }> = [
+  { value: 'cancel', label: 'Cancel (stop future work)' },
+  { value: 'revert', label: 'Revert (stop + undo effects)' },
+];
+const SCOPE_LEVEL_OPTIONS: Array<{ value: ScopeLevel; label: string }> = [
+  { value: 'global', label: 'Global (runs until cancelled)' },
+  { value: 'deckItem', label: 'Deck item (stops when leaving the deck item)' },
+  { value: 'slide', label: 'Slide (stops when leaving the slide)' },
+];
+const ON_SCOPE_EXIT_OPTIONS: Array<{ value: OnScopeExit; label: string }> = [
+  { value: 'cancel', label: 'Cancel pending work' },
+  { value: 'revert', label: 'Revert (undo effects)' },
+  { value: 'none', label: 'Keep running' },
 ];
 
 export function MacroEditorInspectorPanel() {
@@ -92,7 +106,11 @@ function MacroInspector() {
     state: { currentMacro, rows, pendingName, pendingDescription },
     actions: { updateMacroName, updateMacroDescription, deleteCurrentMacro },
   } = useMacroEditorScreen();
+  const { actions: { updateMacroFields } } = useAutomation();
   if (!currentMacro) return null;
+
+  const macroId = currentMacro.id;
+  const loopEnabled = currentMacro.loopEnabled;
 
   return (
     <div className="flex h-full min-h-0 flex-col">
@@ -117,6 +135,54 @@ function MacroInspector() {
           </div>
         </Section.Body>
       </Section.Root>
+      <Section.Root>
+        <Section.Header><Label.xs>Scope & lifecycle</Label.xs></Section.Header>
+        <Section.Body>
+          <FieldSelect
+            label="Scope"
+            value={currentMacro.scopeLevel}
+            options={SCOPE_LEVEL_OPTIONS}
+            onChange={(value) => { void updateMacroFields(macroId, { scopeLevel: value as ScopeLevel }); }}
+            wide
+          />
+          {currentMacro.scopeLevel !== 'global' && (
+            <FieldSelect
+              label="On scope exit"
+              value={currentMacro.onScopeExit}
+              options={ON_SCOPE_EXIT_OPTIONS}
+              onChange={(value) => { void updateMacroFields(macroId, { onScopeExit: value as OnScopeExit }); }}
+              wide
+            />
+          )}
+        </Section.Body>
+      </Section.Root>
+      <Section.Root>
+        <Section.Header><Label.xs>Looping</Label.xs></Section.Header>
+        <Section.Body>
+          <FieldSelect
+            label="Loop"
+            value={loopEnabled ? 'on' : 'off'}
+            options={[{ value: 'off', label: 'Run once' }, { value: 'on', label: 'Repeat' }]}
+            onChange={(value) => { void updateMacroFields(macroId, { loopEnabled: value === 'on' }); }}
+            wide
+          />
+          {loopEnabled && (
+            <FieldInput
+              label="Max iterations (blank = until scope exit / cancel)"
+              type="number"
+              min={1}
+              value={currentMacro.loopCount ?? ''}
+              onChange={(value) => {
+                const trimmed = value.trim();
+                if (trimmed === '') { void updateMacroFields(macroId, { loopCount: null }); return; }
+                const parsed = parseNumber(value, currentMacro.loopCount ?? 1);
+                void updateMacroFields(macroId, { loopCount: Number.isFinite(parsed) ? Math.max(1, Math.round(parsed)) : null });
+              }}
+              wide
+            />
+          )}
+        </Section.Body>
+      </Section.Root>
       <div className="mt-auto p-2">
         <ReacstButton variant="danger" onClick={() => { void deleteCurrentMacro(); }} className="w-full">
           <span className="inline-flex items-center gap-1.5"><Trash2 className="size-4" />Delete macro</span>
@@ -127,13 +193,19 @@ function MacroInspector() {
 }
 
 function CueInspector({ row }: { row: MacroEditorCueRow }) {
-  const { actions: { updateRowKind, updateRowPayload, updateRowFailurePolicy, deleteRow, selectRow } } = useMacroEditorScreen();
-  const { overlays, mediaAssets, stages } = useProjectContent();
+  const { state: { currentMacro }, actions: { updateRowKind, updateRowPayload, updateRowFailurePolicy, updateRowDelays, deleteRow, selectRow } } = useMacroEditorScreen();
+  const { overlays, mediaAssets, stages, macros } = useProjectContent();
   const overlayOptions = overlays.map((overlay) => ({ value: overlay.id, label: overlay.name }));
   const stageOptions = stages.map((s) => ({ value: s.id, label: s.name }));
   const mediaLayerOptions = mediaAssets.filter((asset) => asset.type === 'image' || asset.type === 'video').map((asset) => ({ value: asset.id, label: `${asset.name} (${asset.type})` }));
   const videoOptions = mediaAssets.filter((asset) => asset.type === 'video').map((asset) => ({ value: asset.id, label: asset.name }));
   const audioOptions = mediaAssets.filter((asset) => asset.type === 'audio').map((asset) => ({ value: asset.id, label: asset.name }));
+  // A lifecycle cue can target any macro except the one being edited (a macro
+  // can't cancel itself this way), plus the "all active" wildcard.
+  const macroOptions = [
+    { value: '*', label: 'All active macros' },
+    ...macros.filter((macro) => macro.id !== currentMacro?.id).map((macro) => ({ value: macro.id, label: macro.name })),
+  ];
 
   const kind = row.link?.cue.kind ?? row.draftKind ?? null;
   const payload: CuePayload = row.link?.cue.payload ?? row.draftPayload ?? ({} as CuePayload);
@@ -160,7 +232,7 @@ function CueInspector({ row }: { row: MacroEditorCueRow }) {
             <CueTargetField
               kind={kind}
               payload={payload}
-              options={{ overlayOptions, stageOptions, mediaLayerOptions, videoOptions, audioOptions }}
+              options={{ overlayOptions, stageOptions, mediaLayerOptions, videoOptions, audioOptions, macroOptions }}
               onChange={(next) => updateRowPayload(row.localId, next)}
             />
           ) : null}
@@ -169,6 +241,27 @@ function CueInspector({ row }: { row: MacroEditorCueRow }) {
             value={failurePolicy}
             options={FAILURE_POLICY_OPTIONS}
             onChange={(value) => updateRowFailurePolicy(row.localId, value as CueFailurePolicy)}
+            wide
+          />
+        </Section.Body>
+      </Section.Root>
+      <Section.Root>
+        <Section.Header><Label.xs>Timing</Label.xs></Section.Header>
+        <Section.Body>
+          <FieldInput
+            label="Delay before (ms)"
+            type="number"
+            min={0}
+            value={row.draftDelayBeforeMs}
+            onChange={(value) => { if (value.trim() !== '') updateRowDelays(row.localId, { before: parseNumber(value, row.draftDelayBeforeMs) }); }}
+            wide
+          />
+          <FieldInput
+            label="Delay after (ms)"
+            type="number"
+            min={0}
+            value={row.draftDelayAfterMs}
+            onChange={(value) => { if (value.trim() !== '') updateRowDelays(row.localId, { after: parseNumber(value, row.draftDelayAfterMs) }); }}
             wide
           />
         </Section.Body>
@@ -188,6 +281,7 @@ interface CueTargetOptions {
   mediaLayerOptions: Array<{ value: Id; label: string }>;
   videoOptions: Array<{ value: Id; label: string }>;
   audioOptions: Array<{ value: Id; label: string }>;
+  macroOptions: Array<{ value: string; label: string }>;
 }
 
 function CueTargetField({
@@ -267,20 +361,27 @@ function CueTargetField({
       />
     );
   }
-  if (kind === 'flow.wait') {
-    const currentMs = Number((payload as { ms?: number }).ms ?? 0);
+  if (kind === 'flow.lifecycle') {
+    const lifecycle = payload as { action?: LifecycleAction; target?: LifecycleTarget };
+    const action = lifecycle.action ?? 'cancel';
+    const target = lifecycle.target ?? '*';
     return (
-      <FieldInput
-        label="Delay (ms)"
-        type="number"
-        min={0}
-        value={Number.isFinite(currentMs) ? currentMs : 0}
-        onChange={(value) => {
-          const parsed = parseNumber(value, currentMs);
-          onChange({ ms: Number.isFinite(parsed) ? Math.max(0, Math.round(parsed)) : 0 });
-        }}
-        wide
-      />
+      <>
+        <FieldSelect
+          label="Action"
+          value={action}
+          options={LIFECYCLE_ACTION_OPTIONS}
+          onChange={(value) => onChange({ action: value as LifecycleAction, target })}
+          wide
+        />
+        <FieldSelect
+          label="Target"
+          value={String(target)}
+          options={options.macroOptions}
+          onChange={(value) => onChange({ action, target: value as LifecycleTarget })}
+          wide
+        />
+      </>
     );
   }
   return <div className="text-xs text-tertiary">No target needed for this cue.</div>;

--- a/app/renderer/screens/macro-editor/layers-panel.tsx
+++ b/app/renderer/screens/macro-editor/layers-panel.tsx
@@ -78,7 +78,7 @@ function SortableLayerRow({
   isSelected: boolean;
   onSelect: (rowId: string) => void;
 }) {
-  const { overlays, stages, mediaAssets } = useProjectContent();
+  const { overlays, stages, mediaAssets, macros } = useProjectContent();
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: row.localId });
   const style = {
     transform: CSS.Transform.toString(transform),
@@ -87,7 +87,7 @@ function SortableLayerRow({
   };
 
   const label = row.link
-    ? describeCue(row.link.cue, { overlays, stages, mediaAssets })
+    ? describeCue(row.link.cue, { overlays, stages, mediaAssets, macros })
     : row.draftKind
     ? CUE_KIND_LABELS[row.draftKind]
     : 'Unconfigured cue';
@@ -96,15 +96,17 @@ function SortableLayerRow({
     <div ref={setNodeRef} style={style}>
       <SelectableRow.Root selected={isSelected} onClick={() => onSelect(row.localId)} className="w-full">
         <SelectableRow.Leading>
-          <button
-            type="button"
+          {/* A span, not a button: the row itself is a <button>, and nesting a
+              real button inside is invalid DOM. dnd-kit's attributes supply
+              role="button"/tabIndex/aria, so the handle stays keyboard-operable. */}
+          <span
             aria-label="Drag to reorder"
-            className="cursor-grab text-tertiary hover:text-secondary"
+            className="inline-flex cursor-grab text-tertiary hover:text-secondary"
             {...attributes}
             {...listeners}
           >
             <GripVertical size={14} strokeWidth={1.5} />
-          </button>
+          </span>
         </SelectableRow.Leading>
         <SelectableRow.Label>{label}</SelectableRow.Label>
       </SelectableRow.Root>

--- a/app/renderer/screens/macro-editor/screen-context.tsx
+++ b/app/renderer/screens/macro-editor/screen-context.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
-import type { Cue, CueFailurePolicy, CueKind, CuePayload, Id, Macro, MacroCue } from '@core/types';
+import type { Cue, CueFailurePolicy, CueKind, CuePayload, Id, LifecycleAction, LifecycleTarget, Macro, MacroCue } from '@core/types';
 import { useAutomation } from '@renderer/features/automation/automation-context';
 import { useProjectContent } from '@renderer/contexts/use-project-content';
 import { useWorkbench } from '@renderer/contexts/workbench-context';
@@ -16,6 +16,8 @@ export interface MacroEditorCueRow {
   draftKind: CueKind | null;
   draftPayload: CuePayload | null;
   draftFailurePolicy: CueFailurePolicy;
+  draftDelayBeforeMs: number;
+  draftDelayAfterMs: number;
 }
 
 // Local pending state for the macro currently open in the editor. While the
@@ -49,6 +51,7 @@ interface MacroEditorScreenContextValue {
     updateRowKind: (rowId: string, kind: CueKind) => void;
     updateRowPayload: (rowId: string, payload: CuePayload) => void;
     updateRowFailurePolicy: (rowId: string, policy: CueFailurePolicy) => void;
+    updateRowDelays: (rowId: string, delays: { before?: number; after?: number }) => void;
     updateMacroName: (name: string) => void;
     updateMacroDescription: (description: string) => void;
     saveChanges: () => Promise<void>;
@@ -68,16 +71,19 @@ function rowsFromMacro(macro: Macro): MacroEditorCueRow[] {
       draftKind: null,
       draftPayload: null,
       draftFailurePolicy: link.cue.failurePolicy,
+      draftDelayBeforeMs: link.delayBeforeMs,
+      draftDelayAfterMs: link.delayAfterMs,
     }));
 }
 
 // Serialize a row to a comparison key. We don't care about localId — only the
 // observable shape of the saved cue + its position.
 function rowSignature(row: MacroEditorCueRow, index: number): string {
+  const delays = `${row.draftDelayBeforeMs}|${row.draftDelayAfterMs}`;
   if (row.link) {
-    return `${index}|link|${row.link.cue.kind}|${JSON.stringify(row.link.cue.payload)}|${row.link.cue.failurePolicy}`;
+    return `${index}|link|${row.link.cue.kind}|${JSON.stringify(row.link.cue.payload)}|${row.link.cue.failurePolicy}|${delays}`;
   }
-  return `${index}|draft|${row.draftKind ?? ''}|${JSON.stringify(row.draftPayload ?? null)}|${row.draftFailurePolicy}`;
+  return `${index}|draft|${row.draftKind ?? ''}|${JSON.stringify(row.draftPayload ?? null)}|${row.draftFailurePolicy}|${delays}`;
 }
 
 function rowsSignature(rows: MacroEditorCueRow[]): string {
@@ -157,18 +163,21 @@ export function MacroEditorScreenProvider({ children }: { children: ReactNode })
         // 1. Resolve every row to a (cueId, orderIndex). Drafts that aren't
         //    complete yet are skipped — they stay in-memory and remain
         //    "pending" until the user fills them in.
-        const cuePayloads: Array<{ id?: Id; cueId: Id; orderIndex: number }> = [];
+        // Delays are stored on the macro step (per-occurrence), so they travel
+        // with the cue link straight into setMacroCues — no separate write, and
+        // no risk of mutating a cue shared by another macro.
+        const cuePayloads: Array<{ id?: Id; cueId: Id; orderIndex: number; delayBeforeMs: number; delayAfterMs: number }> = [];
         for (let i = 0; i < draftToSave.rows.length; i++) {
           const row = draftToSave.rows[i];
           if (row.link) {
-            cuePayloads.push({ id: row.link.id, cueId: row.link.cueId, orderIndex: i });
+            cuePayloads.push({ id: row.link.id, cueId: row.link.cueId, orderIndex: i, delayBeforeMs: row.draftDelayBeforeMs, delayAfterMs: row.draftDelayAfterMs });
             continue;
           }
           const draftKind = row.draftKind;
           const draftPayload = row.draftPayload;
           if (!draftKind || !draftPayload || !hasCompletePayload(draftKind, draftPayload)) continue;
           const cue = await ensureCue({ kind: draftKind, payload: draftPayload, failurePolicy: row.draftFailurePolicy });
-          cuePayloads.push({ cueId: cue.id, orderIndex: cuePayloads.length });
+          cuePayloads.push({ cueId: cue.id, orderIndex: cuePayloads.length, delayBeforeMs: row.draftDelayBeforeMs, delayAfterMs: row.draftDelayAfterMs });
         }
 
         // 2. Push name/description first (cheap), then cues. updateMacro
@@ -242,6 +251,8 @@ export function MacroEditorScreenProvider({ children }: { children: ReactNode })
         draftKind: null,
         draftPayload: null,
         draftFailurePolicy: 'continue',
+        draftDelayBeforeMs: 0,
+        draftDelayAfterMs: 0,
       }],
     }));
     setSelectedRowId(localId);
@@ -328,6 +339,18 @@ export function MacroEditorScreenProvider({ children }: { children: ReactNode })
     }));
   }, [mutateDraft]);
 
+  const updateRowDelays = useCallback((rowId: string, delays: { before?: number; after?: number }) => {
+    mutateDraft((current) => ({
+      ...current,
+      rows: current.rows.map((row) => {
+        if (row.localId !== rowId) return row;
+        const before = delays.before !== undefined ? Math.max(0, Math.round(delays.before)) : row.draftDelayBeforeMs;
+        const after = delays.after !== undefined ? Math.max(0, Math.round(delays.after)) : row.draftDelayAfterMs;
+        return { ...row, draftDelayBeforeMs: before, draftDelayAfterMs: after };
+      }),
+    }));
+  }, [mutateDraft]);
+
   const updateMacroName = useCallback((name: string) => {
     mutateDraft((current) => ({ ...current, name }));
   }, [mutateDraft]);
@@ -369,6 +392,7 @@ export function MacroEditorScreenProvider({ children }: { children: ReactNode })
       updateRowKind,
       updateRowPayload,
       updateRowFailurePolicy,
+      updateRowDelays,
       updateMacroName,
       updateMacroDescription,
       saveChanges,
@@ -377,7 +401,7 @@ export function MacroEditorScreenProvider({ children }: { children: ReactNode })
   }), [
     addCueDraft, currentMacro, deleteCurrentMacro, deleteRow, hasPendingChanges, isPushingChanges,
     macros, pendingDescription, pendingName, reorderRows, rows, saveChanges, selectMacro, selectRow,
-    selectedRowId, updateMacroDescription, updateMacroName, updateRowFailurePolicy, updateRowKind,
+    selectedRowId, updateMacroDescription, updateMacroName, updateRowDelays, updateRowFailurePolicy, updateRowKind,
     updateRowPayload,
   ]);
 
@@ -403,8 +427,12 @@ export function hasCompletePayload(kind: CueKind, payload: CuePayload | null): p
       return typeof (payload as { stageId?: Id }).stageId === 'string' && (payload as { stageId: string }).stageId.length > 0;
     case 'layer.clear':
       return typeof (payload as { layer?: string }).layer === 'string';
-    case 'flow.wait':
-      return typeof (payload as { ms?: number }).ms === 'number';
+    case 'flow.lifecycle': {
+      const lifecycle = payload as { action?: LifecycleAction; target?: LifecycleTarget };
+      return (lifecycle.action === 'cancel' || lifecycle.action === 'revert')
+        && typeof lifecycle.target === 'string'
+        && lifecycle.target.length > 0;
+    }
     default:
       return true;
   }
@@ -424,7 +452,7 @@ export function defaultPayloadForKind(
   if (kind === 'audio.arm') return { assetId: context.mediaAssets.find((asset) => asset.type === 'audio')?.id ?? '' };
   if (kind === 'stage.set') return { stageId: context.stages[0]?.id ?? '' };
   if (kind === 'layer.clear') return { layer: 'media' };
-  if (kind === 'flow.wait') return { ms: 500 };
+  if (kind === 'flow.lifecycle') return { action: 'cancel', target: '*' };
   return {} as CuePayload;
 }
 

--- a/docs/adr/0001-macro-is-the-scope-and-lifecycle-unit.md
+++ b/docs/adr/0001-macro-is-the-scope-and-lifecycle-unit.md
@@ -1,0 +1,25 @@
+# Macro is the scope and lifecycle unit (no Cue Groups)
+
+The macro lifecycle proposal (issue #70) originally introduced a separate **Cue Group** entity to
+own scoping, looping, and lifecycle targeting. We rejected that: a **Macro** is already an ordered
+container of cues, so we folded scope, looping, and lifecycle control directly into the Macro and
+dropped Cue Groups entirely. The Macro is the single unit that is triggered, scoped, looped, and
+cancelled/reverted. This keeps one mental model instead of two overlapping container concepts.
+
+We also decided **Revert** (the lifecycle undo) uses a **static per-cue inverse** map
+(`overlay.activate` → clear that overlay, `*.arm` → `*.clear`, `*.set` → `*.clear`) applied only to
+cues a run actually executed — rather than snapshotting and restoring prior on-screen state.
+Snapshot/restore was rejected because restoring pre-macro content causes surprising flicker and
+re-appearance of old content in a live presentation; operators want a macro's effects gone, then
+set the next state themselves. Note that single-slot layer inverses (video/audio/stage/media) are
+*unconditional clears*, not "restore the previous arm": reverting a run that armed video V clears
+whatever is armed now, even if something else replaced V. Only overlays revert by specific id.
+
+Delays are stored on the **macro step** (`action_steps`), not on the **cue**. Cues are
+content-deduped and shared across macros, so a delay placed on the shared cue row would leak into
+every macro using that cue (and the `flow.wait` migration could double-count). Delays are a
+per-occurrence property, so they belong on the step.
+
+Both choices are hard to reverse (they shape the data model and the operator's mental model),
+surprising to a future reader (who might expect a Group entity or a true state rollback), and the
+result of weighing real alternatives.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lumacast",
   "productName": "LumaCast",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "private": true,
   "description": "Cross-platform presentation tool with reusable content hierarchy, slide rendering, and NDI output",
   "author": "IT-PSAPE",


### PR DESCRIPTION
## Summary

- Implements scoped/lifecycle-controlled macros with looping and per-step delays (closes #70). **Cue Groups were dropped** in favor of folding scope, loop, and lifecycle targeting into the Macro itself — one execution unit instead of two overlapping containers. Schema migration v19 → v20; `flow.wait` is folded into per-step delays and retired. Decisions recorded in `docs/adr/0001-...md`; glossary in `CONTEXT.md`. See [comment](https://github.com/IT-PSAPE/LumaCast/issues/70#issuecomment-4566661573) for the implementation summary and [comment](https://github.com/IT-PSAPE/LumaCast/issues/70#issuecomment-4566663518) for decisions/rationale.
- Match dropdown panel width to its trigger with a min-width floor (so `FieldSelect` and friends no longer ignore the trigger size).
- Bump to **0.1.18**.

## Test plan

- [ ] **Bug from #70**: slide-scoped macro with a delayed cue — trigger from a slide, advance before the delay fires; the delayed cue must NOT fire on the next slide.
- [ ] Same macro with `onScopeExit: revert` → advancing reverses applied cues (overlay clears, media clears, etc.).
- [ ] Looping macro (count 3, slide scope) alternating two overlays → loops 3× then stops; leaving the slide mid-loop stops it.
- [ ] `flow.lifecycle` cue targeting "All active" inside a "reset" macro → cancels/reverts other runs but does not kill itself.
- [ ] Re-take the same slide twice with a looping macro → two concurrent runs (stacking).
- [ ] Migration: open a DB that has macros containing `flow.wait` → waits become adjacent-step delays, no `flow.wait` cues remain, timing preserved.
- [ ] Clear program output ("Clear content" / "Clear all" in the program panel) → slide-scoped and deck-item-scoped runs are swept; global runs survive.
- [ ] `FieldSelect` and other Dropdown panels match the trigger width; narrow triggers fall back to the 120px minimum.
- [ ] `npm run typecheck`, `npm run build`, `npm test` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)